### PR TITLE
chore: gitignore python artifacts and diacritize data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,10 @@ poetry-database/
 poetry-splash-ci-fixes/
 .vercel
 .env*.local
+
+# Python artifacts
+__pycache__/
+*.pyc
+
+# Diacritization pipeline data (large parquets, generated artifacts)
+scripts/diacritize-data/


### PR DESCRIPTION
Adds `__pycache__/`, `*.pyc`, and `scripts/diacritize-data/` to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)