### PR TITLE
fix(ci): Add required permissions for PR Feedback Bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ on:
       - 'LICENSE'
       - '.gitignore'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   # Stage 0: Detect what changed to optimize CI execution
   detect-changes:


### PR DESCRIPTION
## Summary
Fixes the PR Feedback Bot 403 error that has been affecting all PRs by adding the missing `pull-requests: write` permission to the GitHub Actions workflow.

## Problem
The PR Feedback Bot has been failing on all PRs (including #1, #2, #10, #21, #22) with:
```
RequestError [HttpError]: Resource not accessible by integration
status: 403
```

## Root Cause
The workflow on the main branch is missing the `permissions:` block that grants the bot access to post comments on pull requests.

## Solution
Added the required permissions block to `.github/workflows/ci.yml`:
```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

## Testing
This PR will validate the fix when CI runs - the PR Feedback Bot should successfully post a CI summary comment.

## Impact
- ✅ PR Feedback Bot will be able to post CI/CD summaries on all future PRs
- ✅ No changes to test execution or other CI functionality
- ✅ Minimal security impact (scoped to posting PR comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)