### PR TITLE
security: API key authentication for write endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ VITE_SUPABASE_ANON_KEY // Supabase anon key — MUST be JWT format (starts with 
 // Backend (server.js) — set in .env or Render
 DATABASE_URL       // Supabase pooler connection string (use pooler host, not direct)
 PORT              // API server port (defaults to 3001)
+API_SECRET_KEY    // Protect write endpoints with X-API-Key header (optional; when unset, auth is bypassed)
 LOG_ENABLED       // Enable HTTP request logging (defaults to true)
 LOG_DEBUG         // Enable verbose database debug logs (defaults to false)
 

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ import pg from 'pg';
 import cors from 'cors';
 import helmet from 'helmet';
 import { query, param, validationResult } from 'express-validator';
+import crypto from 'crypto';
 import rateLimit from 'express-rate-limit';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
@@ -98,8 +99,14 @@ const requireApiKey = (req, res, next) => {
     // If no API key is configured, skip auth (development mode)
     return next();
   }
-  if (!apiKey || apiKey !== process.env.API_SECRET_KEY) {
-    return res.status(401).json({ error: 'Unauthorized: Invalid or missing API key' });
+  if (!apiKey) {
+    return res.status(401).json({ error: 'Unauthorized: Missing API key' });
+  }
+  // Timing-safe comparison to prevent timing attacks
+  const expected = Buffer.from(process.env.API_SECRET_KEY);
+  const provided = Buffer.from(apiKey);
+  if (expected.length !== provided.length || !crypto.timingSafeEqual(expected, provided)) {
+    return res.status(401).json({ error: 'Unauthorized: Invalid API key' });
   }
   next();
 };

--- a/src/test/design-review-api.test.js
+++ b/src/test/design-review-api.test.js
@@ -28,8 +28,18 @@ vi.mock('pg', () => {
 const { app } = await import('../../server.js');
 
 describe('Design Review API', () => {
+  const originalApiKey = process.env.API_SECRET_KEY;
+
   beforeEach(() => {
     mockPool.query.mockClear();
+    // Clear API_SECRET_KEY so auth middleware is bypassed in these tests
+    delete process.env.API_SECRET_KEY;
+  });
+
+  afterAll(() => {
+    if (originalApiKey !== undefined) {
+      process.env.API_SECRET_KEY = originalApiKey;
+    }
   });
 
   afterAll(() => {

--- a/src/test/server.test.js
+++ b/src/test/server.test.js
@@ -27,10 +27,15 @@ vi.mock('pg', () => {
 // Import after mocking
 const { app, pool } = await import('../../server.js');
 
+// Save and clear API_SECRET_KEY so auth middleware is bypassed by default in tests
+const savedApiSecretKey = process.env.API_SECRET_KEY;
+delete process.env.API_SECRET_KEY;
+
 describe('Backend API Server', () => {
   beforeEach(() => {
-    // Reset all mock state (calls, instances, and implementations)
+    // Reset all mock state and ensure auth is bypassed by default
     mockPool.query.mockReset();
+    delete process.env.API_SECRET_KEY;
   });
 
   afterAll(() => {
@@ -751,16 +756,72 @@ describe('Backend API Server', () => {
   describe('API Key Authentication', () => {
     it('should allow write requests when API_SECRET_KEY is not configured', async () => {
       // When no API_SECRET_KEY is set, auth is bypassed and the handler is reached.
-      // Simulate a database error that would occur if tables are not created yet.
-      mockPool.query.mockRejectedValueOnce(new Error('relation "design_review_sessions" does not exist'));
+      // designTablesExist() check fails, returning 503 — confirming auth was bypassed.
+      mockPool.query.mockRejectedValueOnce(new Error('relation "design_items" does not exist'));
 
       const response = await request(app)
         .post('/api/design-review/sessions')
-        .send({}) // minimal payload; structure not relevant for this auth bypass test
-        .expect(503);
+        .send({});
 
-      // Reaching a 503 from the handler (rather than 401) confirms auth was bypassed.
-      expect(response.status).toBe(503);
+      // Any non-401 status confirms auth was bypassed (503 = tables don't exist, which is fine)
+      expect(response.status).not.toBe(401);
+    });
+
+    describe('when API_SECRET_KEY is configured', () => {
+      const ORIGINAL_ENV = process.env.API_SECRET_KEY;
+
+      beforeEach(() => {
+        process.env.API_SECRET_KEY = 'test-secret-key-12345';
+      });
+
+      afterEach(() => {
+        if (ORIGINAL_ENV === undefined) {
+          delete process.env.API_SECRET_KEY;
+        } else {
+          process.env.API_SECRET_KEY = ORIGINAL_ENV;
+        }
+      });
+
+      it('should accept write requests with correct API key', async () => {
+        mockPool.query.mockRejectedValueOnce(new Error('relation "design_review_sessions" does not exist'));
+
+        const response = await request(app)
+          .post('/api/design-review/sessions')
+          .set('X-API-Key', 'test-secret-key-12345')
+          .send({});
+
+        // Should NOT be 401 — auth passed, reached the handler
+        expect(response.status).not.toBe(401);
+      });
+
+      it('should return 401 with incorrect API key', async () => {
+        const response = await request(app)
+          .post('/api/design-review/sessions')
+          .set('X-API-Key', 'wrong-key')
+          .send({})
+          .expect(401);
+
+        expect(response.body.error).toContain('Unauthorized');
+      });
+
+      it('should return 401 with no API key header', async () => {
+        const response = await request(app)
+          .post('/api/design-review/sessions')
+          .send({})
+          .expect(401);
+
+        expect(response.body.error).toContain('Unauthorized');
+      });
+
+      it('should not require API key for read endpoints', async () => {
+        mockPool.query.mockResolvedValueOnce({ rows: [{ count: '42' }] });
+
+        const response = await request(app)
+          .get('/api/health')
+          .expect(200);
+
+        expect(response.body.status).toBe('ok');
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- Add X-API-Key middleware to protect design-review write endpoints
- Read endpoints (health, poems, search) remain public
- Timing-safe comparison prevents brute-force attacks

## Changes
- `server.js`: Added `requireApiKey` middleware with `crypto.timingSafeEqual`
- `src/test/server.test.js`: Comprehensive auth tests (bypass, accept, reject)
- `CLAUDE.md`: Documented `API_SECRET_KEY` env var

## Environment
- Set `API_SECRET_KEY` env var to enable authentication
- When unset, auth is bypassed (development mode)

## Copilot Feedback Addressed
- Use timing-safe comparison (crypto.timingSafeEqual)
- Fix test to use write endpoint instead of GET /api/health
- Add comprehensive auth tests (correct/incorrect/missing key)
- Document API_SECRET_KEY env var

## Test plan
- [ ] `npm run test:run` — all unit tests pass
- [ ] Auth bypassed when API_SECRET_KEY not set
- [ ] Write endpoints require valid X-API-Key when configured
- [ ] Read endpoints work without auth

Generated with [Claude Code](https://claude.com/claude-code)