### PR TITLE
chore(deps): fix tar hardlink traversal vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6747,9 +6747,9 @@
       }
     },
     "node_modules/supabase": {
-      "version": "2.76.15",
-      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.76.15.tgz",
-      "integrity": "sha512-m69o1XPAzZaIWfQiEeT+KY/Ci3OSA663RyoH9xECbXSxhr7dsipLCpCqT1E4MCob0mMhHh/7A+Eltx4y1qSwiQ==",
+      "version": "2.76.17",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.76.17.tgz",
+      "integrity": "sha512-e7RFs8EXXQKBQKVnN1TQwgVQjsDvwjxgdFBQ7RGNv+qv5VL+d/dzqTEVX9FYaOTTkeoSNJ8iw2qPO1gvKs+9vg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6757,7 +6757,7 @@
         "bin-links": "^6.0.0",
         "https-proxy-agent": "^7.0.2",
         "node-fetch": "^3.3.2",
-        "tar": "7.5.9"
+        "tar": "7.5.10"
       },
       "bin": {
         "supabase": "bin/supabase"
@@ -6874,9 +6874,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #9: `tar` <=7.5.9 high-severity hardlink path traversal
- Bumps `tar` 7.5.9→7.5.10 (transitive via `supabase` CLI)
- Dev-only dependency — zero production impact
- All unit tests pass

## Test plan
- [x] `npm audit` returns 0 vulnerabilities
- [x] `npm run test:run` passes (226 tests, 8 suites)

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)