### PR TITLE
fix(e2e): select poet before discovering in filter test

### DIFF
--- a/e2e/user-flows.spec.js
+++ b/e2e/user-flows.spec.js
@@ -229,7 +229,11 @@ test.describe('User Flows', () => {
     const catVisible = await categoryButton.isVisible().catch(() => false);
 
     if (catVisible) {
+      // Desktop: open dropdown and select a specific poet
       await categoryButton.click();
+      const poetOption = page.locator('text=نزار قباني').first();
+      await expect(poetOption).toBeVisible({ timeout: 3000 });
+      await poetOption.click();
     } else {
       // Mobile: open Settings gear in VerticalSidebar, then click poet cycle button
       const settingsBtn = page.locator('button[title="Settings"]').first();
@@ -237,7 +241,7 @@ test.describe('User Flows', () => {
       await page.waitForTimeout(300);
       const poetBtn = page.locator('button[title="Poet filter"]').first();
       await expect(poetBtn).toBeVisible({ timeout: 2000 });
-      // Click poet filter to cycle from "All" to "Nizar Qabbani"
+      // Click poet filter to cycle from "All" to next poet
       await poetBtn.click();
     }
 


### PR DESCRIPTION
## Summary
- The poet filter E2E test (#6) was failing on both `main` and `feature/v1-soft-launch` because it opened the CategoryPill dropdown but never selected a specific poet before clicking Discover
- The `waitForRequest` for a URL containing `poet=` timed out since no poet filter was applied
- Fix: after opening the dropdown, select "نزار قباني" so the subsequent Discover request includes the `poet=` query param

## Test plan
- [x] All 21 E2E tests pass locally (20 passed, 1 skipped)
- [x] Poet filter test (#6) specifically verified passing
- [ ] CI smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)