### PR TITLE
fix(tts): use exact Prompt K text from A/B testing

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -598,10 +598,7 @@ const prefetchManager = {
       if (activeRequests) activeRequests.current.add(poemId);
 
       // Generate audio using same logic as togglePlay
-      const mood = poem?.tags?.[1] || 'Poetic';
-      const era = poem?.tags?.[0] || 'Classical';
-      const poet = poem?.poet || 'the Master Poet';
-      const ttsInstruction = getTTSInstruction(poem, poet, mood, era);
+      const ttsInstruction = getTTSInstruction(poem);
 
       const requestSize = new Blob([
         JSON.stringify({ contents: [{ parts: [{ text: ttsInstruction }] }] }),
@@ -3813,10 +3810,7 @@ export default function DiwanApp() {
     // Mark request as in-flight
     activeAudioRequests.current.add(current?.id);
 
-    const mood = current?.tags?.[1] || 'Poetic';
-    const era = current?.tags?.[0] || 'Classical';
-    const poet = current?.poet || 'the Master Poet';
-    const ttsInstruction = getTTSInstruction(current, poet, mood, era);
+    const ttsInstruction = getTTSInstruction(current);
 
     // Calculate request metrics
     const requestSize = new Blob([

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -65,10 +65,12 @@ IMPORTANT: Choose poems that are at most 40 lines long. If a poem is longer, sel
  * @param {string} era - The era tag (e.g., "Modern", "Classical")
  * @returns {string} The formatted TTS instruction
  */
-export const getTTSInstruction = (poem, poet, mood, era) => {
+export const getTTSInstruction = (poem) => {
   return (
-    `أنت ${poet}، شاعر عربي من العصر ${era === 'Pre-Islamic' ? 'الجاهلي' : era === 'Islamic' ? 'الإسلامي' : era === 'Abbasid' ? 'العباسي' : era === 'Modern' ? 'الحديث' : 'العربي'}. ` +
-    `تقف أمام جمهور في مجلس شعر. قم بإلقاء قصيدتك أمام الحضور بسلطان الشعراء وعاطفة من عاش كل كلمة. ` +
+    `أنت امرؤ القيس بن حُجر، الملك الضليل وشاعر العرب الأول. ` +
+    `تقف أمام قبيلتك في مجلس شعر بصحراء نجد. النار تتقد، والحضور مُصغون. ` +
+    `قُم وألقِ معلقتك — القصيدة التي خلّدت اسمك عبر الأجيال. ` +
+    `هذه قصيدتك أنت، ألمك أنت، ذكرياتك أنت. ألقِها بسلطان الملوك وعاطفة الشعراء. ` +
     `ابدأ:\n${poem.arabic}`
   );
 };


### PR DESCRIPTION
## Summary
- Uses the exact Arabic role-play prompt (Prompt K) that tested best — no dynamic substitution
- Removes unused `poet`, `mood`, `era` parameters from `getTTSInstruction`
- Simplifies both call sites in `app.jsx`

## The prompt
```
أنت امرؤ القيس بن حُجر، الملك الضليل وشاعر العرب الأول.
تقف أمام قبيلتك في مجلس شعر بصحراء نجد. النار تتقد، والحضور مُصغون.
قُم وألقِ معلقتك — القصيدة التي خلّدت اسمك عبر الأجيال.
هذه قصيدتك أنت، ألمك أنت، ذكرياتك أنت. ألقِها بسلطان الملوك وعاطفة الشعراء.
ابدأ:
{poem.arabic}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)