### PR TITLE
security: server-side Gemini API proxy

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,9 @@ pool.query('SELECT NOW()', (err, res) => {
 
 // Middleware
 app.use(cors());
-app.use(express.json({ limit: '10mb' }));
+app.use(express.json());
+// Larger body limit only for AI proxy endpoints
+app.use('/api/ai', express.json({ limit: '10mb' }));
 app.use('/api/', rateLimit({ windowMs: 60_000, max: 100, standardHeaders: true, legacyHeaders: false }));
 
 // Request logging middleware
@@ -262,7 +264,7 @@ app.get('/api/poems/search', async (req, res) => {
 // GEMINI API PROXY (keeps API key server-side)
 // ═══════════════════════════════════════════════════════════════
 
-const GEMINI_API_KEY = process.env.GEMINI_API_KEY || process.env.VITE_GEMINI_API_KEY || '';
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY || '';
 const GEMINI_BASE = 'https://generativelanguage.googleapis.com/v1beta';
 
 // GET /api/ai/models — list available models
@@ -283,13 +285,15 @@ app.get('/api/ai/models', async (req, res) => {
   }
 });
 
-// POST /api/ai/generate — proxy generateContent / streamGenerateContent
+// POST /api/ai/:model/:action — proxy generateContent / streamGenerateContent
 app.post('/api/ai/:model/:action', async (req, res) => {
   try {
-    if (!GEMINI_API_KEY) {
-      return res.status(503).json({ error: 'AI features unavailable: no API key configured' });
-    }
     const { model, action } = req.params;
+
+    // Validate model name to prevent SSRF (before any upstream requests)
+    if (!/^gemini-[\w.-]+$/.test(model)) {
+      return res.status(400).json({ error: 'Invalid model name' });
+    }
 
     // Only allow known actions
     const allowedActions = ['generateContent', 'streamGenerateContent'];
@@ -297,14 +301,21 @@ app.post('/api/ai/:model/:action', async (req, res) => {
       return res.status(400).json({ error: 'Invalid action' });
     }
 
+    if (!GEMINI_API_KEY) {
+      return res.status(503).json({ error: 'AI features unavailable: no API key configured' });
+    }
+
     const url = `${GEMINI_BASE}/models/${model}:${action}?key=${GEMINI_API_KEY}`;
 
     if (action === 'streamGenerateContent') {
-      // Stream the response back
+      const controller = new AbortController();
+      req.on('close', () => controller.abort());
+
       const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(req.body)
+        body: JSON.stringify(req.body),
+        signal: controller.signal
       });
 
       if (!response.ok) {
@@ -316,16 +327,18 @@ app.post('/api/ai/:model/:action', async (req, res) => {
       res.setHeader('Cache-Control', 'no-cache');
       res.setHeader('Connection', 'keep-alive');
 
-      // Pipe the response stream
       const reader = response.body.getReader();
-      const pump = async () => {
+      try {
         while (true) {
           const { done, value } = await reader.read();
-          if (done) { res.end(); break; }
+          if (done || res.writableEnded) break;
           res.write(value);
         }
-      };
-      await pump();
+      } catch (err) {
+        if (err.name !== 'AbortError') throw err;
+      } finally {
+        if (!res.writableEnded) res.end();
+      }
     } else {
       // Non-streaming: forward as normal JSON
       const response = await fetch(url, {

--- a/src/test/server.test.js
+++ b/src/test/server.test.js
@@ -652,6 +652,69 @@ describe('Backend API Server', () => {
     });
   });
 
+  describe('AI Proxy Endpoints', () => {
+    describe('GET /api/ai/models', () => {
+      it('should return 503 when no API key configured', async () => {
+        // GEMINI_API_KEY is empty at module load time in test environment
+        const response = await request(app)
+          .get('/api/ai/models')
+          .expect(503);
+
+        expect(response.body.error).toContain('unavailable');
+      });
+    });
+
+    describe('POST /api/ai/:model/:action', () => {
+      it('should return 400 for invalid action', async () => {
+        const response = await request(app)
+          .post('/api/ai/gemini-2.0-flash/invalidAction')
+          .send({ contents: [] })
+          .expect(400);
+
+        expect(response.body.error).toBe('Invalid action');
+      });
+
+      it('should return 400 for invalid model name (path traversal)', async () => {
+        const response = await request(app)
+          .post('/api/ai/../../etc/passwd/generateContent')
+          .send({ contents: [] });
+
+        // Express may resolve path traversal differently, but the model
+        // name should fail validation regardless of how it arrives
+        expect([400, 404]).toContain(response.status);
+      });
+
+      it('should return 400 for model name not matching gemini pattern', async () => {
+        const response = await request(app)
+          .post('/api/ai/gpt-4/generateContent')
+          .send({ contents: [] })
+          .expect(400);
+
+        expect(response.body.error).toBe('Invalid model name');
+      });
+
+      it('should return 503 when no API key configured', async () => {
+        // GEMINI_API_KEY is empty at module load time in test environment
+        const response = await request(app)
+          .post('/api/ai/gemini-2.0-flash/generateContent')
+          .send({ contents: [] })
+          .expect(503);
+
+        expect(response.body.error).toContain('unavailable');
+      });
+
+      it('should accept valid gemini model names', async () => {
+        // With no API key in test env, valid model names still return 503 (not 400)
+        const response = await request(app)
+          .post('/api/ai/gemini-2.0-flash/generateContent')
+          .send({ contents: [] });
+
+        // Should not be 400 (validation error) - the model name is valid
+        expect(response.status).not.toBe(400);
+      });
+    });
+  });
+
   describe('Keep-Alive Mechanism', () => {
     it('should have health endpoint that returns totalPoems for keep-alive pings', async () => {
       // Mock successful database query


### PR DESCRIPTION
## Summary
- Server-side Gemini API proxy to keep API key off the frontend
- Supports both generateContent and streamGenerateContent actions
- SSRF protection via model name validation

## Changes
- `server.js`: Proxy endpoints with security hardening
- `src/app.jsx`: Frontend calls proxy instead of direct Gemini API
- `src/test/server.test.js`: Proxy endpoint validation tests

## Security Measures
- Model name validated against `^gemini-[\w.-]+$` regex (prevents SSRF)
- Input validation runs before API key check (rejects bad input regardless of config)
- 10mb body limit scoped to `/api/ai/*` only (prevents DoS on other endpoints)
- Stream disconnect handled via AbortController
- No VITE_ env var fallback (key stays server-side only)

## Copilot Feedback Addressed
- ✅ SSRF: Validate model parameter
- ✅ Scope 10mb limit to /api/ai only
- ✅ Remove VITE_GEMINI_API_KEY fallback
- ✅ Handle stream client disconnect
- ✅ Fix comment to match route
- ✅ Add proxy endpoint tests

## Test plan
- [ ] `npm run test:run` — all unit tests pass
- [ ] Invalid model name returns 400
- [ ] Invalid action returns 400
- [ ] Missing API key returns 503
- [ ] Stream disconnects clean up properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)