### PR TITLE
fix(test): stabilize flaky Discover button disabled state test

### DIFF
--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -129,8 +129,12 @@ describe('DiwanApp', () => {
       const discoverBtn = screen.getByLabelText('Discover new poem')
       await userEvent.click(discoverBtn)
 
-      // Button should be disabled during fetch
-      expect(discoverBtn).toBeDisabled()
+      // Button should be disabled during fetch — use waitFor because
+      // setIsFetching(true) is a React state update that may not have
+      // flushed to the DOM by the time userEvent.click resolves
+      await waitFor(() => {
+        expect(discoverBtn).toBeDisabled()
+      })
 
       // Resolve to clean up
       resolveFetch({ ok: true, json: async () => createDbPoem(99) })


### PR DESCRIPTION
## Summary
- Wraps the `expect(discoverBtn).toBeDisabled()` assertion in `waitFor()` so the test correctly waits for React to flush the `setIsFetching(true)` state update to the DOM
- Without this fix, the synchronous assertion after `userEvent.click()` could run before the re-render, causing intermittent test failures

## Root Cause
The test clicked the Discover button and immediately asserted `expect(discoverBtn).toBeDisabled()`. The `handleFetch` handler calls `setIsFetching(true)`, which is a React state update batched for the next render. By the time `await userEvent.click()` resolved, the DOM had not yet been updated with the disabled attribute, causing the assertion to fail.

## Test plan
- [x] `npm run test:run` passes (26/26 App tests green)
- [x] Verified fix addresses the race condition by using `waitFor` retry semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)