### PR TITLE
chore: disable prod debug, replace favicon, bump to v1.0.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Poetry Bil-Araby | بالعربي</title>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poetry-bil-araby",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#d4a574" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"/><line x1="16" y1="8" x2="2" y2="22"/><line x1="17.5" y1="15" x2="9" y2="15"/></svg>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -10,7 +10,7 @@ import { INSIGHTS_SYSTEM_PROMPT, DISCOVERY_SYSTEM_PROMPT, getTTSInstruction } fr
 
 const FEATURES = {
   grounding: false,
-  debug: true,
+  debug: import.meta.env.DEV,
   logging: true,      // Emit structured logs to console (captured by Vercel/browser)
   caching: true,      // Enable IndexedDB caching for audio/insights
   streaming: true,    // Enable streaming insights (progressive rendering)


### PR DESCRIPTION
## Summary
- Gate `FEATURES.debug` behind `import.meta.env.DEV` so debug panel never ships to production
- Replace Vite default favicon (`/vite.svg`) with a feather pen SVG icon matching the app's amber accent
- Bump `package.json` version from `0.0.0` to `1.0.0` for public launch readiness

## Test plan
- [x] `npm run test:run` passes (226/226)
- [x] Debug panel hidden in production build (`npm run build && npm run preview`)
- [x] Favicon renders correctly in browser

Fixes #111, Fixes #115, Fixes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)