### PR TITLE
feat(routing): add useQueryParams hook for deep-linkable URL state

### DIFF
--- a/src/hooks/useQueryParams.js
+++ b/src/hooks/useQueryParams.js
@@ -1,0 +1,38 @@
+import { useMemo } from 'react';
+import { useLocation } from 'wouter';
+
+/**
+ * Custom hook for reading and writing URL query parameters.
+ * Built on top of wouter's useLocation — no additional dependencies.
+ *
+ * Note: wouter's useLocation() returns only the pathname (no query string),
+ * so we read params from window.location.search directly.
+ *
+ * @returns {[Object, Function]} [params, setParams]
+ *   - params: plain object of current query parameter key-value pairs
+ *   - setParams: function to merge updates into query params (set value to null to delete a param)
+ *
+ * URL scheme examples:
+ *   /?poet=Nizar+Qabbani
+ *   /poem/123?poet=Nizar+Qabbani
+ */
+export function useQueryParams() {
+  const [location, navigate] = useLocation();
+
+  const params = useMemo(() => {
+    const search = window.location.search;
+    return Object.fromEntries(new URLSearchParams(search));
+  }, [location]); // re-parse when wouter detects navigation
+
+  const setParams = (updates) => {
+    const next = new URLSearchParams(window.location.search);
+    Object.entries(updates).forEach(([k, v]) =>
+      v == null ? next.delete(k) : next.set(k, String(v))
+    );
+    const qs = next.toString();
+    const base = window.location.pathname;
+    navigate(qs ? `${base}?${qs}` : base, { replace: true });
+  };
+
+  return [params, setParams];
+}


### PR DESCRIPTION
## Summary

- Adds `src/hooks/useQueryParams.js` — a custom hook for reading and writing URL query parameters
- Built on wouter's `useLocation()` with no additional dependencies
- Reads params from `window.location.search` (since wouter only exposes the pathname)
- `setParams` merges updates into existing params; pass `null` to delete a param
- Uses `{ replace: true }` to avoid polluting browser history on every param change

## Usage

```js
import { useQueryParams } from './hooks/useQueryParams';

const [params, setParams] = useQueryParams();
// params.poet -> 'Nizar Qabbani'
setParams({ poet: 'Al-Mutanabbi' });
setParams({ poet: null }); // removes the param
```

## Test plan

- [ ] Import and call `useQueryParams` inside a wouter `<Router>` context
- [ ] Verify `params` reflects current URL query string on mount
- [ ] Verify `setParams({ key: 'value' })` updates the URL without a full page reload
- [ ] Verify `setParams({ key: null })` removes the key from the URL
- [ ] Verify browser back/forward does not create extra history entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)