### PR TITLE
feat(design): Sonner toast redesign — gold glass design language, top position

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -64,13 +64,22 @@ ReactDOM.createRoot(document.getElementById('root')).render(
       <DiwanApp />
       <Analytics />
       <Toaster
-        position="bottom-center"
+        position="top-center"
         theme="dark"
+        gap={8}
         toastOptions={{
+          duration: 2500,
+          className: 'poetry-toast',
           style: {
-            background: 'rgba(12,12,14,0.97)',
-            border: '1px solid rgba(196,163,90,0.2)',
-            color: '#F5F0E8',
+            background: 'rgba(12,12,14,0.88)',
+            backdropFilter: 'blur(24px) saturate(150%)',
+            WebkitBackdropFilter: 'blur(24px) saturate(150%)',
+            border: '1px solid rgba(197,160,89,0.25)',
+            borderRadius: '1rem',
+            color: '#e7e5e4',
+            fontFamily: "'Forum', serif",
+            boxShadow: '0 0 40px rgba(197,160,89,0.08), 0 8px 32px rgba(0,0,0,0.6)',
+            padding: '0.75rem 1rem',
           },
         }}
       />

--- a/src/stores/actions/fetchPoem.js
+++ b/src/stores/actions/fetchPoem.js
@@ -124,7 +124,7 @@ async function fetchFromDatabase({
   emitEvent(newPoem.id, 'serve', { source: 'database' });
   addLog('Event', `→ serve event emitted | poem_id: ${newPoem.id} | source: database`, 'info');
 
-  toast('New poem discovered', { description: newPoem.poet, duration: 2500 });
+  toast('New poem discovered', { description: newPoem.poet, duration: 3000, icon: '✦' });
   setPoems((prev) => {
     const updated = [...prev, newPoem];
     const freshFiltered = filterPoemsByCategory(updated, usePoemStore.getState().selectedCategory);
@@ -224,7 +224,7 @@ async function fetchFromAI({
   track('poem_discovered', { source: 'ai', poet: newPoem.poet });
   emitEvent(newPoem.id, 'serve', { source: 'ai' });
   addLog('Event', `→ serve event emitted | poem_id: ${newPoem.id} | source: ai`, 'info');
-  toast('New poem discovered', { description: newPoem.poet, duration: 2500 });
+  toast('New poem discovered', { description: newPoem.poet, duration: 3000, icon: '✦' });
 
   setPoems((prev) => {
     const updated = [...prev, newPoem];

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -184,3 +184,44 @@
 }
 .fire-tap { animation: fireTapFlash 0.42s ease-out forwards; }
 
+/* ============================================
+   Sonner toast overrides — gold glass design language
+   ============================================ */
+
+[data-sonner-toaster] [data-sonner-toast] {
+  --normal-bg: rgba(12,12,14,0.88);
+  --normal-border: rgba(197,160,89,0.25);
+}
+
+/* Default/success toast title in gold */
+[data-sonner-toast] [data-title] {
+  color: var(--gold);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+/* Description text (poet name) in muted warm italic */
+[data-sonner-toast] [data-description] {
+  color: rgba(212,200,168,0.88);
+  font-style: italic;
+}
+
+/* Error toast — subtle red accent, keep glass bg */
+[data-sonner-toast][data-type="error"] {
+  border-color: rgba(239,68,68,0.3) !important;
+}
+[data-sonner-toast][data-type="error"] [data-title] {
+  color: #fca5a5;
+}
+
+/* Gold glow entrance animation */
+[data-sonner-toast][data-mounted="true"] {
+  animation: toastGlow 0.6s ease-out;
+}
+
+@keyframes toastGlow {
+  0%   { box-shadow: 0 0 0 rgba(197,160,89,0),    0 0  0 rgba(0,0,0,0); }
+  50%  { box-shadow: 0 0 20px rgba(197,160,89,0.15), 0 4px 16px rgba(0,0,0,0.4); }
+  100% { box-shadow: 0 0 40px rgba(197,160,89,0.08), 0 8px 32px rgba(0,0,0,0.6); }
+}
+


### PR DESCRIPTION
## Summary

- Toasts now drop from **top-center** instead of bottom
- Full gold glass morphism treatment: `backdrop-blur(24px) saturate(150%)`, dark bg with gold border
- Forum serif font, `rounded-2xl`, ambient gold box-shadow
- CSS `[data-sonner-*]` overrides: gold title, warm italic poet description, red-tinted error border
- `toastGlow` keyframe: smooth gold shimmer entrance animation
- Poem discovery toast enhanced with `✦` icon and 3s duration
- Ratchet mode toasts left untouched (intentionally off-brand)

## Test plan

- [ ] Trigger poem discovery (DB or AI mode) — toast should appear at top-center with gold title and italic poet name
- [ ] Trigger an audio error (play without audio ready) — toast should show red-tinted border with pinkish title
- [ ] Verify ratchet mode toasts remain unchanged
- [ ] Cross-browser: Chrome, Safari (WebKit backdrop-filter prefix applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)