### PR TITLE
fix(ui): remove static purple scroll-progress bar

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -4985,21 +4985,7 @@ export default function DiwanApp() {
           transition: box-shadow 0.15s ease;
         }
 
-        .scroll-progress {
-          position: fixed;
-          top: 0;
-          left: 0;
-          right: 0;
-          height: 3px;
-          background: linear-gradient(to right, #6366f1, #9333ea);
-          transform: scaleX(0.36);
-          transform-origin: left;
-          z-index: 100;
-          opacity: 0.85;
-        }
       `}</style>
-
-      <div className="scroll-progress" />
 
       <DebugPanel
         logs={logs}


### PR DESCRIPTION
## Summary
- Remove dead `.scroll-progress` CSS rule and div — a 3px indigo-to-purple gradient bar fixed at top of viewport, not connected to any scroll logic

Cherry-picked from `feature/unify-controls` (2c50255).

## Test plan
- [x] Visual: no purple bar above brand on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)