### PR TITLE
feat(auth): enable Google OAuth for production

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -927,7 +927,10 @@ const OverflowMenu = ({
   onToggleDatabase,
   user,
   onOpenSavedPoems,
-  onOpenSettings
+  onOpenSettings,
+  onSignIn,
+  onSignOut,
+  isSupabaseConfigured
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [fontSubmenuOpen, setFontSubmenuOpen] = useState(false);
@@ -1066,6 +1069,19 @@ const OverflowMenu = ({
             )}
           </div>
 
+          {isSupabaseConfigured && !user && (
+            <button
+              onClick={() => { onSignIn(); setIsOpen(false); }}
+              className={itemClass}
+            >
+              <LogIn size={18} style={{ color: gold }} />
+              <div className="flex flex-col items-start">
+                <div className="font-amiri text-base font-medium" style={{ color: gold }}>تسجيل الدخول</div>
+                <div className="font-brand-en text-[9px] uppercase tracking-[0.12em] opacity-45 text-[#a8a29e]">Sign In</div>
+              </div>
+            </button>
+          )}
+
           {user && (
             <>
               <button
@@ -1086,6 +1102,16 @@ const OverflowMenu = ({
                 <div className="flex flex-col items-start">
                   <div className="font-amiri text-base font-medium" style={{ color: gold }}>الإعدادات</div>
                   <div className="font-brand-en text-[9px] uppercase tracking-[0.12em] opacity-45 text-[#a8a29e]">Settings</div>
+                </div>
+              </button>
+              <button
+                onClick={() => { onSignOut(); setIsOpen(false); }}
+                className={itemClass}
+              >
+                <LogOut size={18} style={{ color: gold }} />
+                <div className="flex flex-col items-start">
+                  <div className="font-amiri text-base font-medium" style={{ color: gold }}>تسجيل الخروج</div>
+                  <div className="font-brand-en text-[9px] uppercase tracking-[0.12em] opacity-45 text-[#a8a29e]">Sign Out</div>
                 </div>
               </button>
             </>
@@ -2822,6 +2848,9 @@ export default function DiwanApp() {
                   user={user}
                   onOpenSavedPoems={handleOpenSavedPoems}
                   onOpenSettings={handleOpenSettings}
+                  onSignIn={handleSignIn}
+                  onSignOut={handleSignOut}
+                  isSupabaseConfigured={isSupabaseConfigured}
                 />
               )}
             </div>

--- a/supabase/migrations/20260219000000_postgrest_schema_grants.sql
+++ b/supabase/migrations/20260219000000_postgrest_schema_grants.sql
@@ -1,0 +1,10 @@
+-- Grant table-level access to PostgREST roles for auth-related tables
+-- RLS policies (in 20260119 migration) filter rows; these GRANTs allow PostgREST
+-- to reach the tables at all via the Supabase client SDK.
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON user_settings TO authenticated;
+GRANT SELECT, INSERT, DELETE ON saved_poems TO authenticated;
+GRANT SELECT ON discussions TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON discussions TO authenticated;
+GRANT SELECT ON discussion_likes TO anon;
+GRANT SELECT, INSERT, DELETE ON discussion_likes TO authenticated;


### PR DESCRIPTION
## Summary
- **OverflowMenu sign-in/sign-out** — Mobile/narrow screens now show "تسجيل الدخول / Sign In" (when logged out) and "تسجيل الخروج / Sign Out" (when logged in) in the overflow menu, using the existing `LogIn`/`LogOut` lucide-react icons
- **PostgREST schema grants** — New migration (`20260219000000`) grants `authenticated` and `anon` roles table-level access so the Supabase client SDK (PostgREST) can reach `user_settings`, `saved_poems`, `discussions`, and `discussion_likes`
- **Migration already pushed** — The PostgREST grants migration has been applied to the remote Supabase database

## Infrastructure status (verified)
- ✅ Google OAuth enabled in Supabase (`external.google: true`)
- ✅ Apple OAuth not yet configured (deferred — `external.apple: false`)
- ✅ `VITE_SUPABASE_URL` set in Vercel (production, preview, development)
- ✅ `VITE_SUPABASE_ANON_KEY` set in Vercel (production, preview, development)
- ✅ Backend healthy: 84,329 poems connected
- ✅ Auth tables migration (`20260119000000`) already applied
- ✅ PostgREST grants migration (`20260219000000`) now applied

## What's NOT changed
- `useAuth.js` — already complete with Google/Apple OAuth + `redirectTo: window.location.origin`
- `supabaseClient.js` — already gracefully degrades when not configured
- `AuthModal` — already has Google button (Apple button stays, shows error if not configured)
- `AuthButton` — desktop sign-in/sign-out already works

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 226 unit tests pass (`npm run test:run`)
- [ ] CI pipeline (build + unit + E2E with PostgreSQL)
- [ ] Manual: Open production URL on phone → tap overflow menu → Sign In → Google OAuth flow
- [ ] Manual: After sign-in, verify avatar appears, save poem, sign out, sign back in, verify persistence

## User action still needed
- **Google OAuth redirect URI**: Verify `https://<SUPABASE_REF>.supabase.co/auth/v1/callback` is in Google Cloud Console authorized redirect URIs
- **Supabase Site URL**: Set to production Vercel URL in Supabase dashboard → Authentication → URL Configuration
- **Supabase Redirect URLs**: Add production Vercel URL + `http://localhost:5173`

🤖 Generated with [Claude Code](https://claude.com/claude-code)