### PR TITLE
fix(server): two-tier health check for Render deploy reliability

### DIFF
--- a/server.js
+++ b/server.js
@@ -230,8 +230,13 @@ const validate = (req, res, next) => {
   next();
 };
 
-// Health check endpoint
-app.get('/api/health', async (req, res) => {
+// Lightweight health check (no DB query — fast enough for Render's deploy probe)
+app.get('/api/health', (req, res) => {
+  res.json({ status: 'ok', uptime: process.uptime() });
+});
+
+// Full health check with database connectivity
+app.get('/api/health/full', async (req, res) => {
   try {
     const totalResult = await pool.query('SELECT COUNT(*) FROM poems');
     const qf = servingFilters();
@@ -242,11 +247,13 @@ app.get('/api/health', async (req, res) => {
       status: 'ok',
       database: 'connected',
       totalPoems: parseInt(totalResult.rows[0].count),
-      servedPoems: parseInt(servedResult.rows[0].count)
+      servedPoems: parseInt(servedResult.rows[0].count),
+      uptime: process.uptime(),
     });
   } catch (error) {
     res.status(500).json({
       status: 'error',
+      database: 'disconnected',
       message: error.message
     });
   }
@@ -1493,9 +1500,9 @@ if (currentFile === mainFile) {
       };
       
       const pingHealth = () => {
-        const url = process.env.RENDER_EXTERNAL_URL 
-          ? `${process.env.RENDER_EXTERNAL_URL}/api/health`
-          : `http://localhost:${PORT}/api/health`;
+        const url = process.env.RENDER_EXTERNAL_URL
+          ? `${process.env.RENDER_EXTERNAL_URL}/api/health/full`
+          : `http://localhost:${PORT}/api/health/full`;
         
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 10000);
@@ -1508,7 +1515,7 @@ if (currentFile === mainFile) {
             return res.json();
           })
           .then(data => {
-            console.log(`✓ Keep-alive ping successful - ${data.totalPoems} poems in database`);
+            console.log(`✓ Keep-alive ping successful - ${data.totalPoems ?? '?'} poems in database`);
 
             // Schedule next ping with new random interval
             keepAliveTimeout = setTimeout(() => {

--- a/src/test/server.test.js
+++ b/src/test/server.test.js
@@ -44,7 +44,26 @@ describe('Backend API Server', () => {
   });
 
   describe('GET /api/health', () => {
-    it('should return health status when database is connected', async () => {
+    it('should return lightweight health status without DB query', async () => {
+      const response = await request(app)
+        .get('/api/health')
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(response.body).toHaveProperty('status', 'ok');
+      expect(response.body).toHaveProperty('uptime');
+      expect(typeof response.body.uptime).toBe('number');
+      // Lightweight endpoint should NOT have database fields
+      expect(response.body).not.toHaveProperty('database');
+      expect(response.body).not.toHaveProperty('totalPoems');
+      expect(response.body).not.toHaveProperty('servedPoems');
+      // Should not trigger any DB queries
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /api/health/full', () => {
+    it('should return full health status when database is connected', async () => {
       // Mock successful database queries (total + served count)
       mockPool.query.mockResolvedValueOnce({
         rows: [{ count: '42' }]
@@ -54,16 +73,15 @@ describe('Backend API Server', () => {
       });
 
       const response = await request(app)
-        .get('/api/health')
+        .get('/api/health/full')
         .expect('Content-Type', /json/)
         .expect(200);
 
-      expect(response.body).toEqual({
-        status: 'ok',
-        database: 'connected',
-        totalPoems: 42,
-        servedPoems: 30
-      });
+      expect(response.body).toHaveProperty('status', 'ok');
+      expect(response.body).toHaveProperty('database', 'connected');
+      expect(response.body).toHaveProperty('totalPoems', 42);
+      expect(response.body).toHaveProperty('servedPoems', 30);
+      expect(response.body).toHaveProperty('uptime');
 
       expect(mockPool.query).toHaveBeenCalledWith('SELECT COUNT(*) FROM poems');
     });
@@ -73,12 +91,13 @@ describe('Backend API Server', () => {
       mockPool.query.mockRejectedValueOnce(new Error('Database connection failed'));
 
       const response = await request(app)
-        .get('/api/health')
+        .get('/api/health/full')
         .expect('Content-Type', /json/)
         .expect(500);
 
       expect(response.body).toEqual({
         status: 'error',
+        database: 'disconnected',
         message: 'Database connection failed'
       });
     });
@@ -88,10 +107,11 @@ describe('Backend API Server', () => {
       mockPool.query.mockRejectedValueOnce(new Error('Connection timeout'));
 
       const response = await request(app)
-        .get('/api/health')
+        .get('/api/health/full')
         .expect(500);
 
       expect(response.body.status).toBe('error');
+      expect(response.body.database).toBe('disconnected');
       expect(response.body.message).toContain('timeout');
     });
   });
@@ -583,8 +603,6 @@ describe('Backend API Server', () => {
 
   describe('Security Headers', () => {
     it('should include helmet security headers', async () => {
-      mockPool.query.mockResolvedValueOnce({ rows: [{ count: '10' }] });
-      mockPool.query.mockResolvedValueOnce({ rows: [{ count: '8' }] });
       const response = await request(app).get('/api/health').expect(200);
       expect(response.headers['x-content-type-options']).toBe('nosniff');
       expect(response.headers).not.toHaveProperty('x-powered-by');
@@ -593,13 +611,6 @@ describe('Backend API Server', () => {
 
   describe('CORS Configuration', () => {
     it('should allow cross-origin requests from allowed origins', async () => {
-      mockPool.query.mockResolvedValueOnce({
-        rows: [{ count: '10' }]
-      });
-      mockPool.query.mockResolvedValueOnce({
-        rows: [{ count: '8' }]
-      });
-
       const response = await request(app)
         .get('/api/health')
         .set('Origin', 'http://localhost:5173')
@@ -836,7 +847,7 @@ describe('Backend API Server', () => {
   });
 
   describe('Keep-Alive Mechanism', () => {
-    it('should have health endpoint that returns totalPoems and servedPoems for keep-alive pings', async () => {
+    it('should have full health endpoint that returns totalPoems and servedPoems for keep-alive pings', async () => {
       // Mock successful database queries (total + served count)
       mockPool.query.mockResolvedValueOnce({
         rows: [{ count: '84329' }]
@@ -846,7 +857,7 @@ describe('Backend API Server', () => {
       });
 
       const response = await request(app)
-        .get('/api/health')
+        .get('/api/health/full')
         .expect('Content-Type', /json/)
         .expect(200);
 
@@ -858,21 +869,14 @@ describe('Backend API Server', () => {
       expect(response.body.servedPoems).toBe(4767);
     });
 
-    it('should respond quickly to health checks (< 100ms)', async () => {
-      mockPool.query.mockResolvedValueOnce({
-        rows: [{ count: '84329' }]
-      });
-      mockPool.query.mockResolvedValueOnce({
-        rows: [{ count: '4767' }]
-      });
-
+    it('should respond quickly to lightweight health checks (< 100ms)', async () => {
       const startTime = Date.now();
       await request(app)
         .get('/api/health')
         .expect(200);
       const duration = Date.now() - startTime;
 
-      // Health check should be very fast for keep-alive pings
+      // Lightweight health check should be very fast (no DB query)
       expect(duration).toBeLessThan(100);
     });
   });


### PR DESCRIPTION
## Summary

- **Root cause**: The `/api/health` endpoint runs `SELECT COUNT(*) FROM poems` on an 84K-row table. During Render cold starts, this query can exceed the 15-second health check timeout, causing deploy failures.
- **Fix**: Split into two endpoints:
  - `GET /api/health` -- lightweight, no DB query, returns `{status, uptime}`. Used by Render's deploy health probe and frontend backup pings.
  - `GET /api/health/full` -- DB-backed, returns `{status, database, totalPoems, servedPoems, uptime}`. Used by keep-alive self-pings to warm the connection pool.
- Keep-alive self-ping updated to hit `/api/health/full` so DB connections stay warm between requests.
- `render.yaml` healthCheckPath unchanged (still `/api/health`).

## Test plan

- [x] All 58 server unit tests pass (lightweight health, full health, security headers, CORS, keep-alive)
- [ ] Verify Render deploy succeeds without health check timeout
- [ ] Verify keep-alive pings log poem count from `/api/health/full`
- [ ] Verify frontend backup pings still work on `/api/health`

Generated with [Claude Code](https://claude.ai/code)