### PR TITLE
fix(splash): prevent production crash during phase transitions

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1399,11 +1399,9 @@ const SplashScreen = ({ isOpen, onDismiss, showOnboarding, theme }) => {
     });
     setStarsGenerated(true);
     return () => {
-      if (container) {
-        while (container.firstChild) {
-          container.removeChild(container.firstChild);
-        }
-      }
+      // Use textContent to clear imperatively-added children safely —
+      // avoids removeChild errors if React is also tearing down the tree
+      if (container) container.textContent = '';
     };
   }, [isOpen, phase, starsGenerated]);
 
@@ -1590,46 +1588,54 @@ const SplashScreen = ({ isOpen, onDismiss, showOnboarding, theme }) => {
     }
   `;
 
-  // DESERT SPLASH (phase 0)
-  if (phase === 0) {
-    const desertNight = '#1A0F0A';
-    const gold = '#C5A059';
-    const sandMuted = isDark ? 'rgba(232,213,183,0.5)' : 'rgba(26,15,10,0.4)';
-    const dunes = isDark
-      ? [{ h: '25%', bg: '#6B3720', br: '55% 75% 0 0 / 100%', z: 4, anim: 'splashDune1 10s ease-in-out infinite alternate' },
-         { h: '33%', bg: '#5A2E1A', br: '75% 45% 0 0 / 100%', z: 3, anim: 'splashDune2 14s ease-in-out infinite alternate' },
-         { h: '40%', bg: '#4A2516', br: '45% 65% 0 0 / 100%', z: 2, anim: 'splashDune3 18s ease-in-out infinite alternate' },
-         { h: '48%', bg: '#3A1C12', br: '65% 50% 0 0 / 100%', z: 1, anim: 'splashDune4 23s ease-in-out infinite alternate' }]
-      : [{ h: '25%', bg: '#D4B896', br: '55% 75% 0 0 / 100%', z: 4, anim: 'splashDune1 10s ease-in-out infinite alternate' },
-         { h: '33%', bg: '#C8A880', br: '75% 45% 0 0 / 100%', z: 3, anim: 'splashDune2 14s ease-in-out infinite alternate' },
-         { h: '40%', bg: '#BC9A6E', br: '45% 65% 0 0 / 100%', z: 2, anim: 'splashDune3 18s ease-in-out infinite alternate' },
-         { h: '48%', bg: '#B08C5E', br: '65% 50% 0 0 / 100%', z: 1, anim: 'splashDune4 23s ease-in-out infinite alternate' }];
-    const bgGradient = isDark
-      ? 'linear-gradient(180deg, #0D0A14 0%, #1A0F0A 40%, #3A1C12 100%)'
-      : `linear-gradient(180deg, #F5EDE0 0%, #EDE0CC 40%, #B08C5E 100%)`;
+  // Computed values needed by both phases
+  const desertNight = '#1A0F0A';
+  const gold = '#C5A059';
+  const sandMuted = isDark ? 'rgba(232,213,183,0.5)' : 'rgba(26,15,10,0.4)';
+  const dunes = isDark
+    ? [{ h: '25%', bg: '#6B3720', br: '55% 75% 0 0 / 100%', z: 4, anim: 'splashDune1 10s ease-in-out infinite alternate' },
+       { h: '33%', bg: '#5A2E1A', br: '75% 45% 0 0 / 100%', z: 3, anim: 'splashDune2 14s ease-in-out infinite alternate' },
+       { h: '40%', bg: '#4A2516', br: '45% 65% 0 0 / 100%', z: 2, anim: 'splashDune3 18s ease-in-out infinite alternate' },
+       { h: '48%', bg: '#3A1C12', br: '65% 50% 0 0 / 100%', z: 1, anim: 'splashDune4 23s ease-in-out infinite alternate' }]
+    : [{ h: '25%', bg: '#D4B896', br: '55% 75% 0 0 / 100%', z: 4, anim: 'splashDune1 10s ease-in-out infinite alternate' },
+       { h: '33%', bg: '#C8A880', br: '75% 45% 0 0 / 100%', z: 3, anim: 'splashDune2 14s ease-in-out infinite alternate' },
+       { h: '40%', bg: '#BC9A6E', br: '45% 65% 0 0 / 100%', z: 2, anim: 'splashDune3 18s ease-in-out infinite alternate' },
+       { h: '48%', bg: '#B08C5E', br: '65% 50% 0 0 / 100%', z: 1, anim: 'splashDune4 23s ease-in-out infinite alternate' }];
+  const bgGradient = isDark
+    ? 'linear-gradient(180deg, #0D0A14 0%, #1A0F0A 40%, #3A1C12 100%)'
+    : `linear-gradient(180deg, #F5EDE0 0%, #EDE0CC 40%, #B08C5E 100%)`;
+  const kineticStep = phase - 1; // 0, 1, or 2
+  const progressWidth = ((Math.max(kineticStep, 0) + 1) / 3 * 100) + '%';
+  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
 
-    return (
+  // Single return — both phases always in the DOM, toggled by display.
+  // This prevents React from unmounting/remounting the tree when phase changes,
+  // which avoids removeChild errors from imperatively-added star DOM nodes.
+  return (
+    <>
+      <style>{splashStyles}</style>
+
+      {/* DESERT SPLASH (phase 0) — hidden via display:none when phase >= 1 */}
       <div
         style={{
           position: 'fixed', inset: 0, zIndex: 60,
           background: bgGradient,
-          display: 'flex', alignItems: 'center', justifyContent: 'center', flexDirection: 'column',
+          display: phase === 0 ? 'flex' : 'none',
+          alignItems: 'center', justifyContent: 'center', flexDirection: 'column',
           transition: 'opacity 1s ease-out',
           opacity: fadeState === 'out' ? 0 : 1,
         }}
         role="dialog"
         aria-label="Welcome to Poetry Bil-Araby"
       >
-        <style>{splashStyles}</style>
-
         {/* Sand texture SVG overlay */}
         <div style={{
           position: 'absolute', inset: 0, zIndex: 0, pointerEvents: 'none', opacity: 0.04,
           backgroundImage: "url(\"data:image/svg+xml,%3Csvg width='80' height='80' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.55' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.6'/%3E%3C/svg%3E\")",
         }} />
 
-        {/* Starfield */}
-        <div ref={starsRef} style={{ position: 'absolute', inset: 0, overflow: 'hidden' }} />
+        {/* Starfield — dangerouslySetInnerHTML tells React these children are externally managed */}
+        <div ref={starsRef} style={{ position: 'absolute', inset: 0, overflow: 'hidden' }} dangerouslySetInnerHTML={{ __html: '' }} />
 
         {/* Dunes */}
         {dunes.map((d, i) => (
@@ -1692,184 +1698,177 @@ const SplashScreen = ({ isOpen, onDismiss, showOnboarding, theme }) => {
           aria-label="Enter the app"
         >Enter</button>
       </div>
-    );
-  }
 
-  // KINETIC WALKTHROUGH (phases 1-3)
-  const kineticStep = phase - 1; // 0, 1, or 2
-  const progressWidth = ((kineticStep + 1) / 3 * 100) + '%';
-  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
-
-  return (
-    <div
-      style={{
-        position: 'fixed', inset: 0, zIndex: 60,
-        background: '#000000',
-        display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
-        cursor: 'pointer', overflow: 'hidden',
-        transition: 'opacity 0.6s ease',
-        opacity: fadeState === 'out' ? 0 : 1,
-      }}
-      onClick={handleWalkthroughTap}
-      role="dialog"
-      aria-label="Onboarding walkthrough"
-    >
-      <style>{splashStyles}</style>
-
-      {/* Particle canvas */}
-      <canvas
-        ref={canvasRef}
+      {/* KINETIC WALKTHROUGH (phases 1-3) — hidden via display:none until phase >= 1 */}
+      <div
         style={{
-          position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
-          pointerEvents: 'none', zIndex: 1,
-          willChange: 'transform', transform: 'translateZ(0)',
+          position: 'fixed', inset: 0, zIndex: 60,
+          background: '#000000',
+          display: phase >= 1 ? 'flex' : 'none',
+          flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+          cursor: 'pointer', overflow: 'hidden',
+          transition: 'opacity 0.6s ease',
+          opacity: fadeState === 'out' ? 0 : 1,
         }}
-      />
+        onClick={handleWalkthroughTap}
+        role="dialog"
+        aria-label="Onboarding walkthrough"
+      >
+        {/* Particle canvas */}
+        <canvas
+          ref={canvasRef}
+          style={{
+            position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
+            pointerEvents: 'none', zIndex: 1,
+            willChange: 'transform', transform: 'translateZ(0)',
+          }}
+        />
 
-      {/* Kinetic stage */}
-      <div style={{
-        position: 'relative', zIndex: 2, textAlign: 'center',
-        width: '100%', maxWidth: '600px', padding: '2rem',
-      }}>
-        {/* Step 0: Arabic reveal — بالعربي */}
-        {kineticStep === 0 && (
-          <div style={{
-            display: 'flex', flexDirection: 'column', alignItems: 'center',
-            justifyContent: 'center', minHeight: '40vh',
-          }} key="kinetic-0">
+        {/* Kinetic stage */}
+        <div style={{
+          position: 'relative', zIndex: 2, textAlign: 'center',
+          width: '100%', maxWidth: '600px', padding: '2rem',
+        }}>
+          {/* Step 0: Arabic reveal — بالعربي */}
+          {kineticStep === 0 && (
             <div style={{
-              fontFamily: "'Reem Kufi', sans-serif", fontWeight: 700,
-              fontSize: 'clamp(3.5rem, 9vw, 6rem)', color: '#ffffff',
-              direction: 'rtl', lineHeight: 1.2, marginBottom: '1.5rem',
-              opacity: 0,
-              animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
-                : isMobile ? 'splashArabicRevealMobile 1s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards'
-                : 'splashArabicReveal 1s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards',
-              willChange: 'transform, opacity, filter',
-              backfaceVisibility: 'hidden',
-              transform: 'translateZ(0)',
-            }} lang="ar" dir="rtl">بالعربي</div>
-            <div style={{
-              fontFamily: "'Tajawal', sans-serif", fontSize: '0.9375rem',
-              color: '#666666', direction: 'rtl',
-              opacity: 0,
-              animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
-                : 'splashFadeIn 0.6s ease-out 0.7s forwards',
-              willChange: 'opacity',
-            }} lang="ar" dir="rtl">الشعر العربي بين يديك</div>
-          </div>
-        )}
-
-        {/* Step 1: English letter-by-letter — poetry */}
-        {kineticStep === 1 && (
-          <div style={{
-            display: 'flex', flexDirection: 'column', alignItems: 'center',
-            justifyContent: 'center', minHeight: '40vh',
-          }} key="kinetic-1">
-            <div style={{
-              fontFamily: "'Forum', cursive",
-              fontSize: 'clamp(4rem, 10vw, 7rem)',
-              textTransform: 'lowercase', letterSpacing: '-0.05em',
-              color: '#ffffff', lineHeight: 1, marginBottom: '1.5rem',
-            }}>
-              {'poetry'.split('').map((letter, i) => (
-                <span key={i} style={{
-                  display: 'inline-block', opacity: 0,
-                  transform: 'translateY(30px)',
-                  animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
-                    : `splashLetterReveal ${isMobile ? '0.35s' : '0.5s'} cubic-bezier(0.16, 1, 0.3, 1) forwards`,
-                  animationDelay: `${0.1 + i * 0.08}s`,
-                  willChange: 'transform, opacity',
-                  backfaceVisibility: 'hidden',
-                }}>{letter}</span>
-              ))}
-            </div>
-            <div style={{
-              fontSize: '0.8125rem', letterSpacing: '0.3em',
-              textTransform: 'uppercase', color: '#555555',
-              opacity: 0,
-              animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
-                : 'splashFadeIn 0.6s ease-out 0.8s forwards',
-              willChange: 'opacity',
-            }}>Where words become worlds</div>
-          </div>
-        )}
-
-        {/* Step 2: Count + Explore */}
-        {kineticStep === 2 && (
-          <div style={{
-            display: 'flex', flexDirection: 'column', alignItems: 'center',
-            justifyContent: 'center', minHeight: '40vh',
-          }} key="kinetic-2">
-            <div style={{
-              fontFamily: "'Forum', cursive",
-              fontSize: 'clamp(2.5rem, 7vw, 4.5rem)',
-              color: '#ffffff', letterSpacing: '-0.02em', marginBottom: '1rem',
-              opacity: 0,
-              animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
-                : 'splashCountReveal 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards',
-              willChange: 'transform, opacity',
-              backfaceVisibility: 'hidden',
-            }}>84,000 verses await</div>
-            <div style={{
-              fontFamily: "'Reem Kufi', sans-serif", fontWeight: 700,
-              fontSize: 'clamp(1.5rem, 4vw, 2.5rem)',
-              color: '#888888', direction: 'rtl', marginBottom: '2rem',
-              opacity: 0,
-              animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
-                : 'splashFadeIn 0.5s ease-out 0.6s forwards',
-              willChange: 'opacity',
-            }} lang="ar" dir="rtl">أكثر من 84,000 بيت بانتظارك</div>
-            <button
-              data-splash-finish="true"
-              onClick={handleFinish}
-              style={{
-                display: 'inline-flex', alignItems: 'center', gap: '8px',
-                padding: '14px 40px', border: '1px solid #333333',
-                borderRadius: '999px', background: 'transparent',
-                color: '#ffffff', fontFamily: "'Tajawal', sans-serif",
-                fontSize: '13px', fontWeight: 500, letterSpacing: '0.15em',
-                textTransform: 'uppercase', cursor: 'pointer',
-                transition: 'background 0.3s ease, border-color 0.3s ease',
-                minHeight: '48px', opacity: 0,
+              display: 'flex', flexDirection: 'column', alignItems: 'center',
+              justifyContent: 'center', minHeight: '40vh',
+            }} key="kinetic-0">
+              <div style={{
+                fontFamily: "'Reem Kufi', sans-serif", fontWeight: 700,
+                fontSize: 'clamp(3.5rem, 9vw, 6rem)', color: '#ffffff',
+                direction: 'rtl', lineHeight: 1.2, marginBottom: '1.5rem',
+                opacity: 0,
                 animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
-                  : 'splashFadeIn 0.5s ease-out 1s forwards',
-                willChange: 'opacity', backfaceVisibility: 'hidden',
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.background = 'rgba(255, 255, 255, 0.06)';
-                e.currentTarget.style.borderColor = '#666666';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.background = 'transparent';
-                e.currentTarget.style.borderColor = '#333333';
-              }}
-              aria-label="Start exploring"
-            >
-              <span>Explore</span>
-              <ArrowRight size={16} />
-            </button>
-          </div>
-        )}
+                  : isMobile ? 'splashArabicRevealMobile 1s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards'
+                  : 'splashArabicReveal 1s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards',
+                willChange: 'transform, opacity, filter',
+                backfaceVisibility: 'hidden',
+                transform: 'translateZ(0)',
+              }} lang="ar" dir="rtl">بالعربي</div>
+              <div style={{
+                fontFamily: "'Tajawal', sans-serif", fontSize: '0.9375rem',
+                color: '#666666', direction: 'rtl',
+                opacity: 0,
+                animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
+                  : 'splashFadeIn 0.6s ease-out 0.7s forwards',
+                willChange: 'opacity',
+              }} lang="ar" dir="rtl">الشعر العربي بين يديك</div>
+            </div>
+          )}
+
+          {/* Step 1: English letter-by-letter — poetry */}
+          {kineticStep === 1 && (
+            <div style={{
+              display: 'flex', flexDirection: 'column', alignItems: 'center',
+              justifyContent: 'center', minHeight: '40vh',
+            }} key="kinetic-1">
+              <div style={{
+                fontFamily: "'Forum', cursive",
+                fontSize: 'clamp(4rem, 10vw, 7rem)',
+                textTransform: 'lowercase', letterSpacing: '-0.05em',
+                color: '#ffffff', lineHeight: 1, marginBottom: '1.5rem',
+              }}>
+                {'poetry'.split('').map((letter, i) => (
+                  <span key={i} style={{
+                    display: 'inline-block', opacity: 0,
+                    transform: 'translateY(30px)',
+                    animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
+                      : `splashLetterReveal ${isMobile ? '0.35s' : '0.5s'} cubic-bezier(0.16, 1, 0.3, 1) forwards`,
+                    animationDelay: `${0.1 + i * 0.08}s`,
+                    willChange: 'transform, opacity',
+                    backfaceVisibility: 'hidden',
+                  }}>{letter}</span>
+                ))}
+              </div>
+              <div style={{
+                fontSize: '0.8125rem', letterSpacing: '0.3em',
+                textTransform: 'uppercase', color: '#555555',
+                opacity: 0,
+                animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
+                  : 'splashFadeIn 0.6s ease-out 0.8s forwards',
+                willChange: 'opacity',
+              }}>Where words become worlds</div>
+            </div>
+          )}
+
+          {/* Step 2: Count + Explore */}
+          {kineticStep === 2 && (
+            <div style={{
+              display: 'flex', flexDirection: 'column', alignItems: 'center',
+              justifyContent: 'center', minHeight: '40vh',
+            }} key="kinetic-2">
+              <div style={{
+                fontFamily: "'Forum', cursive",
+                fontSize: 'clamp(2.5rem, 7vw, 4.5rem)',
+                color: '#ffffff', letterSpacing: '-0.02em', marginBottom: '1rem',
+                opacity: 0,
+                animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
+                  : 'splashCountReveal 0.8s cubic-bezier(0.16, 1, 0.3, 1) 0.1s forwards',
+                willChange: 'transform, opacity',
+                backfaceVisibility: 'hidden',
+              }}>84,000 verses await</div>
+              <div style={{
+                fontFamily: "'Reem Kufi', sans-serif", fontWeight: 700,
+                fontSize: 'clamp(1.5rem, 4vw, 2.5rem)',
+                color: '#888888', direction: 'rtl', marginBottom: '2rem',
+                opacity: 0,
+                animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
+                  : 'splashFadeIn 0.5s ease-out 0.6s forwards',
+                willChange: 'opacity',
+              }} lang="ar" dir="rtl">أكثر من 84,000 بيت بانتظارك</div>
+              <button
+                data-splash-finish="true"
+                onClick={handleFinish}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: '8px',
+                  padding: '14px 40px', border: '1px solid #333333',
+                  borderRadius: '999px', background: 'transparent',
+                  color: '#ffffff', fontFamily: "'Tajawal', sans-serif",
+                  fontSize: '13px', fontWeight: 500, letterSpacing: '0.15em',
+                  textTransform: 'uppercase', cursor: 'pointer',
+                  transition: 'background 0.3s ease, border-color 0.3s ease',
+                  minHeight: '48px', opacity: 0,
+                  animation: prefersReducedMotion ? 'splashFadeIn 0.01ms forwards'
+                    : 'splashFadeIn 0.5s ease-out 1s forwards',
+                  willChange: 'opacity', backfaceVisibility: 'hidden',
+                }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.background = 'rgba(255, 255, 255, 0.06)';
+                  e.currentTarget.style.borderColor = '#666666';
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.background = 'transparent';
+                  e.currentTarget.style.borderColor = '#333333';
+                }}
+                aria-label="Start exploring"
+              >
+                <span>Explore</span>
+                <ArrowRight size={16} />
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Tap hint */}
+        <div style={{
+          position: 'fixed', bottom: '3rem', left: '50%',
+          transform: 'translateX(-50%)', fontSize: '0.65rem',
+          letterSpacing: '0.35em', textTransform: 'uppercase',
+          color: '#333333', zIndex: 5,
+        }}>Tap anywhere</div>
+
+        {/* Progress bar */}
+        <div style={{
+          position: 'fixed', bottom: 0, left: 0, height: '2px',
+          background: 'rgba(255, 255, 255, 0.15)',
+          transition: 'width 0.6s cubic-bezier(0.16, 1, 0.3, 1)',
+          zIndex: 5, width: progressWidth,
+          willChange: 'width', transform: 'translateZ(0)',
+        }} />
       </div>
-
-      {/* Tap hint */}
-      <div style={{
-        position: 'fixed', bottom: '3rem', left: '50%',
-        transform: 'translateX(-50%)', fontSize: '0.65rem',
-        letterSpacing: '0.35em', textTransform: 'uppercase',
-        color: '#333333', zIndex: 5,
-      }}>Tap anywhere</div>
-
-      {/* Progress bar */}
-      <div style={{
-        position: 'fixed', bottom: 0, left: 0, height: '2px',
-        background: 'rgba(255, 255, 255, 0.15)',
-        transition: 'width 0.6s cubic-bezier(0.16, 1, 0.3, 1)',
-        zIndex: 5, width: progressWidth,
-        willChange: 'width', transform: 'translateZ(0)',
-      }} />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- SplashScreen crashed in production builds when transitioning from desert splash (phase 0) to kinetic walkthrough (phase 1+)
- Root cause: separate `return` statements for each phase caused React to fully unmount/remount the DOM tree, triggering `removeChild` errors on imperatively-added star elements
- Fix: single return with both phases always in the DOM, toggled via `display: none`/`display: flex`

## Test plan
- [x] 260/260 unit tests pass
- [x] 10/10 user flow E2E tests pass
- [x] 10/10 translation cache E2E tests pass
- [x] Production build (`npm run build` + preview) splash transition completes without crash (verified via Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)