### PR TITLE
fix(tts): remove systemInstruction (causes 400 on TTS model)

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -48,7 +48,6 @@ import {
 import {
   INSIGHTS_SYSTEM_PROMPT,
   DISCOVERY_SYSTEM_PROMPT,
-  TTS_SYSTEM_PROMPT,
   getTTSContent,
 } from './prompts';
 import { parseInsight } from './utils/insightParser';
@@ -604,7 +603,6 @@ const prefetchManager = {
 
       const requestBody = JSON.stringify({
         contents: [{ parts: [{ text: ttsContent }] }],
-        systemInstruction: { parts: [{ text: TTS_SYSTEM_PROMPT }] },
         generationConfig: {
           responseModalities: TTS_CONFIG.responseModalities,
           speechConfig: {
@@ -3827,7 +3825,6 @@ export default function DiwanApp() {
     // Calculate request metrics
     const requestBody = JSON.stringify({
       contents: [{ parts: [{ text: ttsContent }] }],
-      systemInstruction: { parts: [{ text: TTS_SYSTEM_PROMPT }] },
       generationConfig: {
         responseModalities: TTS_CONFIG.responseModalities,
         speechConfig: {

--- a/src/prompts.js
+++ b/src/prompts.js
@@ -52,23 +52,23 @@ IMPORTANT: Choose poems that are at most 40 lines long. If a poem is longer, sel
 `;
 
 /**
- * Text-to-Speech (TTS) System Instruction
+ * Text-to-Speech (TTS) Instruction
  * Used by: togglePlay, prefetchAudio
  *
- * Sent as systemInstruction so the TTS model knows HOW to recite,
- * while only the poem text (in contents) is actually spoken aloud.
+ * The TTS model (gemini-2.5-flash-preview-tts) does NOT support systemInstruction.
+ * Everything must go in contents as a single text block.
  *
- * Arabic role-play prompt (Prompt K) — scene-setting approach that produces
- * the most authentic Arabic poetry recitation.
+ * Prompt K scene-setting produces the most authentic Arabic poetry recitation.
+ * The model inhabits the poet rather than following a rule list.
  */
 export const TTS_SYSTEM_PROMPT = `أنت امرؤ القيس بن حُجر، الملك الضليل وشاعر العرب الأول. تقف أمام قبيلتك في مجلس شعر بصحراء نجد. النار تتقد، والحضور مُصغون. قُم وألقِ معلقتك — القصيدة التي خلّدت اسمك عبر الأجيال. هذه قصيدتك أنت، ألمك أنت، ذكرياتك أنت. ألقِها بسلطان الملوك وعاطفة الشعراء.`;
 
 /**
- * Get the poem text for TTS content.
- * Only the poem arabic text is sent as content to be spoken aloud.
+ * Build the full TTS content string (instruction + poem).
+ * TTS model requires everything in a single contents text block.
  *
  * @param {Object} poem - The poem object containing arabic text
- * @returns {string} The poem text to be recited
+ * @returns {string} Combined instruction + poem text
  */
-export const getTTSContent = (poem) => poem.arabic;
+export const getTTSContent = (poem) => `${TTS_SYSTEM_PROMPT}\nابدأ:\n${poem.arabic}`;
 


### PR DESCRIPTION
## Summary
- The TTS model (`gemini-2.5-flash-preview-tts`) does NOT support `systemInstruction` — it returns HTTP 400 "Model tried to generate text"
- Removes `systemInstruction` from both TTS API call sites (prefetch + on-demand)
- Keeps instruction + poem combined in `contents` as a single text block (which is what the TTS model expects)
- Refactors: `getTTSInstruction(poem)` → `getTTSContent(poem)` + `TTS_SYSTEM_PROMPT` constant for cleaner code separation

## Test plan
- [ ] Verify audio plays on first poem load
- [ ] Discover a new poem and verify audio plays
- [ ] Check no 400 errors in console for TTS prefetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)