### PR TITLE
fix(ui): establish info hierarchy for header, poet/title, and translations

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -4993,6 +4993,8 @@ export default function DiwanApp() {
           zIndex: 40,
           pointerEvents: 'none',
           padding: `${0.13 - headerOpacity * 0.13}rem 1rem ${0.2 - headerOpacity * 0.2}rem`,
+          height: headerOpacity > 0 ? `${64 - headerOpacity * 32}px` : 'auto',
+          overflow: headerOpacity > 0 ? 'hidden' : 'visible',
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
@@ -5002,7 +5004,7 @@ export default function DiwanApp() {
           backdropFilter: `blur(${12 - headerOpacity * 8}px)`,
           WebkitBackdropFilter: `blur(${12 - headerOpacity * 8}px)`,
           borderBottom: `1px solid ${darkMode ? `rgba(197,160,89,${0.1 - headerOpacity * 0.1})` : `rgba(107,87,68,${0.1 - headerOpacity * 0.1})`}`,
-          transition: 'padding 0.4s ease-out, background-color 0.3s, backdrop-filter 0.3s',
+          transition: 'padding 0.4s ease-out, height 0.4s ease-out, background-color 0.3s, backdrop-filter 0.3s',
         }}
       >
         <div


### PR DESCRIPTION
- Remove vertical centering (min-h-full + justify-center) that prevented scroll
  accumulation; replace with mt-8 top margin for breathing room
- Restructure poet/title block: title (bold, gold, largest) → poet (regular,
  75% opacity, smaller) → English (50% opacity, tertiary)
- Reduce minimal-frame padding on mobile (16px/24px) with md breakpoint
  restoring desktop padding (28px/40px)
- Add backdrop blur (12px) and semi-transparent background to fixed header,
  activated progressively as user scrolls
- Add subtle left border accent (border-l-2) to inline translation lines
  for visual separation from Arabic verses

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>