### PR TITLE
fix(ui): sidebar not showing for logged-in users

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1746,6 +1746,9 @@ export default function DiwanApp() {
     };
 
     scheduleDetect();
+    // Re-measure after a short delay to catch DOM updates from auth state changes
+    // (React may not have rendered the new buttons in the first rAF)
+    const delayedRecheck = setTimeout(scheduleDetect, 100);
 
     // ResizeObserver catches font-load changes and dynamic content updates.
     // Guard for environments where ResizeObserver is unavailable (older browsers, some test envs).
@@ -1757,6 +1760,7 @@ export default function DiwanApp() {
 
     window.addEventListener('resize', scheduleDetect);
     return () => {
+      clearTimeout(delayedRecheck);
       if (pendingRafRef.current !== null) {
         cancelAnimationFrame(pendingRafRef.current);
         pendingRafRef.current = null;


### PR DESCRIPTION
## Summary
Fix vertical sidebar not appearing on mobile for logged-in users.

## Root Cause
The overflow detection `useEffect` runs when `user` changes (login/logout). It measures the control bar in a single `requestAnimationFrame`, but React hasn't rendered the new auth buttons yet at that point. The measurement sees the pre-login layout and may set `isOverflow = false`, hiding the sidebar.

## Fix
Add a delayed recheck (100ms) after the initial rAF measurement, giving React time to render the new auth buttons before re-measuring overflow.

## Changes
- `src/app.jsx`: Add `setTimeout(scheduleDetect, 100)` after initial detection, with cleanup in the effect return

## Test plan
- [x] All 241 unit tests pass
- [ ] On mobile: log in → sidebar should appear
- [ ] On mobile: log out → sidebar behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)