### PR TITLE
fix(server): random poem selection and serving filter gaps

### DIFF
--- a/server.js
+++ b/server.js
@@ -233,11 +233,16 @@ const validate = (req, res, next) => {
 // Health check endpoint
 app.get('/api/health', async (req, res) => {
   try {
-    const result = await pool.query('SELECT COUNT(*) FROM poems');
+    const totalResult = await pool.query('SELECT COUNT(*) FROM poems');
+    const qf = servingFilters();
+    const servedResult = qf
+      ? await pool.query(`SELECT COUNT(*) FROM poems p WHERE 1=1 ${qf}`)
+      : totalResult;
     res.json({
       status: 'ok',
       database: 'connected',
-      totalPoems: parseInt(result.rows[0].count)
+      totalPoems: parseInt(totalResult.rows[0].count),
+      servedPoems: parseInt(servedResult.rows[0].count)
     });
   } catch (error) {
     res.status(500).json({
@@ -277,12 +282,7 @@ app.get('/api/poems/random', [
       if (qf) query += ` WHERE 1=1 ${qf}`;
     }
 
-    // Prefer poems with cached translations, then random
-    if (hasTranslationColumns) {
-      query += ' ORDER BY (p.cached_translation IS NOT NULL) DESC, RANDOM() LIMIT 1';
-    } else {
-      query += ' ORDER BY RANDOM() LIMIT 1';
-    }
+    query += ' ORDER BY RANDOM() LIMIT 1';
 
     const result = await pool.query(query, params);
 
@@ -374,10 +374,12 @@ app.get('/api/poems/by-poet/:poet', [
 // Get list of available poets
 app.get('/api/poets', async (req, res) => {
   try {
+    const qf = servingFilters();
     const query = `
       SELECT DISTINCT po.name, COUNT(p.id) as poem_count
       FROM poets po
       JOIN poems p ON po.id = p.poet_id
+      ${qf ? 'WHERE 1=1 ' + qf : ''}
       GROUP BY po.name
       HAVING COUNT(p.id) > 0
       ORDER BY poem_count DESC

--- a/src/test/server.test.js
+++ b/src/test/server.test.js
@@ -45,9 +45,12 @@ describe('Backend API Server', () => {
 
   describe('GET /api/health', () => {
     it('should return health status when database is connected', async () => {
-      // Mock successful database query
+      // Mock successful database queries (total + served count)
       mockPool.query.mockResolvedValueOnce({
         rows: [{ count: '42' }]
+      });
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ count: '30' }]
       });
 
       const response = await request(app)
@@ -58,7 +61,8 @@ describe('Backend API Server', () => {
       expect(response.body).toEqual({
         status: 'ok',
         database: 'connected',
-        totalPoems: 42
+        totalPoems: 42,
+        servedPoems: 30
       });
 
       expect(mockPool.query).toHaveBeenCalledWith('SELECT COUNT(*) FROM poems');
@@ -169,7 +173,7 @@ describe('Backend API Server', () => {
       );
     });
 
-    it('should not filter when poet is "All"', async () => {
+    it('should not filter by poet when poet is "All"', async () => {
       mockPool.query.mockResolvedValueOnce({
         rows: [mockPoem]
       });
@@ -178,8 +182,9 @@ describe('Backend API Server', () => {
         .get('/api/poems/random?poet=All')
         .expect(200);
 
+      // Should not filter by poet name (no po.name = $1), but serving filters may still apply
       expect(pool.query).toHaveBeenCalledWith(
-        expect.not.stringContaining('WHERE'),
+        expect.not.stringContaining('po.name ='),
         []
       );
     });
@@ -579,6 +584,7 @@ describe('Backend API Server', () => {
   describe('Security Headers', () => {
     it('should include helmet security headers', async () => {
       mockPool.query.mockResolvedValueOnce({ rows: [{ count: '10' }] });
+      mockPool.query.mockResolvedValueOnce({ rows: [{ count: '8' }] });
       const response = await request(app).get('/api/health').expect(200);
       expect(response.headers['x-content-type-options']).toBe('nosniff');
       expect(response.headers).not.toHaveProperty('x-powered-by');
@@ -589,6 +595,9 @@ describe('Backend API Server', () => {
     it('should allow cross-origin requests from allowed origins', async () => {
       mockPool.query.mockResolvedValueOnce({
         rows: [{ count: '10' }]
+      });
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ count: '8' }]
       });
 
       const response = await request(app)
@@ -815,6 +824,7 @@ describe('Backend API Server', () => {
 
       it('should not require API key for read endpoints', async () => {
         mockPool.query.mockResolvedValueOnce({ rows: [{ count: '42' }] });
+        mockPool.query.mockResolvedValueOnce({ rows: [{ count: '30' }] });
 
         const response = await request(app)
           .get('/api/health')
@@ -826,10 +836,13 @@ describe('Backend API Server', () => {
   });
 
   describe('Keep-Alive Mechanism', () => {
-    it('should have health endpoint that returns totalPoems for keep-alive pings', async () => {
-      // Mock successful database query
+    it('should have health endpoint that returns totalPoems and servedPoems for keep-alive pings', async () => {
+      // Mock successful database queries (total + served count)
       mockPool.query.mockResolvedValueOnce({
         rows: [{ count: '84329' }]
+      });
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ count: '4767' }]
       });
 
       const response = await request(app)
@@ -841,11 +854,16 @@ describe('Backend API Server', () => {
       expect(response.body).toHaveProperty('database', 'connected');
       expect(response.body).toHaveProperty('totalPoems');
       expect(response.body.totalPoems).toBe(84329);
+      expect(response.body).toHaveProperty('servedPoems');
+      expect(response.body.servedPoems).toBe(4767);
     });
 
     it('should respond quickly to health checks (< 100ms)', async () => {
       mockPool.query.mockResolvedValueOnce({
         rows: [{ count: '84329' }]
+      });
+      mockPool.query.mockResolvedValueOnce({
+        rows: [{ count: '4767' }]
       });
 
       const startTime = Date.now();


### PR DESCRIPTION
## Summary
- **`/api/poems/random`**: Remove `cached_translation IS NOT NULL DESC` ORDER BY that pinned every request to poem id=86001. Now uses pure `ORDER BY RANDOM()` — verified 10/10 unique results locally.
- **`/api/poets`**: Apply serving filters (`quality_score >= 75`, `verses <= 24`) so `poem_count` reflects only serveable poems and poets with 0 serveable poems are excluded.
- **`/api/health`**: Add `servedPoems` count alongside `totalPoems` (9,072 total → 4,767 served).

## Test plan
- [x] Unit tests updated and passing (260/260)
- [x] Local verification: 10 consecutive `/api/poems/random` calls returned 10 different poems
- [x] `/api/health` returns both `totalPoems: 9072` and `servedPoems: 4767`
- [x] `/api/poets` counts reflect filtered totals
- [ ] CI passes
- [ ] Post-deploy: verify production `/api/poems/random` returns varied results

🤖 Generated with [Claude Code](https://claude.com/claude-code)