### PR TITLE
fix(tts): use full production TTS prompt for best audio quality

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -48,7 +48,6 @@ import {
   INSIGHTS_SYSTEM_PROMPT,
   DISCOVERY_SYSTEM_PROMPT,
   getTTSInstruction,
-  getTTSInstructionShort,
 } from './prompts';
 import { parseInsight } from './utils/insightParser';
 import { repairAndParseJSON } from './utils/jsonRepair';
@@ -69,7 +68,6 @@ const FEATURES = {
   database: true, // Enable database poem source (requires backend server running)
   onboarding: true, // Show kinetic walkthrough (phases 1-3) on first visit
   forceOnboarding: false, // Bypass hasSeenOnboarding check (enable to force onboarding every visit)
-  ttsFastPrompt: true, // Use shortened TTS prompt (~200 chars) for faster TTFB vs full prompt (~750 chars)
 };
 
 const DESIGN = {
@@ -603,8 +601,7 @@ const prefetchManager = {
       const mood = poem?.tags?.[1] || 'Poetic';
       const era = poem?.tags?.[0] || 'Classical';
       const poet = poem?.poet || 'the Master Poet';
-      const ttsPromptFn = FEATURES.ttsFastPrompt ? getTTSInstructionShort : getTTSInstruction;
-      const ttsInstruction = ttsPromptFn(poem, poet, mood, era);
+      const ttsInstruction = getTTSInstruction(poem, poet, mood, era);
 
       const requestSize = new Blob([
         JSON.stringify({ contents: [{ parts: [{ text: ttsInstruction }] }] }),
@@ -3819,8 +3816,7 @@ export default function DiwanApp() {
     const mood = current?.tags?.[1] || 'Poetic';
     const era = current?.tags?.[0] || 'Classical';
     const poet = current?.poet || 'the Master Poet';
-    const ttsPromptFn = FEATURES.ttsFastPrompt ? getTTSInstructionShort : getTTSInstruction;
-    const ttsInstruction = ttsPromptFn(current, poet, mood, era);
+    const ttsInstruction = getTTSInstruction(current, poet, mood, era);
 
     // Calculate request metrics
     const requestSize = new Blob([

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -78,10 +78,3 @@ export const getTTSInstruction = (poem, poet, mood, era) => {
   );
 };
 
-/**
- * Shortened TTS Instruction (~200 chars prompt) for faster TTFB.
- * Used when FEATURES.ttsFastPrompt is true.
- */
-export const getTTSInstructionShort = (poem, poet, mood, era) => {
-  return `Recite this ${mood} Arabic poem by ${poet} (${era}) with expressive inshad style. Project emotion, vary pace, stress the qafiya.\nPoem:\n${poem.arabic}`;
-};


### PR DESCRIPTION
## Summary
- Remove `getTTSInstructionShort` and the `ttsFastPrompt` feature flag
- Always use the full `getTTSInstruction` prompt (REST A) which A/B testing confirmed produces the best sounding Arabic poetry recitations
- Clean up dead code: remove unused short prompt function from `src/prompts.js` and conditional logic from `src/app.jsx`

## Test plan
- [ ] Verify TTS audio generation still works in both prefetch and on-demand paths
- [ ] Confirm no remaining references to `getTTSInstructionShort` or `ttsFastPrompt`

Generated with [Claude Code](https://claude.com/claude-code)