### PR TITLE
chore: remove duplicate gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,3 @@ poetry-splash-ci-fixes/
 __pycache__/
 *.pyc
 
-# Diacritization pipeline data (large parquets, generated artifacts)
-scripts/diacritize-data/


### PR DESCRIPTION
Remove duplicate `scripts/diacritize-data/` line in .gitignore.