### PR TITLE
fix(ui): rename Learn button to Explain

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2740,10 +2740,10 @@ export default function DiwanApp() {
               </div>
 
               <div className="flex flex-col items-center gap-1 min-w-[52px]">
-                <button onClick={handleAnalyze} disabled={isInterpreting || interpretation} aria-label="Learn about poem meaning" className="min-w-[46px] min-h-[46px] p-[11px] bg-transparent border-none cursor-pointer transition-all duration-300 flex items-center justify-center rounded-full hover:bg-[#C5A059]/12 hover:scale-105 disabled:opacity-50">
+                <button onClick={handleAnalyze} disabled={isInterpreting || interpretation} aria-label="Explain poem meaning" className="min-w-[46px] min-h-[46px] p-[11px] bg-transparent border-none cursor-pointer transition-all duration-300 flex items-center justify-center rounded-full hover:bg-[#C5A059]/12 hover:scale-105 disabled:opacity-50">
                   {isInterpreting ? <Loader2 className="animate-spin text-[#C5A059]" size={21} /> : <Compass className="text-[#C5A059]" size={21} />}
                 </button>
-                <span className="font-brand-en text-[8.5px] font-bold tracking-[0.08em] uppercase opacity-60 whitespace-nowrap">Learn</span>
+                <span className="font-brand-en text-[8.5px] font-bold tracking-[0.08em] uppercase opacity-60 whitespace-nowrap">Explain</span>
               </div>
 
               <div className="flex flex-col items-center gap-1 min-w-[52px]">

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -149,9 +149,9 @@ describe('DiwanApp', () => {
       render(<DiwanApp />)
 
       // Option K design removed left/right navigation
-      // Verify primary buttons exist: Listen, Learn, Discover, Poets
+      // Verify primary buttons exist: Listen, Explain, Discover, Poets
       expect(screen.getByLabelText(/play recitation|pause recitation/i)).toBeInTheDocument()
-      expect(screen.getByLabelText('Learn about poem meaning')).toBeInTheDocument()
+      expect(screen.getByLabelText('Explain poem meaning')).toBeInTheDocument()
       expect(screen.getByLabelText('Discover new poem')).toBeInTheDocument()
       expect(screen.getByLabelText('Select poet category')).toBeInTheDocument()
     })
@@ -367,7 +367,7 @@ describe('DiwanApp', () => {
   describe('AI Features Smoke Tests', () => {
     const mockInsightText = 'POEM:\nTranslation line\nTHE DEPTH: Deep meaning here.\nTHE AUTHOR: Celebrated poet info.'
 
-    it('Learn button is enabled for a DB poem (no english/tags)', async () => {
+    it('Explain button is enabled for a DB poem (no english/tags)', async () => {
       render(<DiwanApp />)
 
       global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(100) })
@@ -375,10 +375,10 @@ describe('DiwanApp', () => {
       await userEvent.click(screen.getByLabelText('Discover new poem'))
       await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), { timeout: 3000 })
 
-      expect(screen.getByLabelText('Learn about poem meaning')).not.toBeDisabled()
+      expect(screen.getByLabelText('Explain poem meaning')).not.toBeDisabled()
     })
 
-    it('shows insights after clicking Learn on a DB poem', async () => {
+    it('shows insights after clicking Explain on a DB poem', async () => {
       render(<DiwanApp />)
 
       global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(101) })
@@ -386,10 +386,10 @@ describe('DiwanApp', () => {
       await userEvent.click(screen.getByLabelText('Discover new poem'))
       await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), { timeout: 3000 })
 
-      // Mock the Gemini insights streaming response BEFORE clicking Learn
+      // Mock the Gemini insights streaming response BEFORE clicking Explain
       global.fetch.mockResolvedValueOnce(createStreamingMock(mockInsightText))
 
-      await userEvent.click(screen.getByLabelText('Learn about poem meaning'))
+      await userEvent.click(screen.getByLabelText('Explain poem meaning'))
 
       // Wait for insight content (insightParts.depth) to appear in the DOM
       await waitFor(() => {
@@ -500,7 +500,7 @@ describe('DiwanApp', () => {
         json: async () => ({ error: { message: 'API key not valid' } })
       })
 
-      await userEvent.click(screen.getByLabelText('Learn about poem meaning'))
+      await userEvent.click(screen.getByLabelText('Explain poem meaning'))
 
       // Error is logged to the auto-expanded DebugPanel (rendered in the DOM even when collapsed)
       await waitFor(() => {


### PR DESCRIPTION
## Summary
- Renames the "Learn" button to "Explain" in the control bar
- Updates aria-label from "Learn about poem meaning" to "Explain poem meaning"
- Updates all test references (~7 locations)

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:run` passes (226/226)
- [ ] Visual check: button now says "Explain"

🤖 Generated with [Claude Code](https://claude.com/claude-code)