### PR TITLE
refactor(ui): replace AI references with human/poetic language

### DIFF
--- a/design-review/DESIGN-SYSTEM-SPEC.md
+++ b/design-review/DESIGN-SYSTEM-SPEC.md
@@ -31,7 +31,7 @@ Bottom bar with action buttons. Present in the main app view.
 |--------|------|----------|
 | Listen | Speaker/Audio | Play audio synthesis of the poem (Gemini multimodal) |
 | Save | Bookmark/Heart | Save current poem to favorites |
-| Explain/Insights | Lightbulb/Star | Show AI-generated explanation of the poem |
+| Explain/Insights | Lightbulb/Star | Show in-depth explanation of the poem |
 | Next | Arrow right | Load next poem |
 | Shuffle/Random | Dice/Shuffle | Load random poem |
 | Poet | Person/Quill | Show poet info or filter by poet |

--- a/design-review/e2e/gen-1/e2e-a1-gold-orbit-story.html
+++ b/design-review/e2e/gen-1/e2e-a1-gold-orbit-story.html
@@ -700,7 +700,7 @@
         </div>
         <div>
           <div class="glass-sheet-label">Listen</div>
-          <div class="glass-sheet-sublabel">AI recitation</div>
+          <div class="glass-sheet-sublabel">Voice recitation</div>
         </div>
       </div>
       <div class="glass-sheet-item" data-action="share">

--- a/design-review/e2e/gen-1/e2e-a2-paper-photon.html
+++ b/design-review/e2e/gen-1/e2e-a2-paper-photon.html
@@ -370,7 +370,7 @@ body {
     <div class="editorial-section">Issue No. 2 -- The Voice</div>
     <div class="editorial-headline">Listen & Feel</div>
     <div class="editorial-headline-ar" lang="ar" dir="rtl">استمع واشعر</div>
-    <div class="editorial-body">AI-powered recitation captures the natural rhythm and melody of Arabic verse. Each poem breathes with the cadence of its original meter.</div>
+    <div class="editorial-body">Recitation captures the natural rhythm and melody of Arabic verse. Each poem breathes with the cadence of its original meter.</div>
     <div class="editorial-pull" lang="ar" dir="rtl">"الشعر ديوان العرب"</div>
     <div class="editorial-body-ar" lang="ar" dir="rtl">إلقاء صوتي يلتقط الإيقاع الطبيعي ولحن الشعر العربي</div>
     <div class="editorial-page-num">Page 2 of 3</div>
@@ -378,8 +378,8 @@ body {
 
   <div class="editorial-page" data-page="2">
     <div class="editorial-section">Issue No. 3 -- The Insight</div>
-    <div class="editorial-headline">AI Insights</div>
-    <div class="editorial-headline-ar" lang="ar" dir="rtl">رؤى ذكية</div>
+    <div class="editorial-headline">Poetic Insights</div>
+    <div class="editorial-headline-ar" lang="ar" dir="rtl">رؤى شعرية</div>
     <div class="editorial-body">Deep analysis illuminates meter, meaning, and historical context. Intelligent annotations guide you through layers of poetic tradition.</div>
     <div class="editorial-body-ar" lang="ar" dir="rtl">تحليل عميق يكشف الوزن والمعنى والسياق التاريخي لكل قصيدة</div>
     <div class="editorial-page-num">Page 3 of 3</div>

--- a/design-review/e2e/gen-1/e2e-a8-deco-discovery.html
+++ b/design-review/e2e/gen-1/e2e-a8-deco-discovery.html
@@ -408,13 +408,13 @@
       <div class="deco-title">Listen & Feel</div>
       <div class="deco-title-ar" lang="ar" dir="rtl">استمع واشعر</div>
       <div class="deco-divider-thin"></div>
-      <div class="deco-desc">AI-powered recitation captures the symmetry and rhythm of every verse with natural precision.</div>
+      <div class="deco-desc">Recitation captures the symmetry and rhythm of every verse with natural precision.</div>
       <div class="deco-desc-ar" lang="ar" dir="rtl">إلقاء صوتي يلتقط التناظر والإيقاع في كل بيت بدقة طبيعية</div>
     </div>
     <div class="deco-panel" data-panel="2">
       <div class="deco-step-num">Step III</div><div class="deco-divider"></div>
-      <div class="deco-title">AI Insights</div>
-      <div class="deco-title-ar" lang="ar" dir="rtl">رؤى ذكية</div>
+      <div class="deco-title">Poetic Insights</div>
+      <div class="deco-title-ar" lang="ar" dir="rtl">رؤى شعرية</div>
       <div class="deco-divider-thin"></div>
       <div class="deco-desc">Deep analysis unveils the geometric patterns of meaning woven into every line of poetry.</div>
       <div class="deco-desc-ar" lang="ar" dir="rtl">تحليل عميق يكشف الأنماط الهندسية للمعنى المنسوجة في كل بيت</div>

--- a/design-review/e2e/gen-1/e2e-b8-ritual-spotlight-hybrid.html
+++ b/design-review/e2e/gen-1/e2e-b8-ritual-spotlight-hybrid.html
@@ -205,7 +205,7 @@ body {
   <div class="ma-step" data-ma="1">
     <div class="ma-title">Listen</div>
     <div class="ma-title-ar" lang="ar" dir="rtl">استمع</div>
-    <div class="ma-desc">Each word breathes. AI gives voice to what was written in stillness.</div>
+    <div class="ma-desc">Each word breathes. Voice given to what was written in stillness.</div>
   </div>
   <div class="ma-step" data-ma="2">
     <div class="ma-title">Understand</div>

--- a/design-review/e2e/gen-2a/02-zen-manuscript.html
+++ b/design-review/e2e/gen-2a/02-zen-manuscript.html
@@ -460,7 +460,7 @@ button:focus-visible {
   <div class="zen-panel" data-zen="2">
     <div class="zen-kanji" lang="ar" dir="rtl">اكتشف</div>
     <div class="zen-title">Discover</div>
-    <div class="zen-desc">AI reveals the meaning beneath. Understanding deepens like ripples on water.</div>
+    <div class="zen-desc">Meaning reveals itself beneath the verse. Understanding deepens like ripples on water.</div>
   </div>
   <div class="zen-drops">
     <div class="zen-drop active" data-drop="0"></div>

--- a/design-review/e2e/gen-2b/01-particle-scroll.html
+++ b/design-review/e2e/gen-2b/01-particle-scroll.html
@@ -505,7 +505,7 @@
       <div class="emit-count">03 / 03</div>
       <div class="emit-ar" lang="ar" dir="rtl">استمع واستكشف</div>
       <div class="emit-en">Listen & Explore</div>
-      <div class="emit-desc">AI voices bring verses to life. Navigate, save, and discover your own path through poetry.</div>
+      <div class="emit-desc">Verses come to life when spoken aloud. Navigate, save, and discover your own path through poetry.</div>
     </div>
 
     <div class="emit-orbits">

--- a/design-review/e2e/gen-2b/04-neumorphic-warmth.html
+++ b/design-review/e2e/gen-2b/04-neumorphic-warmth.html
@@ -660,7 +660,7 @@
           <div class="neu-icon"><i data-lucide="music"></i></div>
           <div class="neu-ar" lang="ar" dir="rtl">استمع للإلقاء</div>
           <div class="neu-en">Listen to Recitation</div>
-          <div class="neu-desc">AI voices bring each verse to life. Feel the warmth and rhythm of Arabic poetry spoken aloud.</div>
+          <div class="neu-desc">Each verse comes to life when spoken. Feel the warmth and rhythm of Arabic poetry aloud.</div>
         </div>
         <div class="neu-panel" data-neu="2">
           <div class="neu-icon"><i data-lucide="heart"></i></div>

--- a/design-review/e2e/gen-2b/05-scroll-codex.html
+++ b/design-review/e2e/gen-2b/05-scroll-codex.html
@@ -748,8 +748,8 @@
             <div class="section-mark">/** @chapter 3 */</div>
             <h3 lang="ar">استمع وتأمّل</h3>
             <div class="subtitle">// Listen & Reflect</div>
-            <p lang="ar">اسمع القصيدة بصوت الذكاء الاصطناعي وتدبّر معانيها</p>
-            <p class="en-text">Listen to AI-narrated poetry and contemplate its meaning</p>
+            <p lang="ar">اسمع القصيدة بصوتها الحي وتدبّر معانيها</p>
+            <p class="en-text">Listen to poetry recited aloud and contemplate its meaning</p>
             <div class="rule"></div>
             <div class="codex-tabs">
                 <div class="codex-tab"></div>

--- a/design-review/e2e/gen-3/codex-spine-story.html
+++ b/design-review/e2e/gen-3/codex-spine-story.html
@@ -812,7 +812,7 @@
         <div class="codex-title">Listen & Feel</div>
         <div class="codex-title-ar" lang="ar" dir="rtl">استمع واشعر</div>
         <div class="codex-divider"></div>
-        <div class="codex-desc">AI-powered recitation breathes life into ancient verses, as if read aloud in a scholar's chamber.</div>
+        <div class="codex-desc">Recitation breathes life into ancient verses, as if read aloud in a scholar's chamber.</div>
         <div class="codex-desc-ar" lang="ar" dir="rtl">إلقاء صوتي يبعث الحياة في الأبيات القديمة كأنك تسمعها في مجلس عالم</div>
         <div class="codex-folio">Folio 2</div>
       </div>
@@ -821,8 +821,8 @@
       <div class="codex-page" data-page="2">
         <div class="chapter-num">III</div>
         <div class="chapter-label">Chapter the Third</div>
-        <div class="codex-title">AI Insights</div>
-        <div class="codex-title-ar" lang="ar" dir="rtl">رؤى ذكية</div>
+        <div class="codex-title">Poetic Insights</div>
+        <div class="codex-title-ar" lang="ar" dir="rtl">رؤى شعرية</div>
         <div class="codex-divider"></div>
         <div class="codex-desc">Deep analysis illuminates the hidden meanings, as a scholar's marginal notes guide the reader.</div>
         <div class="codex-desc-ar" lang="ar" dir="rtl">تحليل عميق يكشف المعاني الخفية كحواشي العلماء التي تهدي القارئ</div>

--- a/design-review/e2e/gen-3/ls1-chiaroscuro.html
+++ b/design-review/e2e/gen-3/ls1-chiaroscuro.html
@@ -644,16 +644,16 @@
         </div>
         <div class="onboard-title">Listen & Feel</div>
         <div class="onboard-title-ar" lang="ar" dir="rtl">استمع واشعر</div>
-        <div class="onboard-desc">AI-powered recitation brings each verse to life, like light revealing hidden text.</div>
-        <div class="onboard-desc-ar" lang="ar" dir="rtl">إلقاء صوتي بالذكاء الاصطناعي يجعل كل بيت ينبض بالحياة</div>
+        <div class="onboard-desc">Recitation brings each verse to life, like light revealing hidden text.</div>
+        <div class="onboard-desc-ar" lang="ar" dir="rtl">إلقاء صوتي يجعل كل بيت ينبض بالحياة</div>
       </div>
 
       <div class="onboard-card" data-card="2">
         <div class="onboard-icon">
           <i data-lucide="sparkles" style="width:24px;height:24px"></i>
         </div>
-        <div class="onboard-title">AI Insights</div>
-        <div class="onboard-title-ar" lang="ar" dir="rtl">رؤى ذكية</div>
+        <div class="onboard-title">Poetic Insights</div>
+        <div class="onboard-title-ar" lang="ar" dir="rtl">رؤى شعرية</div>
         <div class="onboard-desc">Deep analysis illuminates meaning hidden in every verse.</div>
         <div class="onboard-desc-ar" lang="ar" dir="rtl">تحليل عميق يضيء المعاني الكامنة في كل بيت</div>
       </div>

--- a/design-review/e2e/gen-3/pf3-ink-constellation.html
+++ b/design-review/e2e/gen-3/pf3-ink-constellation.html
@@ -592,8 +592,8 @@
       <i data-lucide="languages" class="onboarding-icon"></i>
       <h2 class="onboarding-title">Bilingual Experience</h2>
       <p class="onboarding-title-ar" lang="ar" dir="rtl">تجربة ثنائية اللغة</p>
-      <p class="onboarding-desc">Read poems in their original Arabic with AI-powered English translations and cultural context.</p>
-      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية وسياق ثقافي مدعوم بالذكاء الاصطناعي.</p>
+      <p class="onboarding-desc">Read poems in their original Arabic with eloquent English translations and cultural context.</p>
+      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية بليغة وسياق ثقافي عميق.</p>
       <div class="onboarding-dots">
         <span class="onboarding-dot"></span>
         <span class="onboarding-dot active"></span>

--- a/design-review/e2e/gen-3/pf4-ink-tilt-splash.html
+++ b/design-review/e2e/gen-3/pf4-ink-tilt-splash.html
@@ -694,8 +694,8 @@
       <i data-lucide="languages" class="onboarding-icon"></i>
       <h2 class="onboarding-title">Bilingual Experience</h2>
       <p class="onboarding-title-ar" lang="ar" dir="rtl">تجربة ثنائية اللغة</p>
-      <p class="onboarding-desc">Read poems in their original Arabic with AI-powered English translations and cultural context.</p>
-      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية وسياق ثقافي مدعوم بالذكاء الاصطناعي.</p>
+      <p class="onboarding-desc">Read poems in their original Arabic with eloquent English translations and cultural context.</p>
+      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية بليغة وسياق ثقافي عميق.</p>
       <div class="onboarding-dots">
         <span class="onboarding-dot"></span>
         <span class="onboarding-dot active"></span>

--- a/design-review/main-app/live-app-mockup/production-app-mockup.html
+++ b/design-review/main-app/live-app-mockup/production-app-mockup.html
@@ -1071,7 +1071,7 @@ body {
 
   <!-- API Key Banner -->
   <div class="api-banner" id="apiBanner">
-    Running in Database-only mode — add a Gemini API key for AI features
+    Running in Database-only mode — add a Gemini API key for LLM features
     <button onclick="document.getElementById('apiBanner').classList.add('hidden')" style="margin-left:12px;opacity:0.6;background:none;border:none;cursor:pointer;color:inherit;font-size:inherit">✕</button>
   </div>
 
@@ -1196,7 +1196,7 @@ body {
               <span class="ctrl-label" style="color:var(--gold)">Copy</span>
             </div>
 
-            <!-- DB/AI Toggle -->
+            <!-- DB/LLM Toggle -->
             <div class="ctrl-group">
               <button class="ctrl-btn" id="btnDbToggle" aria-label="Toggle database mode">
                 <i data-lucide="library" id="dbIcon"></i>
@@ -2243,7 +2243,7 @@ function init() {
     document.getElementById('poetDropdown').classList.toggle('open');
   });
 
-  // -- DB/AI toggle --
+  // -- DB/LLM toggle --
   document.getElementById('btnDbToggle').addEventListener('click', function() {
     S.useDatabase = !S.useDatabase;
     var icon = document.getElementById('dbIcon');
@@ -2256,11 +2256,11 @@ function init() {
     if (icon) { icon.setAttribute('data-lucide', newIcon); }
     if (vsbDbIcon) { vsbDbIcon.setAttribute('data-lucide', newIcon); }
     if (overflowDbIcon) { overflowDbIcon.setAttribute('data-lucide', newIcon); }
-    if (label) label.textContent = S.useDatabase ? 'Local' : 'AI';
-    if (overflowDbLabelAr) overflowDbLabelAr.textContent = S.useDatabase ? '\u0642\u0627\u0639\u062F\u0629 \u0627\u0644\u0628\u064A\u0627\u0646\u0627\u062A' : '\u0630\u0643\u0627\u0621 \u0627\u0635\u0637\u0646\u0627\u0639\u064A';
-    if (overflowDbLabelEn) overflowDbLabelEn.textContent = S.useDatabase ? 'Local Database' : 'AI Generation';
+    if (label) label.textContent = S.useDatabase ? 'Local' : 'Web';
+    if (overflowDbLabelAr) overflowDbLabelAr.textContent = S.useDatabase ? '\u0642\u0627\u0639\u062F\u0629 \u0627\u0644\u0628\u064A\u0627\u0646\u0627\u062A' : '\u062A\u0648\u0644\u064A\u062F\u064A';
+    if (overflowDbLabelEn) overflowDbLabelEn.textContent = S.useDatabase ? 'Local Database' : 'LLM';
     lucide.createIcons();
-    addLog('Source', S.useDatabase ? 'Database' : 'AI', 'info');
+    addLog('Source', S.useDatabase ? 'Database' : 'LLM', 'info');
   });
 
   // -- Auth button --

--- a/design-review/splash/light/previews/option-1-improved-chiaroscuro.html
+++ b/design-review/splash/light/previews/option-1-improved-chiaroscuro.html
@@ -553,18 +553,18 @@
         </div>
         <div class="onboard-title">Listen & Feel</div>
         <div class="onboard-title-ar" lang="ar">استمع واشعر</div>
-        <div class="onboard-desc">AI-powered recitation brings each verse to life with natural voice.</div>
-        <div class="onboard-desc-ar" lang="ar">إلقاء صوتي بالذكاء الاصطناعي يجعل كل بيت ينبض بالحياة</div>
+        <div class="onboard-desc">Recitation brings each verse to life with natural voice.</div>
+        <div class="onboard-desc-ar" lang="ar">إلقاء صوتي يجعل كل بيت ينبض بالحياة</div>
       </div>
 
       <div class="onboard-card" data-card="2">
         <div class="onboard-icon">
           <i data-lucide="sparkles" style="width:24px;height:24px"></i>
         </div>
-        <div class="onboard-title">AI Insights</div>
-        <div class="onboard-title-ar" lang="ar">رؤى ذكية</div>
-        <div class="onboard-desc">Deep analysis and explanations powered by AI to unlock every verse.</div>
-        <div class="onboard-desc-ar" lang="ar">تحليل وشرح بالذكاء الاصطناعي لفهم كل بيت</div>
+        <div class="onboard-title">Poetic Insights</div>
+        <div class="onboard-title-ar" lang="ar">رؤى شعرية</div>
+        <div class="onboard-desc">Deep analysis and explanations to unlock every verse.</div>
+        <div class="onboard-desc-ar" lang="ar">تحليل وشرح عميق لفهم كل بيت</div>
       </div>
 
       <div class="onboard-dots">

--- a/design-review/splash/light/previews/option-3-minimal-ray-tracing.html
+++ b/design-review/splash/light/previews/option-3-minimal-ray-tracing.html
@@ -476,17 +476,17 @@
         </div>
         <div class="onboard-title">Listen & Feel</div>
         <div class="onboard-title-ar" lang="ar">استمع واشعر</div>
-        <div class="onboard-desc">AI-powered recitation brings each verse to life with natural voice.</div>
-        <div class="onboard-desc-ar" lang="ar">إلقاء صوتي بالذكاء الاصطناعي يجعل كل بيت ينبض بالحياة</div>
+        <div class="onboard-desc">Recitation brings each verse to life with natural voice.</div>
+        <div class="onboard-desc-ar" lang="ar">إلقاء صوتي يجعل كل بيت ينبض بالحياة</div>
       </div>
       <div class="onboard-card" data-card="2">
         <div class="onboard-icon">
           <i data-lucide="sparkles" style="width:24px;height:24px"></i>
         </div>
-        <div class="onboard-title">AI Insights</div>
-        <div class="onboard-title-ar" lang="ar">رؤى ذكية</div>
-        <div class="onboard-desc">Deep analysis and explanations powered by AI to unlock every verse.</div>
-        <div class="onboard-desc-ar" lang="ar">تحليل وشرح بالذكاء الاصطناعي لفهم كل بيت</div>
+        <div class="onboard-title">Poetic Insights</div>
+        <div class="onboard-title-ar" lang="ar">رؤى شعرية</div>
+        <div class="onboard-desc">Deep analysis and explanations to unlock every verse.</div>
+        <div class="onboard-desc-ar" lang="ar">تحليل وشرح عميق لفهم كل بيت</div>
       </div>
       <div class="onboard-dots">
         <div class="onboard-dot active" data-dot="0"></div>

--- a/design-review/splash/particles/previews/option-2-gold-mystical.html
+++ b/design-review/splash/particles/previews/option-2-gold-mystical.html
@@ -532,8 +532,8 @@
       <i data-lucide="languages" class="onboarding-icon"></i>
       <h2 class="onboarding-title">Bilingual Experience</h2>
       <p class="onboarding-title-ar" lang="ar" dir="rtl">تجربة ثنائية اللغة</p>
-      <p class="onboarding-desc">Read poems in their original Arabic with AI-powered English translations and cultural context.</p>
-      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية وسياق ثقافي مدعوم بالذكاء الاصطناعي.</p>
+      <p class="onboarding-desc">Read poems in their original Arabic with eloquent English translations and cultural context.</p>
+      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية بليغة وسياق ثقافي عميق.</p>
       <div class="onboarding-dots">
         <span class="onboarding-dot"></span>
         <span class="onboarding-dot active"></span>

--- a/design-review/splash/particles/previews/option-3-minimal-constellation.html
+++ b/design-review/splash/particles/previews/option-3-minimal-constellation.html
@@ -512,8 +512,8 @@
       <i data-lucide="languages" class="onboarding-icon"></i>
       <h2 class="onboarding-title">Bilingual Experience</h2>
       <p class="onboarding-title-ar" lang="ar" dir="rtl">تجربة ثنائية اللغة</p>
-      <p class="onboarding-desc">Read poems in their original Arabic with AI-powered English translations and cultural context.</p>
-      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية وسياق ثقافي مدعوم بالذكاء الاصطناعي.</p>
+      <p class="onboarding-desc">Read poems in their original Arabic with eloquent English translations and cultural context.</p>
+      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية بليغة وسياق ثقافي عميق.</p>
       <div class="onboarding-dots">
         <span class="onboarding-dot"></span>
         <span class="onboarding-dot active"></span>

--- a/design-review/splash/zen/previews/option-1-refined.html
+++ b/design-review/splash/zen/previews/option-1-refined.html
@@ -577,8 +577,8 @@
       <i data-lucide="languages" class="onboarding-icon"></i>
       <h2 class="onboarding-title">Bilingual Experience</h2>
       <p class="onboarding-title-ar" lang="ar" dir="rtl">تجربة ثنائية اللغة</p>
-      <p class="onboarding-desc">Read poems in their original Arabic with AI-powered English translations and cultural context.</p>
-      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية وسياق ثقافي مدعوم بالذكاء الاصطناعي.</p>
+      <p class="onboarding-desc">Read poems in their original Arabic with eloquent English translations and cultural context.</p>
+      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية بليغة وسياق ثقافي عميق.</p>
       <div class="onboarding-dots">
         <span class="onboarding-dot"></span>
         <span class="onboarding-dot active"></span>

--- a/design-review/splash/zen/previews/option-2-haiku.html
+++ b/design-review/splash/zen/previews/option-2-haiku.html
@@ -573,8 +573,8 @@
       <i data-lucide="languages" class="onboarding-icon"></i>
       <h2 class="onboarding-title">Bilingual Experience</h2>
       <p class="onboarding-title-ar" lang="ar" dir="rtl">تجربة ثنائية اللغة</p>
-      <p class="onboarding-desc">Read poems in their original Arabic with AI-powered English translations and cultural context.</p>
-      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية وسياق ثقافي مدعوم بالذكاء الاصطناعي.</p>
+      <p class="onboarding-desc">Read poems in their original Arabic with eloquent English translations and cultural context.</p>
+      <p class="onboarding-desc-ar" lang="ar" dir="rtl">اقرأ القصائد بالعربية الأصلية مع ترجمات إنجليزية بليغة وسياق ثقافي عميق.</p>
       <div class="onboarding-dots">
         <span class="onboarding-dot"></span>
         <span class="onboarding-dot active"></span>

--- a/e2e/user-flows.spec.js
+++ b/e2e/user-flows.spec.js
@@ -16,7 +16,8 @@ const MOCK_POEM_DARWISH = {
   poetArabic: 'محمود درويش',
   title: 'On This Earth',
   titleArabic: 'على هذه الأرض',
-  arabic: 'على هذه الأرضِ ما يستحقُّ الحياةْ\nتردُّدُ أبريلَ، رائحةُ الخبزِ في الفجرِ\nآراءُ امرأةٍ في الرجالِ',
+  arabic:
+    'على هذه الأرضِ ما يستحقُّ الحياةْ\nتردُّدُ أبريلَ، رائحةُ الخبزِ في الفجرِ\nآراءُ امرأةٍ في الرجالِ',
   english: '',
   tags: ['وطنية'],
   isFromDatabase: true,
@@ -114,8 +115,14 @@ test.describe('User Flows', () => {
     // After click, the mock route serves a different poem
     await expect(discoverButton).toBeEnabled({ timeout: 10000 });
     // Verify that either poet from our mock data is displayed
-    const darwishVisible = await page.locator('text=محمود درويش').isVisible().catch(() => false);
-    const mutanabbiVisible = await page.locator('text=المتنبي').isVisible().catch(() => false);
+    const darwishVisible = await page
+      .locator('text=محمود درويش')
+      .isVisible()
+      .catch(() => false);
+    const mutanabbiVisible = await page
+      .locator('text=المتنبي')
+      .isVisible()
+      .catch(() => false);
     expect(darwishVisible || mutanabbiVisible).toBe(true);
   });
 
@@ -124,7 +131,7 @@ test.describe('User Flows', () => {
     // Set up a delayed Gemini TTS response to observe loading state
     await page.route('**/api/ai/**', async (route) => {
       // Simulate slow TTS — respond after 500ms with an error (no real audio needed)
-      await new Promise(r => setTimeout(r, 500));
+      await new Promise((r) => setTimeout(r, 500));
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -165,9 +172,7 @@ test.describe('User Flows', () => {
     }
 
     // "Poetic Insight" heading should appear in the side panel
-    await expect(
-      page.locator('text=Poetic Insight').first()
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=Poetic Insight').first()).toBeVisible({ timeout: 10000 });
   });
 
   // #4 — Toggle dark/light theme
@@ -185,7 +190,9 @@ test.describe('User Flows', () => {
       await themeDropdown.click();
       await page.waitForTimeout(300);
       // Click the mode toggle button — target via English sub-text
-      const modeButton = page.locator('button:has-text("Light Mode"), button:has-text("Dark Mode")').first();
+      const modeButton = page
+        .locator('button:has-text("Light Mode"), button:has-text("Dark Mode")')
+        .first();
       await expect(modeButton).toBeVisible({ timeout: 3000 });
       await modeButton.click();
     } else {
@@ -193,7 +200,9 @@ test.describe('User Flows', () => {
       const settingsBtn = page.locator('button[title="Settings"]').first();
       await settingsBtn.click();
       await page.waitForTimeout(300);
-      const themeBtn = page.locator('button[title="Light mode"], button[title="Dark mode"]').first();
+      const themeBtn = page
+        .locator('button[title="Light mode"], button[title="Dark mode"]')
+        .first();
       await expect(themeBtn).toBeVisible({ timeout: 3000 });
       await themeBtn.click();
     }
@@ -294,16 +303,18 @@ test.describe('User Flows', () => {
     }).toPass({ timeout: 3000 });
   });
 
-  // #8 — Switch DB/AI mode
-  test('user sees DB/AI mode toggle', async ({ page }) => {
+  // #8 — Switch DB/LLM mode
+  test('user sees DB/LLM mode toggle', async ({ page }) => {
     await expect(page.locator('footer')).toBeVisible();
 
     // Desktop: the toggle button should be visible in the control bar
-    const toggleButton = page.locator('button[aria-label*="Database Mode"], button[aria-label*="AI Mode"]').first();
+    const toggleButton = page
+      .locator('button[aria-label*="Database Mode"], button[aria-label*="LLM Mode"]')
+      .first();
     const isVisible = await toggleButton.isVisible().catch(() => false);
 
     if (!isVisible) {
-      // Mobile: open Settings gear in VerticalSidebar, then find DB/AI toggle
+      // Mobile: open Settings gear in VerticalSidebar, then find DB/LLM toggle
       const settingsBtn = page.locator('button[title="Settings"]').first();
       const settingsVisible = await settingsBtn.isVisible().catch(() => false);
       if (settingsVisible) {
@@ -339,7 +350,7 @@ test.describe('User Flows', () => {
     // There are two design-review links: mobile (md:hidden) and desktop (hidden md:flex).
     // On desktop viewport the second link is visible; on mobile the first.
     const links = page.locator('a[href="/design-review"]');
-    const link = (viewport && viewport.width >= 768) ? links.nth(1) : links.nth(0);
+    const link = viewport && viewport.width >= 768 ? links.nth(1) : links.nth(0);
     await expect(link).toBeVisible({ timeout: 5000 });
 
     // The link href is "/design-review" but Vite serves the static page at "/design-review/"
@@ -425,7 +436,9 @@ test.describe('User Flows', () => {
 
   // #15 — Only one ThumbsDown icon on page (not duplicated in sidebar)
   test('thumbs-down icon appears exactly once on page', async ({ page }) => {
-    await expect(page.locator('button:has(svg.lucide-thumbs-down)').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('button:has(svg.lucide-thumbs-down)').first()).toBeVisible({
+      timeout: 5000,
+    });
     const count = await page.locator('svg.lucide-thumbs-down').count();
     expect(count).toBe(1);
   });
@@ -436,9 +449,11 @@ test.describe('Mobile viewport sidebar', () => {
   test.use({ viewport: { width: 402, height: 874 } });
 
   test('mobile viewport shows VerticalSidebar with Settings', async ({ page }) => {
-    await page.route('**/api/**', route => route.abort());
-    await page.route('**/api/ai/**', route => route.abort());
-    await page.addInitScript(() => { localStorage.setItem('hasSeenOnboarding', 'true'); });
+    await page.route('**/api/**', (route) => route.abort());
+    await page.route('**/api/ai/**', (route) => route.abort());
+    await page.addInitScript(() => {
+      localStorage.setItem('hasSeenOnboarding', 'true');
+    });
 
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
@@ -459,7 +474,9 @@ test.describe('Mobile viewport sidebar', () => {
   // #17 — Flag NOT in VerticalSidebar on mobile
   test('mobile VerticalSidebar does not contain ThumbsDown', async ({ page }) => {
     await setupRouteMocks(page);
-    await page.addInitScript(() => { localStorage.setItem('hasSeenOnboarding', 'true'); });
+    await page.addInitScript(() => {
+      localStorage.setItem('hasSeenOnboarding', 'true');
+    });
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     const enterBtn = page.locator('button[aria-label="Enter the app"]');

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1298,7 +1298,7 @@ const DatabaseToggle = ({ useDatabase, onToggle, disabled }) => {
         onClick={onToggle}
         disabled={disabled}
         className={`min-w-[46px] min-h-[46px] p-[11px] bg-transparent border-none transition-all duration-300 flex items-center justify-center rounded-full ${disabled ? 'opacity-50 cursor-not-allowed' : `cursor-pointer ${GOLD.goldHoverBg} hover:scale-105`}`}
-        aria-label={useDatabase ? 'Switch to AI Mode' : 'Switch to Database Mode'}
+        aria-label={useDatabase ? 'Switch to LLM Mode' : 'Switch to Database Mode'}
       >
         {useDatabase ? (
           <Library size={21} className={GOLD.goldText} />
@@ -2883,7 +2883,7 @@ const VerticalSidebar = ({
 
               <button
                 onClick={onToggleDatabase}
-                title={useDatabase ? 'Switch to AI' : 'Switch to Database'}
+                title={useDatabase ? 'Switch to LLM' : 'Switch to Database'}
                 className={`${subBtnBase} ${subBtnHover}`}
               >
                 {useDatabase ? (
@@ -2976,7 +2976,7 @@ const VerticalSidebar = ({
 
               <button
                 onClick={onToggleDatabase}
-                title={useDatabase ? 'Switch to AI' : 'Switch to Database'}
+                title={useDatabase ? 'Switch to LLM' : 'Switch to Database'}
                 className={`${subBtnBase} ${subBtnHover}`}
               >
                 {useDatabase ? (
@@ -4105,7 +4105,7 @@ export default function DiwanApp() {
         const res = await geminiTextFetch(
           'streamGenerateContent',
           insightsStreamBody,
-          'AI Insights failed',
+          'Insights failed',
           addLog
         );
 
@@ -4184,7 +4184,7 @@ export default function DiwanApp() {
         const res = await geminiTextFetch(
           'generateContent',
           insightsFallbackBody,
-          'AI Insights failed',
+          'Insights failed',
           addLog
         );
         const data = await res.json();
@@ -4252,7 +4252,7 @@ export default function DiwanApp() {
   const handleFetch = async () => {
     addLog(
       'UI Event',
-      `🐰 Discover button clicked | Category: ${selectedCategory} | Source: ${useDatabase ? 'Database' : 'Gemini AI'}`,
+      `🐰 Discover button clicked | Category: ${selectedCategory} | Source: ${useDatabase ? 'Database' : 'LLM'}`,
       'info'
     );
 
@@ -4337,7 +4337,7 @@ export default function DiwanApp() {
           throw dbError; // Re-throw to be caught by outer catch
         }
       } else {
-        // GEMINI AI MODE: Original implementation
+        // LLM MODE: Original implementation
         const prompt =
           selectedCategory === 'All'
             ? 'Find a masterpiece Arabic poem. COMPLETE text.'
@@ -4365,7 +4365,7 @@ export default function DiwanApp() {
         const res = await geminiTextFetch(
           'generateContent',
           requestBody,
-          'AI Discovery failed',
+          'Discovery failed',
           addLog
         );
 

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -1,8 +1,13 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import DiwanApp from '../app.jsx'
-import { createMockGeminiResponse, mockSuccessfulFetch, createDbPoem, createStreamingMock } from './utils'
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DiwanApp from '../app.jsx';
+import {
+  createMockGeminiResponse,
+  mockSuccessfulFetch,
+  createDbPoem,
+  createStreamingMock,
+} from './utils';
 
 // The app auto-loads a poem from the DB on mount (handleFetch in useEffect).
 // This helper pre-mocks that initial fetch so the default poem stays current.
@@ -15,7 +20,7 @@ const defaultDbPoem = {
   arabic: 'حُبُّكِ يا عَمِيقَةَ العَيْنَيْنِ\nتَطَرُّفٌ .. تَصَوُّفٌ .. عِبَادَة',
   english: 'Your love, O woman of deep eyes,\nIs radicalism… is Sufism… is worship.',
   tags: ['Modern', 'Romantic', 'Ghazal'],
-}
+};
 
 // Default mock response for any fetch calls during mount
 const defaultFetchResponse = {
@@ -25,70 +30,74 @@ const defaultFetchResponse = {
   text: async () => '',
   headers: new Map(),
   statusText: 'OK',
-  body: { getReader: () => ({ read: vi.fn().mockResolvedValue({ done: true, value: undefined }) }) },
-}
+  body: {
+    getReader: () => ({ read: vi.fn().mockResolvedValue({ done: true, value: undefined }) }),
+  },
+};
 
 function mockAutoLoadFetch() {
   // Use a persistent implementation that returns the default poem for any URL,
   // handling all mount-time fetches (auto-load, daily poem, health ping, auto-explain).
   // Tests that need specific fetch behavior should call mockResolvedValueOnce AFTER awaiting mount.
-  global.fetch.mockImplementation(() => Promise.resolve({ ...defaultFetchResponse }))
+  global.fetch.mockImplementation(() => Promise.resolve({ ...defaultFetchResponse }));
 }
 
 describe('DiwanApp', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   // ── Feature 1: Poem loads with correct structure ──────────────────────
 
   describe('Poem Structure', () => {
     it('renders the default poem with Arabic text longer than 10 characters', () => {
-      render(<DiwanApp />)
+      render(<DiwanApp />);
       // The default poem's Arabic text is rendered across verse lines with dir="rtl"
-      const rtlElements = document.querySelectorAll('p[dir="rtl"]')
-      expect(rtlElements.length).toBeGreaterThan(0)
+      const rtlElements = document.querySelectorAll('p[dir="rtl"]');
+      expect(rtlElements.length).toBeGreaterThan(0);
 
       // Gather all Arabic verse text
-      const arabicText = Array.from(rtlElements).map(el => el.textContent).join('')
-      expect(arabicText.length).toBeGreaterThan(10)
-    })
+      const arabicText = Array.from(rtlElements)
+        .map((el) => el.textContent)
+        .join('');
+      expect(arabicText.length).toBeGreaterThan(10);
+    });
 
     it('displays the poet name in both Arabic and English', () => {
-      render(<DiwanApp />)
-      expect(document.body.textContent).toContain('نزار قباني')
-      expect(document.body.textContent).toContain('Nizar Qabbani')
-    })
+      render(<DiwanApp />);
+      expect(document.body.textContent).toContain('نزار قباني');
+      expect(document.body.textContent).toContain('Nizar Qabbani');
+    });
 
     it('renders tags for the default poem', () => {
-      render(<DiwanApp />)
-      expect(screen.getByText('Modern')).toBeInTheDocument()
-      expect(screen.getByText('Romantic')).toBeInTheDocument()
-      expect(screen.getByText('Ghazal')).toBeInTheDocument()
-    })
+      render(<DiwanApp />);
+      expect(screen.getByText('Modern')).toBeInTheDocument();
+      expect(screen.getByText('Romantic')).toBeInTheDocument();
+      expect(screen.getByText('Ghazal')).toBeInTheDocument();
+    });
 
     it('renders poem verses with dir="rtl" attribute', () => {
-      render(<DiwanApp />)
-      const rtlVerses = document.querySelectorAll('p[dir="rtl"]')
-      expect(rtlVerses.length).toBeGreaterThan(0)
+      render(<DiwanApp />);
+      const rtlVerses = document.querySelectorAll('p[dir="rtl"]');
+      expect(rtlVerses.length).toBeGreaterThan(0);
       // Each verse line should have RTL direction
-      rtlVerses.forEach(el => {
-        expect(el.getAttribute('dir')).toBe('rtl')
-      })
-    })
-  })
+      rtlVerses.forEach((el) => {
+        expect(el.getAttribute('dir')).toBe('rtl');
+      });
+    });
+  });
 
   // ── Feature 2: Discover poems ─────────────────────────────────────────
 
   describe('Discover Poems', () => {
     it('loads a new poem from the database when Discover is clicked', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       // Wait for mount-time fetches to settle
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
       const newPoem = {
         id: 42,
@@ -99,55 +108,63 @@ describe('DiwanApp', () => {
         arabic: 'سَجِّلْ أَنَا عَرَبِيّ\nوَرَقَمُ بطاقَتي خَمْسُونَ أَلْف',
         english: 'Record! I am an Arab\nAnd my identity card number is fifty thousand',
         tags: ['Modern', 'Political', 'Free Verse'],
-      }
+      };
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: async () => newPoem,
-      })
+      });
 
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
 
-      await waitFor(() => {
-        expect(screen.getByText('محمود درويش')).toBeInTheDocument()
-      }, { timeout: 3000 })
-    })
+      await waitFor(
+        () => {
+          expect(screen.getByText('محمود درويش')).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+    });
 
     it('disables the Discover button while fetching', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       // Wait for mount-time fetches to settle
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
       // Create a never-resolving promise to keep the button disabled
-      let resolveFetch
-      global.fetch.mockImplementationOnce(() => new Promise(r => { resolveFetch = r }))
+      let resolveFetch;
+      global.fetch.mockImplementationOnce(
+        () =>
+          new Promise((r) => {
+            resolveFetch = r;
+          })
+      );
 
-      const discoverBtn = screen.getByLabelText('Discover new poem')
-      await userEvent.click(discoverBtn)
+      const discoverBtn = screen.getByLabelText('Discover new poem');
+      await userEvent.click(discoverBtn);
 
       // Button should be disabled during fetch — use waitFor because
       // setIsFetching(true) is a React state update that may not have
       // flushed to the DOM by the time userEvent.click resolves
       await waitFor(() => {
-        expect(discoverBtn).toBeDisabled()
-      })
+        expect(discoverBtn).toBeDisabled();
+      });
 
       // Resolve to clean up
-      resolveFetch({ ok: true, json: async () => createDbPoem(99) })
-    })
+      resolveFetch({ ok: true, json: async () => createDbPoem(99) });
+    });
 
     it('changes content from the initial poem after Discover', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       // Wait for mount-time fetches to settle
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
       const newPoem = {
         id: 77,
@@ -158,241 +175,251 @@ describe('DiwanApp', () => {
         arabic: 'عَلَى قَدْرِ أَهْلِ الْعَزْمِ تَأْتِي الْعَزَائِمُ',
         english: 'Ambitions come according to the ambitions of their people',
         tags: ['Classical', 'Epic', 'Ode'],
-      }
+      };
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: async () => newPoem,
-      })
+      });
 
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
 
-      await waitFor(() => {
-        expect(screen.getByText('المتنبي')).toBeInTheDocument()
-      }, { timeout: 3000 })
-    })
-  })
+      await waitFor(
+        () => {
+          expect(screen.getByText('المتنبي')).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+    });
+  });
 
   // ── Feature 3: Audio playback ─────────────────────────────────────────
 
   describe('Audio Playback', () => {
     it('calls fetch when Play is clicked', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
-      const playBtn = screen.getByLabelText('Play recitation')
-      await userEvent.click(playBtn)
+      const playBtn = screen.getByLabelText('Play recitation');
+      await userEvent.click(playBtn);
 
       // The app calls fetch to generate audio via Gemini TTS
       await waitFor(() => {
         // At least one additional fetch call (beyond the auto-load)
-        expect(global.fetch.mock.calls.length).toBeGreaterThan(1)
-      })
-    })
+        expect(global.fetch.mock.calls.length).toBeGreaterThan(1);
+      });
+    });
 
     it('shows loading state when generating audio', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
       // Replace fetch with a version that hangs for audio (TTS) calls
       // but resolves normally for everything else (auto-explain, streaming, etc.)
-      const originalMock = global.fetch
+      const originalMock = global.fetch;
       global.fetch = vi.fn((url) => {
         if (typeof url === 'string' && url.includes('/api/ai/gemini')) {
           // Gemini TTS / audio call — hang forever to keep loading state
-          return new Promise(() => {})
+          return new Promise(() => {});
         }
         // All other calls resolve immediately
-        return Promise.resolve({ ok: true, body: null, json: async () => ({}) })
-      })
+        return Promise.resolve({ ok: true, body: null, json: async () => ({}) });
+      });
 
-      const playBtn = screen.getByLabelText('Play recitation')
-      await userEvent.click(playBtn)
+      const playBtn = screen.getByLabelText('Play recitation');
+      await userEvent.click(playBtn);
 
       // The button should be disabled while generating
       await waitFor(() => {
-        expect(playBtn).toBeDisabled()
-      })
-    })
-  })
+        expect(playBtn).toBeDisabled();
+      });
+    });
+  });
 
-  // ── Feature 4: AI Insights ────────────────────────────────────────────
+  // ── Feature 4: Insights ──────────────────────────────────────────────
 
-  describe('AI Insights', () => {
+  describe('Insights', () => {
     const mockInsightText =
-      'POEM:\nTranslation line\nTHE DEPTH: Deep meaning here.\nTHE AUTHOR: Celebrated poet info.'
+      'POEM:\nTranslation line\nTHE DEPTH: Deep meaning here.\nTHE AUTHOR: Celebrated poet info.';
 
     it('shows parsed insight sections after clicking Explain on a DB poem', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       // Wait for mount-time fetches to settle
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
       // Load a DB poem first
-      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(101) })
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
-      await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), { timeout: 3000 })
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(101) });
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
+      await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), {
+        timeout: 3000,
+      });
 
       // Mock Gemini streaming response
-      global.fetch.mockResolvedValueOnce(createStreamingMock(mockInsightText))
+      global.fetch.mockResolvedValueOnce(createStreamingMock(mockInsightText));
 
-      await userEvent.click(screen.getByLabelText('Explain poem meaning'))
+      await userEvent.click(screen.getByLabelText('Explain poem meaning'));
 
-      await waitFor(() => {
-        expect(document.body.textContent).toContain('Deep meaning here.')
-      }, { timeout: 3000 })
-    })
+      await waitFor(
+        () => {
+          expect(document.body.textContent).toContain('Deep meaning here.');
+        },
+        { timeout: 3000 }
+      );
+    });
 
     it('Explain button is enabled for a DB poem', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       // Wait for mount-time fetches to settle
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
-      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(100) })
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
-      await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), { timeout: 3000 })
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(100) });
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
+      await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), {
+        timeout: 3000,
+      });
 
-      expect(screen.getByLabelText('Explain poem meaning')).not.toBeDisabled()
-    })
-  })
+      expect(screen.getByLabelText('Explain poem meaning')).not.toBeDisabled();
+    });
+  });
 
   // ── Feature 5: Copy ───────────────────────────────────────────────────
 
   describe('Copy Functionality', () => {
     it('copies poem text to clipboard with Arabic text, poet, and separator', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       // Wait for auto-load to settle
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
-      await userEvent.click(screen.getByLabelText('Copy poem to clipboard'))
+      await userEvent.click(screen.getByLabelText('Copy poem to clipboard'));
 
       await waitFor(() => {
-        expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1)
-      })
+        expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(1);
+      });
 
-      const copiedText = navigator.clipboard.writeText.mock.calls[0][0]
+      const copiedText = navigator.clipboard.writeText.mock.calls[0][0];
       // Should contain Arabic poem text
-      expect(copiedText).toContain('حُبُّكِ')
+      expect(copiedText).toContain('حُبُّكِ');
       // Should contain poet name
-      expect(copiedText).toContain('نزار قباني')
+      expect(copiedText).toContain('نزار قباني');
       // Should contain the separator
-      expect(copiedText).toContain('---')
-    })
+      expect(copiedText).toContain('---');
+    });
 
     it('shows success indicator after copying', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
-      await userEvent.click(screen.getByLabelText('Copy poem to clipboard'))
+      await userEvent.click(screen.getByLabelText('Copy poem to clipboard'));
 
       // The Check icon replaces the Copy icon on success — look for it in the button
       await waitFor(() => {
-        const copyBtn = screen.getByLabelText('Copy poem to clipboard')
-        const svg = copyBtn.querySelector('svg')
-        expect(svg).toBeTruthy()
-      })
-    })
+        const copyBtn = screen.getByLabelText('Copy poem to clipboard');
+        const svg = copyBtn.querySelector('svg');
+        expect(svg).toBeTruthy();
+      });
+    });
 
     it('does not crash when clipboard write fails', async () => {
-      mockAutoLoadFetch()
-      navigator.clipboard.writeText.mockRejectedValueOnce(new Error('Clipboard denied'))
+      mockAutoLoadFetch();
+      navigator.clipboard.writeText.mockRejectedValueOnce(new Error('Clipboard denied'));
 
-      render(<DiwanApp />)
+      render(<DiwanApp />);
 
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
-      await userEvent.click(screen.getByLabelText('Copy poem to clipboard'))
+      await userEvent.click(screen.getByLabelText('Copy poem to clipboard'));
 
       // App should still be rendered (no crash)
-      expect(screen.getAllByText('poetry').length).toBeGreaterThanOrEqual(1)
-    })
-  })
+      expect(screen.getAllByText('poetry').length).toBeGreaterThanOrEqual(1);
+    });
+  });
 
   // ── Feature 6: Theme toggle ───────────────────────────────────────────
 
   describe('Theme Toggle', () => {
     it('starts in dark mode with bg-[#0c0c0e]', () => {
-      render(<DiwanApp />)
-      const container = document.querySelector('[class*="bg-[#0c0c0e]"]')
-      expect(container).toBeTruthy()
-    })
+      render(<DiwanApp />);
+      const container = document.querySelector('[class*="bg-[#0c0c0e]"]');
+      expect(container).toBeTruthy();
+    });
 
     it('switches to light mode bg-[#FDFCF8] after toggling theme', async () => {
-      render(<DiwanApp />)
+      render(<DiwanApp />);
 
       // Open theme dropdown
-      const themeBtn = screen.getByLabelText('Theme options')
-      await userEvent.click(themeBtn)
+      const themeBtn = screen.getByLabelText('Theme options');
+      await userEvent.click(themeBtn);
 
       // Click the dark/light mode toggle inside the dropdown
       // The dropdown shows "Light Mode" text in dark mode
       await waitFor(() => {
-        expect(document.body.textContent).toContain('Light Mode')
-      })
+        expect(document.body.textContent).toContain('Light Mode');
+      });
 
-      const lightModeBtn = screen.getByText('Light Mode')
-      await userEvent.click(lightModeBtn)
+      const lightModeBtn = screen.getByText('Light Mode');
+      await userEvent.click(lightModeBtn);
 
       await waitFor(() => {
-        const lightContainer = document.querySelector('[class*="bg-[#FDFCF8]"]')
-        expect(lightContainer).toBeTruthy()
-      })
-    })
-  })
+        const lightContainer = document.querySelector('[class*="bg-[#FDFCF8]"]');
+        expect(lightContainer).toBeTruthy();
+      });
+    });
+  });
 
   // ── Feature 7: Poet filtering ─────────────────────────────────────────
 
   describe('Poet Filtering', () => {
     it('opens category dropdown and shows poet list', async () => {
-      render(<DiwanApp />)
+      render(<DiwanApp />);
 
-      const poetsBtn = screen.getByLabelText('Select poet category')
-      await userEvent.click(poetsBtn)
+      const poetsBtn = screen.getByLabelText('Select poet category');
+      await userEvent.click(poetsBtn);
 
       await waitFor(() => {
-        expect(document.body.textContent).toContain('كل الشعراء')
-      })
-    })
+        expect(document.body.textContent).toContain('كل الشعراء');
+      });
+    });
 
     it('sends poet filter parameter when a category is selected and Discover is clicked', async () => {
-      render(<DiwanApp />)
+      render(<DiwanApp />);
 
       // Open the category dropdown and select a poet
-      const poetsBtn = screen.getByLabelText('Select poet category')
-      await userEvent.click(poetsBtn)
+      const poetsBtn = screen.getByLabelText('Select poet category');
+      await userEvent.click(poetsBtn);
 
       await waitFor(() => {
-        expect(document.body.textContent).toContain('محمود درويش')
-      })
+        expect(document.body.textContent).toContain('محمود درويش');
+      });
 
       // Click "Mahmoud Darwish" category
-      const darwishOption = screen.getByText('محمود درويش')
-      await userEvent.click(darwishOption)
+      const darwishOption = screen.getByText('محمود درويش');
+      await userEvent.click(darwishOption);
 
       // Mock the DB fetch response with the selected poet
       const filteredPoem = {
@@ -404,91 +431,97 @@ describe('DiwanApp', () => {
         arabic: 'هذا هو اسمك قالت امرأة وغابت في الممر اللولبي',
         english: 'This is your name, a woman said, then disappeared into the spiral corridor',
         tags: ['Modern', 'Epic', 'Free Verse'],
-      }
+      };
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: async () => filteredPoem,
-      })
+      });
 
       // The useEffect fires handleFetch when a category is selected and filtered.length === 0
       // Wait for the fetch call
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalled()
-      }, { timeout: 3000 })
-    })
-  })
+      await waitFor(
+        () => {
+          expect(global.fetch).toHaveBeenCalled();
+        },
+        { timeout: 3000 }
+      );
+    });
+  });
 
   // ── Feature 8: Arabic RTL & fonts ─────────────────────────────────────
 
   describe('Arabic RTL & Fonts', () => {
     it('renders Arabic verses with dir="rtl"', () => {
-      render(<DiwanApp />)
-      const rtlElements = document.querySelectorAll('p[dir="rtl"]')
-      expect(rtlElements.length).toBeGreaterThan(0)
-    })
+      render(<DiwanApp />);
+      const rtlElements = document.querySelectorAll('p[dir="rtl"]');
+      expect(rtlElements.length).toBeGreaterThan(0);
+    });
 
     it('applies font-amiri class by default', () => {
-      render(<DiwanApp />)
+      render(<DiwanApp />);
       // The currentFontClass is applied to the verse container
-      const amiriElements = document.querySelectorAll('.font-amiri')
-      expect(amiriElements.length).toBeGreaterThan(0)
-    })
+      const amiriElements = document.querySelectorAll('.font-amiri');
+      expect(amiriElements.length).toBeGreaterThan(0);
+    });
 
     it('changes font class when cycling via Theme dropdown', async () => {
-      render(<DiwanApp />)
+      render(<DiwanApp />);
 
       // Verify initial font is Amiri
-      expect(document.querySelectorAll('.font-amiri').length).toBeGreaterThan(0)
+      expect(document.querySelectorAll('.font-amiri').length).toBeGreaterThan(0);
 
       // Open theme dropdown
-      const themeBtn = screen.getByLabelText('Theme options')
-      await userEvent.click(themeBtn)
+      const themeBtn = screen.getByLabelText('Theme options');
+      await userEvent.click(themeBtn);
 
       // The font cycle button shows "Cycle Font: Amiri"
       await waitFor(() => {
-        expect(document.body.textContent).toContain('Cycle Font: Amiri')
-      })
+        expect(document.body.textContent).toContain('Cycle Font: Amiri');
+      });
 
       // Click the font cycle button (Arabic text: تبديل الخط)
-      const fontCycleBtn = screen.getByText('تبديل الخط')
-      await userEvent.click(fontCycleBtn)
+      const fontCycleBtn = screen.getByText('تبديل الخط');
+      await userEvent.click(fontCycleBtn);
 
       // Font should change from Amiri to the next one (Alexandria)
       await waitFor(() => {
-        const alexandriaElements = document.querySelectorAll('.font-alexandria')
-        expect(alexandriaElements.length).toBeGreaterThan(0)
-      })
-    })
-  })
+        const alexandriaElements = document.querySelectorAll('.font-alexandria');
+        expect(alexandriaElements.length).toBeGreaterThan(0);
+      });
+    });
+  });
 
-  // ── AI Mode Tests (existing coverage preserved) ───────────────────────
+  // ── LLM Mode Tests (existing coverage preserved) ─────────────────────
 
-  describe('AI Mode', () => {
-    it('logs error when AI Discover fails with a non-retryable error', async () => {
-      render(<DiwanApp />)
+  describe('LLM Mode', () => {
+    it('logs error when Discover fails with a non-retryable error', async () => {
+      render(<DiwanApp />);
 
-      // Switch to AI mode
-      await userEvent.click(screen.getByLabelText('Switch to AI Mode'))
+      // Switch to generative mode
+      await userEvent.click(screen.getByLabelText('Switch to LLM Mode'));
 
       // 429 quota errors are shown immediately
       global.fetch.mockResolvedValueOnce({
         ok: false,
         status: 429,
-        json: async () => ({ error: { message: 'Quota exceeded for this project' } })
-      })
+        json: async () => ({ error: { message: 'Quota exceeded for this project' } }),
+      });
 
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
 
-      await waitFor(() => {
-        expect(document.body.textContent).toContain('Quota exceeded for this project')
-      }, { timeout: 3000 })
-    })
+      await waitFor(
+        () => {
+          expect(document.body.textContent).toContain('Quota exceeded for this project');
+        },
+        { timeout: 3000 }
+      );
+    });
 
-    it('uses fallback model when primary AI model returns not-found', async () => {
-      render(<DiwanApp />)
+    it('uses fallback model when primary model returns not-found', async () => {
+      render(<DiwanApp />);
 
-      await userEvent.click(screen.getByLabelText('Switch to AI Mode'))
+      await userEvent.click(screen.getByLabelText('Switch to LLM Mode'));
 
       const aiPoem = {
         poet: 'Al-Mutanabbi',
@@ -497,33 +530,38 @@ describe('DiwanApp', () => {
         titleArabic: 'قصيدة الشجاعة',
         arabic: 'عَلَى قَدْرِ أَهْلِ الْعَزْمِ تَأْتِي الْعَزَائِمُ',
         english: 'To the measure of the resolute come resolutions',
-        tags: ['Classical', 'Epic', 'Ode']
-      }
+        tags: ['Classical', 'Epic', 'Ode'],
+      };
 
       global.fetch
         .mockResolvedValueOnce({
           ok: false,
           status: 404,
-          json: async () => ({ error: { message: 'gemini-2.0-flash is not found for API version v1beta' } })
+          json: async () => ({
+            error: { message: 'gemini-2.0-flash is not found for API version v1beta' },
+          }),
         })
         .mockResolvedValueOnce({
           ok: true,
           json: async () => ({
-            candidates: [{ content: { parts: [{ text: JSON.stringify(aiPoem) }] } }]
-          })
-        })
+            candidates: [{ content: { parts: [{ text: JSON.stringify(aiPoem) }] } }],
+          }),
+        });
 
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
 
-      await waitFor(() => {
-        expect(screen.getByText('Al-Mutanabbi')).toBeInTheDocument()
-      }, { timeout: 3000 })
-    })
+      await waitFor(
+        () => {
+          expect(screen.getByText('Al-Mutanabbi')).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+    });
 
-    it('discovers a new poem in AI mode when Gemini responds successfully', async () => {
-      render(<DiwanApp />)
+    it('discovers a new poem in generative mode when Gemini responds successfully', async () => {
+      render(<DiwanApp />);
 
-      await userEvent.click(screen.getByLabelText('Switch to AI Mode'))
+      await userEvent.click(screen.getByLabelText('Switch to LLM Mode'));
 
       const aiPoem = {
         poet: 'Al-Mutanabbi',
@@ -532,56 +570,64 @@ describe('DiwanApp', () => {
         titleArabic: 'قصيدة الشجاعة',
         arabic: 'عَلَى قَدْرِ أَهْلِ الْعَزْمِ تَأْتِي الْعَزَائِمُ',
         english: 'To the measure of the resolute come resolutions',
-        tags: ['Classical', 'Epic', 'Ode']
-      }
+        tags: ['Classical', 'Epic', 'Ode'],
+      };
 
       global.fetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          candidates: [{ content: { parts: [{ text: JSON.stringify(aiPoem) }] } }]
-        })
-      })
+          candidates: [{ content: { parts: [{ text: JSON.stringify(aiPoem) }] } }],
+        }),
+      });
 
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
 
-      await waitFor(() => {
-        expect(screen.getByText('Al-Mutanabbi')).toBeInTheDocument()
-      }, { timeout: 3000 })
-    })
+      await waitFor(
+        () => {
+          expect(screen.getByText('Al-Mutanabbi')).toBeInTheDocument();
+        },
+        { timeout: 3000 }
+      );
+    });
 
-    it('logs error when AI Insights fails with an HTTP error', async () => {
-      mockAutoLoadFetch()
-      render(<DiwanApp />)
+    it('logs error when Insights fails with an HTTP error', async () => {
+      mockAutoLoadFetch();
+      render(<DiwanApp />);
 
       // Wait for mount-time fetches to settle
       await waitFor(() => {
-        expect(document.body.textContent).toContain('نزار قباني')
-      })
+        expect(document.body.textContent).toContain('نزار قباني');
+      });
 
-      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(102) })
-      await userEvent.click(screen.getByLabelText('Discover new poem'))
-      await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), { timeout: 3000 })
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => createDbPoem(102) });
+      await userEvent.click(screen.getByLabelText('Discover new poem'));
+      await waitFor(() => expect(screen.getByText('Mahmoud Darwish')).toBeInTheDocument(), {
+        timeout: 3000,
+      });
 
       global.fetch.mockResolvedValueOnce({
         ok: false,
         status: 400,
-        json: async () => ({ error: { message: 'API key not valid' } })
-      })
+        json: async () => ({ error: { message: 'API key not valid' } }),
+      });
 
-      await userEvent.click(screen.getByLabelText('Explain poem meaning'))
+      await userEvent.click(screen.getByLabelText('Explain poem meaning'));
 
-      await waitFor(() => {
-        expect(document.body.textContent).toContain('API key not valid')
-      }, { timeout: 3000 })
-    })
-  })
+      await waitFor(
+        () => {
+          expect(document.body.textContent).toContain('API key not valid');
+        },
+        { timeout: 3000 }
+      );
+    });
+  });
 
   // ── Debug Panel ───────────────────────────────────────────────────────
 
   describe('Debug Panel', () => {
     it('renders System Logs text when debug feature flag is enabled', () => {
-      render(<DiwanApp />)
-      expect(document.body.textContent).toContain('System Logs')
-    })
-  })
-})
+      render(<DiwanApp />);
+      expect(document.body.textContent).toContain('System Logs');
+    });
+  });
+});

--- a/src/test/database-components.test.jsx
+++ b/src/test/database-components.test.jsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { Library, Sparkles, X, RefreshCw } from 'lucide-react'
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Library, Sparkles, X, RefreshCw } from 'lucide-react';
 
 // Mock DatabaseToggle component
 const DatabaseToggle = ({ useDatabase, onToggle }) => {
@@ -10,17 +10,24 @@ const DatabaseToggle = ({ useDatabase, onToggle }) => {
       <button
         onClick={onToggle}
         className="min-w-[46px] min-h-[46px] p-[11px] bg-transparent border-none cursor-pointer transition-all duration-300 flex items-center justify-center rounded-full hover:bg-[#C5A059]/12 hover:scale-105"
-        aria-label={useDatabase ? "Switch to AI Mode" : "Switch to Database Mode"}
+        aria-label={useDatabase ? 'Switch to LLM Mode' : 'Switch to Database Mode'}
         data-testid="database-toggle-button"
       >
-        {useDatabase ? <Library size={21} className="text-[#C5A059]" data-testid="library-icon" /> : <Sparkles size={21} className="text-[#C5A059]" data-testid="sparkles-icon" />}
+        {useDatabase ? (
+          <Library size={21} className="text-[#C5A059]" data-testid="library-icon" />
+        ) : (
+          <Sparkles size={21} className="text-[#C5A059]" data-testid="sparkles-icon" />
+        )}
       </button>
-      <span className="font-brand-en text-[8.5px] font-bold tracking-[0.08em] uppercase opacity-60 whitespace-nowrap text-[#C5A059]" data-testid="mode-label">
+      <span
+        className="font-brand-en text-[8.5px] font-bold tracking-[0.08em] uppercase opacity-60 whitespace-nowrap text-[#C5A059]"
+        data-testid="mode-label"
+      >
         {useDatabase ? 'Local' : 'Web'}
       </span>
     </div>
-  )
-}
+  );
+};
 
 // Mock ErrorBanner component
 const DESIGN = {
@@ -28,22 +35,31 @@ const DESIGN = {
   glass: 'backdrop-blur-2xl',
   radius: 'rounded-2xl',
   buttonHover: 'hover:scale-105 hover:shadow-lg transition-all duration-300',
-  btnPrimary: 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-indigo-500/40'
-}
+  btnPrimary: 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-indigo-500/40',
+};
 
 const ErrorBanner = ({ error, onDismiss, onRetry, theme }) => {
-  if (!error) return null
+  if (!error) return null;
 
   return (
-    <div className={`fixed top-20 left-1/2 -translate-x-1/2 z-50 max-w-lg w-[calc(100%-2rem)] ${DESIGN.anim}`} data-testid="error-banner">
-      <div className={`${DESIGN.glass} ${theme.glass} ${theme.border} border ${DESIGN.radius} p-4 shadow-2xl`}>
+    <div
+      className={`fixed top-20 left-1/2 -translate-x-1/2 z-50 max-w-lg w-[calc(100%-2rem)] ${DESIGN.anim}`}
+      data-testid="error-banner"
+    >
+      <div
+        className={`${DESIGN.glass} ${theme.glass} ${theme.border} border ${DESIGN.radius} p-4 shadow-2xl`}
+      >
         <div className="flex items-start gap-3">
           <div className="flex-shrink-0 mt-0.5">
             <X size={20} className="text-red-500" data-testid="error-icon" />
           </div>
           <div className="flex-1 min-w-0">
-            <p className={`${theme.text} text-sm font-medium mb-2`} data-testid="error-title">Database Connection Error</p>
-            <p className={`${theme.text} text-xs opacity-70 mb-3`} data-testid="error-message">{error}</p>
+            <p className={`${theme.text} text-sm font-medium mb-2`} data-testid="error-title">
+              Database Connection Error
+            </p>
+            <p className={`${theme.text} text-xs opacity-70 mb-3`} data-testid="error-message">
+              {error}
+            </p>
             <div className="flex gap-2">
               {onRetry && (
                 <button
@@ -67,100 +83,90 @@ const ErrorBanner = ({ error, onDismiss, onRetry, theme }) => {
         </div>
       </div>
     </div>
-  )
-}
+  );
+};
 
 describe('Database Integration Components', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   describe('DatabaseToggle', () => {
     it('renders with database mode enabled', () => {
-      const { getByTestId } = render(
-        <DatabaseToggle useDatabase={true} onToggle={vi.fn()} />
-      )
+      const { getByTestId } = render(<DatabaseToggle useDatabase={true} onToggle={vi.fn()} />);
 
-      expect(getByTestId('database-toggle')).toBeInTheDocument()
-      expect(getByTestId('library-icon')).toBeInTheDocument()
-      expect(getByTestId('mode-label')).toHaveTextContent('Local')
-    })
+      expect(getByTestId('database-toggle')).toBeInTheDocument();
+      expect(getByTestId('library-icon')).toBeInTheDocument();
+      expect(getByTestId('mode-label')).toHaveTextContent('Local');
+    });
 
     it('renders with AI mode enabled', () => {
-      const { getByTestId } = render(
-        <DatabaseToggle useDatabase={false} onToggle={vi.fn()} />
-      )
+      const { getByTestId } = render(<DatabaseToggle useDatabase={false} onToggle={vi.fn()} />);
 
-      expect(getByTestId('database-toggle')).toBeInTheDocument()
-      expect(getByTestId('sparkles-icon')).toBeInTheDocument()
-      expect(getByTestId('mode-label')).toHaveTextContent('Web')
-    })
+      expect(getByTestId('database-toggle')).toBeInTheDocument();
+      expect(getByTestId('sparkles-icon')).toBeInTheDocument();
+      expect(getByTestId('mode-label')).toHaveTextContent('Web');
+    });
 
     it('shows correct icon for database mode (Library)', () => {
       const { getByTestId, queryByTestId } = render(
         <DatabaseToggle useDatabase={true} onToggle={vi.fn()} />
-      )
+      );
 
-      expect(getByTestId('library-icon')).toBeInTheDocument()
-      expect(queryByTestId('sparkles-icon')).not.toBeInTheDocument()
-    })
+      expect(getByTestId('library-icon')).toBeInTheDocument();
+      expect(queryByTestId('sparkles-icon')).not.toBeInTheDocument();
+    });
 
     it('shows correct icon for AI mode (Sparkles)', () => {
       const { getByTestId, queryByTestId } = render(
         <DatabaseToggle useDatabase={false} onToggle={vi.fn()} />
-      )
+      );
 
-      expect(getByTestId('sparkles-icon')).toBeInTheDocument()
-      expect(queryByTestId('library-icon')).not.toBeInTheDocument()
-    })
+      expect(getByTestId('sparkles-icon')).toBeInTheDocument();
+      expect(queryByTestId('library-icon')).not.toBeInTheDocument();
+    });
 
     it('calls onToggle when button is clicked', async () => {
-      const onToggle = vi.fn()
-      const { getByTestId } = render(
-        <DatabaseToggle useDatabase={false} onToggle={onToggle} />
-      )
+      const onToggle = vi.fn();
+      const { getByTestId } = render(<DatabaseToggle useDatabase={false} onToggle={onToggle} />);
 
-      await userEvent.click(getByTestId('database-toggle-button'))
+      await userEvent.click(getByTestId('database-toggle-button'));
 
-      expect(onToggle).toHaveBeenCalledTimes(1)
-    })
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
 
     it('has appropriate aria-label for database mode', () => {
-      const { getByTestId } = render(
-        <DatabaseToggle useDatabase={true} onToggle={vi.fn()} />
-      )
+      const { getByTestId } = render(<DatabaseToggle useDatabase={true} onToggle={vi.fn()} />);
 
       expect(getByTestId('database-toggle-button')).toHaveAttribute(
         'aria-label',
-        'Switch to AI Mode'
-      )
-    })
+        'Switch to LLM Mode'
+      );
+    });
 
-    it('has appropriate aria-label for AI mode', () => {
-      const { getByTestId } = render(
-        <DatabaseToggle useDatabase={false} onToggle={vi.fn()} />
-      )
+    it('has appropriate aria-label for LLM mode', () => {
+      const { getByTestId } = render(<DatabaseToggle useDatabase={false} onToggle={vi.fn()} />);
 
       expect(getByTestId('database-toggle-button')).toHaveAttribute(
         'aria-label',
         'Switch to Database Mode'
-      )
-    })
+      );
+    });
 
     it('toggles between modes correctly', () => {
       const { getByTestId, rerender } = render(
         <DatabaseToggle useDatabase={false} onToggle={vi.fn()} />
-      )
+      );
 
-      expect(getByTestId('mode-label')).toHaveTextContent('Web')
-      expect(getByTestId('sparkles-icon')).toBeInTheDocument()
+      expect(getByTestId('mode-label')).toHaveTextContent('Web');
+      expect(getByTestId('sparkles-icon')).toBeInTheDocument();
 
-      rerender(<DatabaseToggle useDatabase={true} onToggle={vi.fn()} />)
+      rerender(<DatabaseToggle useDatabase={true} onToggle={vi.fn()} />);
 
-      expect(getByTestId('mode-label')).toHaveTextContent('Local')
-      expect(getByTestId('library-icon')).toBeInTheDocument()
-    })
-  })
+      expect(getByTestId('mode-label')).toHaveTextContent('Local');
+      expect(getByTestId('library-icon')).toBeInTheDocument();
+    });
+  });
 
   describe('ErrorBanner', () => {
     const mockTheme = {
@@ -168,24 +174,24 @@ describe('Database Integration Components', () => {
       border: 'border-stone-800',
       text: 'text-stone-200',
       pill: 'bg-stone-900/40 border-stone-700/50',
-      btnPrimary: 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-indigo-500/40'
-    }
+      btnPrimary: 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white shadow-indigo-500/40',
+    };
 
     it('does not render when error is null', () => {
       const { queryByTestId } = render(
         <ErrorBanner error={null} onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
-      )
+      );
 
-      expect(queryByTestId('error-banner')).not.toBeInTheDocument()
-    })
+      expect(queryByTestId('error-banner')).not.toBeInTheDocument();
+    });
 
     it('does not render when error is undefined', () => {
       const { queryByTestId } = render(
         <ErrorBanner error={undefined} onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
-      )
+      );
 
-      expect(queryByTestId('error-banner')).not.toBeInTheDocument()
-    })
+      expect(queryByTestId('error-banner')).not.toBeInTheDocument();
+    });
 
     it('renders when error is provided', () => {
       const { getByTestId } = render(
@@ -195,10 +201,10 @@ describe('Database Integration Components', () => {
           onRetry={vi.fn()}
           theme={mockTheme}
         />
-      )
+      );
 
-      expect(getByTestId('error-banner')).toBeInTheDocument()
-    })
+      expect(getByTestId('error-banner')).toBeInTheDocument();
+    });
 
     it('displays error title correctly', () => {
       const { getByTestId } = render(
@@ -208,188 +214,126 @@ describe('Database Integration Components', () => {
           onRetry={vi.fn()}
           theme={mockTheme}
         />
-      )
+      );
 
-      expect(getByTestId('error-title')).toHaveTextContent('Database Connection Error')
-    })
+      expect(getByTestId('error-title')).toHaveTextContent('Database Connection Error');
+    });
 
     it('displays error message correctly', () => {
-      const errorMessage = 'Backend server is not running. Please start it with: npm run dev:server'
+      const errorMessage =
+        'Backend server is not running. Please start it with: npm run dev:server';
       const { getByTestId } = render(
-        <ErrorBanner
-          error={errorMessage}
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error={errorMessage} onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('error-message')).toHaveTextContent(errorMessage)
-    })
+      expect(getByTestId('error-message')).toHaveTextContent(errorMessage);
+    });
 
     it('shows error icon', () => {
       const { getByTestId } = render(
-        <ErrorBanner
-          error="Test error"
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Test error" onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('error-icon')).toBeInTheDocument()
-    })
+      expect(getByTestId('error-icon')).toBeInTheDocument();
+    });
 
     it('calls onDismiss when dismiss button is clicked', async () => {
-      const onDismiss = vi.fn()
+      const onDismiss = vi.fn();
       const { getByTestId } = render(
-        <ErrorBanner
-          error="Test error"
-          onDismiss={onDismiss}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Test error" onDismiss={onDismiss} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      await userEvent.click(getByTestId('dismiss-button'))
+      await userEvent.click(getByTestId('dismiss-button'));
 
-      expect(onDismiss).toHaveBeenCalledTimes(1)
-    })
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
 
     it('calls onRetry when retry button is clicked', async () => {
-      const onRetry = vi.fn()
+      const onRetry = vi.fn();
       const { getByTestId } = render(
-        <ErrorBanner
-          error="Test error"
-          onDismiss={vi.fn()}
-          onRetry={onRetry}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Test error" onDismiss={vi.fn()} onRetry={onRetry} theme={mockTheme} />
+      );
 
-      await userEvent.click(getByTestId('retry-button'))
+      await userEvent.click(getByTestId('retry-button'));
 
-      expect(onRetry).toHaveBeenCalledTimes(1)
-    })
+      expect(onRetry).toHaveBeenCalledTimes(1);
+    });
 
     it('renders both retry and dismiss buttons when onRetry is provided', () => {
       const { getByTestId } = render(
-        <ErrorBanner
-          error="Test error"
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Test error" onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('retry-button')).toBeInTheDocument()
-      expect(getByTestId('dismiss-button')).toBeInTheDocument()
-    })
+      expect(getByTestId('retry-button')).toBeInTheDocument();
+      expect(getByTestId('dismiss-button')).toBeInTheDocument();
+    });
 
     it('does not render retry button when onRetry is not provided', () => {
       const { queryByTestId, getByTestId } = render(
-        <ErrorBanner
-          error="Test error"
-          onDismiss={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Test error" onDismiss={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(queryByTestId('retry-button')).not.toBeInTheDocument()
-      expect(getByTestId('dismiss-button')).toBeInTheDocument()
-    })
+      expect(queryByTestId('retry-button')).not.toBeInTheDocument();
+      expect(getByTestId('dismiss-button')).toBeInTheDocument();
+    });
 
     it('handles different error messages', () => {
       const { getByTestId, rerender } = render(
-        <ErrorBanner
-          error="Error 1"
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Error 1" onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('error-message')).toHaveTextContent('Error 1')
+      expect(getByTestId('error-message')).toHaveTextContent('Error 1');
 
       rerender(
-        <ErrorBanner
-          error="Error 2"
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Error 2" onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('error-message')).toHaveTextContent('Error 2')
-    })
+      expect(getByTestId('error-message')).toHaveTextContent('Error 2');
+    });
 
     it('applies theme classes correctly', () => {
       const { getByTestId } = render(
-        <ErrorBanner
-          error="Test error"
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Test error" onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      const banner = getByTestId('error-banner')
-      expect(banner).toBeInTheDocument()
-      expect(banner.className).toContain('fixed')
-      expect(banner.className).toContain('top-20')
-      expect(banner.className).toContain('z-50')
-    })
+      const banner = getByTestId('error-banner');
+      expect(banner).toBeInTheDocument();
+      expect(banner.className).toContain('fixed');
+      expect(banner.className).toContain('top-20');
+      expect(banner.className).toContain('z-50');
+    });
 
     it('handles common "Failed to fetch" error', () => {
-      const errorMessage = 'Backend server is not running. Please start it with: npm run dev:server'
+      const errorMessage =
+        'Backend server is not running. Please start it with: npm run dev:server';
       const { getByTestId } = render(
-        <ErrorBanner
-          error={errorMessage}
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error={errorMessage} onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('error-message')).toHaveTextContent(errorMessage)
-    })
+      expect(getByTestId('error-message')).toHaveTextContent(errorMessage);
+    });
 
     it('handles API error responses', () => {
-      const errorMessage = 'Database API returned 500 Internal Server Error'
+      const errorMessage = 'Database API returned 500 Internal Server Error';
       const { getByTestId } = render(
-        <ErrorBanner
-          error={errorMessage}
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error={errorMessage} onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('error-message')).toHaveTextContent(errorMessage)
-    })
+      expect(getByTestId('error-message')).toHaveTextContent(errorMessage);
+    });
 
     it('transitions from visible to hidden when error is cleared', () => {
       const { getByTestId, rerender, queryByTestId } = render(
-        <ErrorBanner
-          error="Test error"
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error="Test error" onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(getByTestId('error-banner')).toBeInTheDocument()
+      expect(getByTestId('error-banner')).toBeInTheDocument();
 
       rerender(
-        <ErrorBanner
-          error={null}
-          onDismiss={vi.fn()}
-          onRetry={vi.fn()}
-          theme={mockTheme}
-        />
-      )
+        <ErrorBanner error={null} onDismiss={vi.fn()} onRetry={vi.fn()} theme={mockTheme} />
+      );
 
-      expect(queryByTestId('error-banner')).not.toBeInTheDocument()
-    })
-  })
-})
+      expect(queryByTestId('error-banner')).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace all user-facing "AI" references across the app and 20+ design review files
- Mode toggles now say "LLM" instead of "AI"
- Feature headings use "Poetic Insights" instead of "AI Insights" (Arabic: رؤى شعرية)
- Onboarding copy uses natural language ("eloquent English translations", "recitation brings each verse to life") instead of "AI-powered" phrasing
- Updated all unit tests (270/270 pass) and E2E selectors to match new labels

## Test plan
- [x] All 270 unit tests pass
- [ ] E2E tests pass with updated aria-label selectors
- [ ] Verify mode toggle labels show "LLM" in UI
- [ ] Verify design review previews show "Poetic Insights" headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)