### PR TITLE
fix: address copilot review comments on PR 315

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -3539,14 +3539,19 @@ export default function DiwanApp() {
       }
     };
     fetchPoets();
-  }, [poetPickerOpen, poetsFetched]);
+    // apiUrl is a module-level constant; addLog is functionally stable (uses
+    // only setLogs and module constants) even though its reference changes per
+    // render — poetsFetched gate prevents repeated fetches regardless.
+  }, [poetPickerOpen, poetsFetched, addLog]);
 
   // Focus search input when poet picker opens (delay allows CSS enter animation to complete)
   useEffect(() => {
+    let timerId;
     if (poetPickerOpen && poetSearchRef.current) {
-      setTimeout(() => poetSearchRef.current?.focus(), 100);
+      timerId = setTimeout(() => poetSearchRef.current?.focus(), 100);
     }
     if (!poetPickerOpen) setPoetSearch('');
+    return () => clearTimeout(timerId);
   }, [poetPickerOpen]);
 
   const closePoetPicker = () => {
@@ -5716,7 +5721,7 @@ export default function DiwanApp() {
                         scrollbarColor: 'rgba(197,160,89,0.2) transparent',
                       }}
                     >
-                      {/* "All Poets" option — always visible */}
+                      {/* "All Poets" option — shown when there is no active search */}
                       {!poetSearch && (
                         <button
                           data-testid="poet-picker-button"

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -731,6 +731,7 @@ describe('DiwanApp', () => {
         { name: 'أحمد شوقي', name_en: 'Ahmed Shawqi', poem_count: '5000' },
         { name: 'إيليا أبو ماضي', name_en: 'Elia Abu Madi', poem_count: '2000' },
       ];
+      const originalImpl = global.fetch.getMockImplementation();
       global.fetch.mockImplementation((url) => {
         if (typeof url === 'string' && url.includes('/api/poets')) {
           return Promise.resolve({
@@ -741,17 +742,26 @@ describe('DiwanApp', () => {
         return Promise.resolve({ ...defaultFetchResponse });
       });
 
-      render(<DiwanApp />);
-      await userEvent.click(screen.getByLabelText('Filter by poet'));
+      try {
+        render(<DiwanApp />);
+        await userEvent.click(screen.getByLabelText('Filter by poet'));
 
-      // Should show dynamic poets under "More Poets"
-      await waitFor(
-        () => {
-          expect(screen.getByText('أحمد شوقي')).toBeInTheDocument();
-          expect(screen.getByText('More Poets')).toBeInTheDocument();
-        },
-        { timeout: 3000 }
-      );
+        // Should show dynamic poets under "More Poets"
+        await waitFor(
+          () => {
+            expect(screen.getByText('أحمد شوقي')).toBeInTheDocument();
+            expect(screen.getByText('More Poets')).toBeInTheDocument();
+          },
+          { timeout: 3000 }
+        );
+      } finally {
+        // Restore original mock so subsequent tests aren't affected
+        if (originalImpl) {
+          global.fetch.mockImplementation(originalImpl);
+        } else {
+          global.fetch.mockReset();
+        }
+      }
     });
 
     it('shows clear filter button when a poet is selected', async () => {


### PR DESCRIPTION
- Add addLog to useEffect dependency array for poet-fetching effect
- Clear setTimeout in focus effect cleanup to prevent stale focus on quick picker close/unmount
- Fix misleading "always visible" comment on All Poets option
- Restore fetch mock after dynamic poets test to prevent test pollution

https://claude.ai/code/session_01G19AcGwgtnpmZT21JLeMDe