### PR TITLE
fix(e2e): replace fragile nth() selectors with aria-label

### DIFF
--- a/e2e/app.spec.js
+++ b/e2e/app.spec.js
@@ -37,8 +37,8 @@ test.describe('Poetry Bil-Araby - Core Functionality', () => {
     // Get initial poem title
     const initialTitle = await page.locator('.font-amiri').first().textContent();
 
-    // Click next button
-    await page.locator('button').filter({ has: page.locator('svg') }).nth(2).click();
+    // Click Discover button (next poem)
+    await page.locator('button[aria-label="Discover new poem"]').click();
 
     // Wait for content to be visible (no fixed timeout)
     await expect(page.locator('.font-amiri').first()).toBeVisible({ timeout: 2000 });
@@ -185,13 +185,10 @@ test.describe('Poetry Bil-Araby - Core Functionality', () => {
     // Grant clipboard permissions
     await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-    // Click copy button (wait for it to be enabled)
-    const copyButton = page.locator('button').filter({
-      has: page.locator('svg')
-    }).nth(4);
+    // Click copy button using accessible selectors (works on desktop and mobile)
+    const copyButton = page.locator('button[aria-label="Copy poem to clipboard"], button[title="Copy poem"]').first();
 
-    // Wait for button to be enabled before clicking
-    await expect(copyButton).toBeEnabled({ timeout: 5000 });
+    await expect(copyButton).toBeVisible({ timeout: 5000 });
     await copyButton.click();
 
     // Should show success indicator (Check icon)


### PR DESCRIPTION
## Summary
- **Problem:** E2E tests for "navigate between poems" and "copy poem text" use positional `nth()` button selectors that break when the Explain button becomes disabled after auto-explain completes
- **Root cause:** `page.locator('button').filter({ has: locator('svg') }).nth(N)` is fragile — the index shifts when buttons are conditionally rendered or disabled
- **Fix:** Replace with stable attribute selectors: `aria-label="Discover new poem"` and `aria-label="Copy poem to clipboard"` / `title="Copy poem"`

## Failing tests fixed
1. `[Desktop Chrome] should navigate between poems using controls` — `nth(2)` was hitting disabled Explain button instead of Discover
2. `[Mobile Chrome] should copy poem text` — `nth(4)` was hitting disabled Explain button instead of Copy
3. `[iPhone 16 Pro] should copy poem text` — same as above

Note: These failures were pre-existing (also seen on commit bfa43d4 / PR #188), not introduced by #190.

## Test plan
- [ ] CI E2E tests pass on all 3 previously failing configurations
- [ ] Unit tests unaffected (241 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)