### PR TITLE
fix(design-review): fix submit workflow — 3 production bugs

### DIFF
--- a/design-review/index.html
+++ b/design-review/index.html
@@ -546,7 +546,7 @@ const CATALOG = [
 // ═══════════════════════════════════════════════════════════════
 const API_BASE = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
   ? 'http://localhost:3001'
-  : 'https://poetry-bil-araby-api.onrender.com';
+  : 'https://poetry-bil-araby-2mb0.onrender.com';
 let apiAvailable = false;
 let syncTimer = null;
 let currentSession = null;
@@ -1176,10 +1176,11 @@ async function submitReview() {
       if (!apiAvailable || !currentSession) throw new Error('Backend not available');
     }
     if (currentSession) {
-      await fetch(API_BASE + '/api/design-review/sessions/' + currentSession.id, {
+      const reviewerRes = await fetch(API_BASE + '/api/design-review/sessions/' + currentSession.id, {
         method: 'PATCH', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ reviewer: reviewerName })
       });
+      if (!reviewerRes.ok) console.warn('Failed to update reviewer name:', reviewerRes.status);
     }
     loadingText.textContent = 'Syncing verdicts...';
     await syncVerdictsToAPI();

--- a/server.js
+++ b/server.js
@@ -381,12 +381,13 @@ app.patch('/api/design-review/sessions/:id', async (req, res) => {
   try {
     if (!(await designTablesExist())) return res.status(503).json({ error: 'Design tables not created yet' });
     const { id } = req.params;
-    const { status, notes, reviewed_count } = req.body;
+    const { status, notes, reviewed_count, reviewer } = req.body;
     const sets = [];
     const params = [id];
     if (status !== undefined) { params.push(status); sets.push(`status = $${params.length}`); }
     if (notes !== undefined) { params.push(notes); sets.push(`notes = $${params.length}`); }
     if (reviewed_count !== undefined) { params.push(reviewed_count); sets.push(`reviewed_count = $${params.length}`); }
+    if (reviewer !== undefined) { params.push(reviewer); sets.push(`reviewer = $${params.length}`); }
     if (status === 'completed') sets.push('completed_at = now()');
     if (sets.length === 0) return res.status(400).json({ error: 'No fields to update' });
 


### PR DESCRIPTION
## Summary
- **Fix dead production API URL** — `poetry-bil-araby-api.onrender.com` → `poetry-bil-araby-2mb0.onrender.com`. All design-review API calls were 404ing in production.
- **Add `reviewer` to PATCH handler** — backend ignored the `reviewer` field, returning 400 "No fields to update". Reviewer name was never persisted.
- **Check reviewer PATCH response** — previously silently swallowed errors; now logs a warning on failure.

## Test plan
- [ ] Verify Vercel preview deployment loads design-review and connects to backend
- [ ] Submit a review with a reviewer name and confirm it persists in the session
- [ ] Check browser console for no errors during submit flow
- [ ] Run `npm run test:run` (226 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)