### PR TITLE
fix(pwa): exclude /design-review from SW navigation fallback

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,8 @@ export default defineConfig({
       manifest: false, // We use our own manifest.json in public/
       workbox: {
         globPatterns: ['**/*.{js,css,html,svg,woff2}'],
+        navigateFallback: 'index.html',
+        navigateFallbackDenylist: [/^\/design-review/],
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,


### PR DESCRIPTION
## Summary
- The PWA service worker was intercepting `/design-review` navigation and serving the main app's cached `index.html` instead of the static `design-review/index.html`
- Adds `navigateFallbackDenylist` to the Workbox config so `/design-review/*` routes bypass the service worker and reach the server

## Context
The design-review page is a separate static HTML app (`design-review/index.html`) copied into `dist/` at build time. Workbox's default `generateSW` mode applies a navigation fallback that serves the precached `index.html` for all navigation requests, which was shadowing the design-review route for users with an active service worker.

## Test plan
- [ ] Build locally and verify `dist/sw.js` contains `denylist` with `design-review`
- [ ] Open production site, click Design Review link — should load the design review UI (not the main app)
- [ ] Verify main app navigation still works (SPA routing unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)