### PR TITLE
fix(ux): fix Embla swipe, update title on slide change, add swipe indicators

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -229,6 +229,9 @@ export default function DiwanApp() {
   const filtered = usePoemStore.getState().filteredPoems();
   const current = usePoemStore.getState().currentPoem();
 
+  // When the carousel is active, show the poem the user has swiped to
+  const displayedPoem = carouselPoems.length > 0 ? carouselPoems[carouselIndex] : current;
+
   const addLog = useUIStore.getState().addLog;
 
   // Track poem view time (emit 'view' event after 3s on same poem)
@@ -937,7 +940,7 @@ export default function DiwanApp() {
   return (
     <div
       className={`h-[100dvh] w-full flex flex-col overflow-hidden overscroll-none ${DESIGN.anim} font-sans ${theme.bg} ${theme.text} ${theme.selectionBg}`}
-      style={{ touchAction: 'pan-y', overflowX: 'hidden' }}
+      style={{ touchAction: 'pan-x pan-y', overflowX: 'hidden' }}
     >
 
       <DebugPanel controlBarRef={controlBarRef} />
@@ -1030,7 +1033,7 @@ export default function DiwanApp() {
                         textShadow: darkMode ? POEM_META.titleShadow.dark : POEM_META.titleShadow.light,
                       }}
                     >
-                      {current?.titleArabic || current?.title}
+                      {displayedPoem?.titleArabic || displayedPoem?.title}
                     </div>
                     {/* Line 2: Poet name */}
                     <div
@@ -1040,10 +1043,10 @@ export default function DiwanApp() {
                         color: darkMode ? POEM_META.poetColor.dark : POEM_META.poetColor.light,
                       }}
                     >
-                      {current?.poetArabic || current?.poet}
+                      {displayedPoem?.poetArabic || displayedPoem?.poet}
                     </div>
                     {/* Line 3: English combined attribution */}
-                    {(current?.poet || current?.title) && (
+                    {(displayedPoem?.poet || displayedPoem?.title) && (
                       <>
                         <div dir="ltr" style={POEM_META.separator} />
                         <div
@@ -1054,7 +1057,7 @@ export default function DiwanApp() {
                             color: darkMode ? POEM_META.englishLineColor.dark : POEM_META.englishLineColor.light,
                           }}
                         >
-                          {current?.poet}{current?.poet && current?.title ? ' \u2014 ' : ''}{current?.title}
+                          {displayedPoem?.poet}{displayedPoem?.poet && displayedPoem?.title ? ' \u2014 ' : ''}{displayedPoem?.title}
                         </div>
                       </>
                     )}

--- a/src/components/PoemCarousel.jsx
+++ b/src/components/PoemCarousel.jsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { transliterate } from '../utils/transliterate.js';
 
 /**
@@ -34,20 +35,47 @@ const PoemCarousel = ({
     dragFree: false,
     loop: false,
     startIndex: currentIndex,
+    containScroll: 'trimSnaps',
   });
+
+  const [showSwipeHint, setShowSwipeHint] = useState(true);
+  const [hasSwiped, setHasSwiped] = useState(false);
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
+
+  // Hide swipe hint after 3 seconds
+  useEffect(() => {
+    if (poems.length <= 1) return;
+    const timer = setTimeout(() => setShowSwipeHint(false), 3000);
+    return () => clearTimeout(timer);
+  }, [poems.length]);
+
+  const updateScrollButtons = useCallback(() => {
+    if (!emblaApi) return;
+    setCanScrollPrev(emblaApi.canScrollPrev());
+    setCanScrollNext(emblaApi.canScrollNext());
+  }, [emblaApi]);
 
   // Notify parent when user swipes
   const onSelect = useCallback(() => {
     if (!emblaApi) return;
     const idx = emblaApi.selectedScrollSnap();
     onSlideChange(idx);
-  }, [emblaApi, onSlideChange]);
+    setHasSwiped(true);
+    setShowSwipeHint(false);
+    updateScrollButtons();
+  }, [emblaApi, onSlideChange, updateScrollButtons]);
 
   useEffect(() => {
     if (!emblaApi) return;
     emblaApi.on('select', onSelect);
-    return () => emblaApi.off('select', onSelect);
-  }, [emblaApi, onSelect]);
+    emblaApi.on('reInit', updateScrollButtons);
+    updateScrollButtons();
+    return () => {
+      emblaApi.off('select', onSelect);
+      emblaApi.off('reInit', updateScrollButtons);
+    };
+  }, [emblaApi, onSelect, updateScrollButtons]);
 
   // Scroll to slide when currentIndex changes from outside (e.g. "Surprise Me")
   useEffect(() => {
@@ -59,14 +87,46 @@ const PoemCarousel = ({
 
   const dotColor = darkMode ? 'rgba(197,160,89,0.5)' : 'rgba(140,100,30,0.4)';
   const dotActiveColor = darkMode ? 'rgba(197,160,89,1)' : 'rgba(140,100,30,0.85)';
+  const goldColor = '#c5a059';
 
   return (
-    <div className="w-full">
-      {/* Carousel viewport — allow horizontal drag, preserve vertical scroll */}
+    <div className="w-full relative">
+      {/* Desktop chevron — previous */}
+      {poems.length > 1 && (
+        <button
+          onClick={() => emblaApi?.scrollPrev()}
+          aria-label="Previous poem"
+          className="hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 transition-all duration-300 ease-in-out"
+          style={{
+            opacity: canScrollPrev ? 0.5 : 0.15,
+            color: goldColor,
+            pointerEvents: canScrollPrev ? 'auto' : 'none',
+          }}
+        >
+          <ChevronRight size={24} />
+        </button>
+      )}
+
+      {/* Desktop chevron — next */}
+      {poems.length > 1 && (
+        <button
+          onClick={() => emblaApi?.scrollNext()}
+          aria-label="Next poem"
+          className="hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 z-10 items-center justify-center w-8 h-8 transition-all duration-300 ease-in-out"
+          style={{
+            opacity: canScrollNext ? 0.5 : 0.15,
+            color: goldColor,
+            pointerEvents: canScrollNext ? 'auto' : 'none',
+          }}
+        >
+          <ChevronLeft size={24} />
+        </button>
+      )}
+
+      {/* Carousel viewport — no touchAction override so Embla can receive horizontal swipe */}
       <div
         ref={emblaRef}
         className="overflow-hidden w-full"
-        style={{ touchAction: 'pan-y pinch-zoom' }}
       >
         <div className="flex">
           {poems.map((poem, slideIdx) => {
@@ -147,6 +207,19 @@ const PoemCarousel = ({
               }}
             />
           ))}
+        </div>
+      )}
+
+      {/* Swipe hint — fades out after 3s or after first swipe */}
+      {poems.length > 1 && !hasSwiped && (
+        <div
+          className="flex justify-center mt-2 md:hidden transition-all duration-300 ease-in-out"
+          style={{ opacity: showSwipeHint ? 0.4 : 0 }}
+          aria-hidden="true"
+        >
+          <span className="font-brand-en text-xs" style={{ color: goldColor }}>
+            Swipe for more by this poet →
+          </span>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Bug 1 (swipe blocked)**: Removed `touchAction: 'pan-y pinch-zoom'` from the Embla viewport element and changed the root app element from `touchAction: 'pan-y'` to `pan-x pan-y`. The browser was consuming horizontal touch events before Embla could see them.
- **Bug 2 (title stuck)**: Added `displayedPoem` computed variable in `app.jsx` — when the carousel is active it equals `carouselPoems[carouselIndex]` instead of `current`, so the title, poet name, and English attribution line all update as the user swipes.
- **Bug 3 (no affordance)**: Added desktop `<` `>` chevrons (gold, dimmed at boundaries, hidden on mobile) and a mobile-only "Swipe for more by this poet →" hint that fades out after 3 seconds or on first swipe.

## Files changed
- `src/components/PoemCarousel.jsx`
- `src/app.jsx` (carousel meta display + root touchAction only)

## Test plan
- [ ] On mobile: open a poet with multiple poems, confirm horizontal swipe works
- [ ] On mobile: title/poet line above the verses updates as you swipe between poems
- [ ] On mobile: swipe hint appears then fades after 3s (or immediately on first swipe)
- [ ] On desktop: chevrons appear; left chevron dims at first slide, right dims at last
- [ ] Vertical scroll still works normally (not broken by touchAction change)
- [ ] `npm run build` passes (verified: ✓ built in 2m 20s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)