### PR TITLE
chore(sentry): add wizard org/project defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ poetry_quality_and_curation/retriever_and_quality_curator/data/*.rar
 # Python artifacts
 __pycache__/
 *.pyc
+
+# Sentry Config File
+.env.sentry-build-plugin

--- a/vite.config.js
+++ b/vite.config.js
@@ -41,8 +41,8 @@ export default defineConfig({
     }),
     // Sentry source map upload — only runs during production build when auth token is present
     sentryVitePlugin({
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
+      org: process.env.SENTRY_ORG || 'siraj-aq',
+      project: process.env.SENTRY_PROJECT || 'node',
       authToken: process.env.SENTRY_AUTH_TOKEN,
       sourcemaps: {
         filesToDeleteAfterUpload: ['./dist/**/*.map'],


### PR DESCRIPTION
## Summary
- Hardcode Sentry org (`siraj-aq`) and project (`node`) as defaults in `sentryVitePlugin`, still overridable via `SENTRY_ORG`/`SENTRY_PROJECT` env vars
- Gitignore `.env.sentry-build-plugin` (wizard-generated auth token file)

Reconciles output from `npx @sentry/wizard@latest -i sourcemaps` with the full Sentry SDK setup from #222.

## Test plan
- [ ] `npm run build` succeeds with hidden source maps
- [ ] No `.env.sentry-build-plugin` committed to repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)