### PR TITLE
fix(routing): fix deep link query params — poet in URL and share links

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -784,11 +784,12 @@ export default function DiwanApp() {
       return [...prev, mappedPoem];
     });
     setShowSavedPoems(false);
-    // Update URL for DB poems
+    // Update URL for DB poems, preserving any existing query params (e.g. ?poet=)
+    const qs = window.location.search;
     if (typeof mappedPoem.id === 'number') {
-      navigate('/poem/' + mappedPoem.id, { replace: true });
+      navigate('/poem/' + mappedPoem.id + qs, { replace: true });
     } else {
-      navigate('/', { replace: true });
+      navigate('/' + qs, { replace: true });
     }
   };
 

--- a/src/hooks/useQueryParams.js
+++ b/src/hooks/useQueryParams.js
@@ -1,12 +1,15 @@
-import { useMemo } from 'react';
-import { useLocation } from 'wouter';
+import { useState, useCallback } from 'react';
 
 /**
  * Custom hook for reading and writing URL query parameters.
- * Built on top of wouter's useLocation — no additional dependencies.
  *
- * Note: wouter's useLocation() returns only the pathname (no query string),
- * so we read params from window.location.search directly.
+ * Uses window.history.replaceState directly rather than wouter's navigate(),
+ * because wouter's useLocation() tracks only the pathname — passing
+ * '/path?foo=bar' to navigate() treats '?foo=bar' as part of the pathname
+ * and does not update window.location.search reliably.
+ *
+ * A local state counter drives re-renders when setParams is called, since
+ * window.location.search is not reactive.
  *
  * @returns {[Object, Function]} [params, setParams]
  *   - params: plain object of current query parameter key-value pairs
@@ -17,22 +20,24 @@ import { useLocation } from 'wouter';
  *   /poem/123?poet=Nizar+Qabbani
  */
 export function useQueryParams() {
-  const [location, navigate] = useLocation();
+  // Incrementing this triggers a re-render so `params` is recomputed from
+  // the updated window.location.search after a replaceState call.
+  const [, forceUpdate] = useState(0);
 
-  const params = useMemo(() => {
-    const search = window.location.search;
-    return Object.fromEntries(new URLSearchParams(search));
-  }, [location]); // re-parse when wouter detects navigation
+  const params = Object.fromEntries(new URLSearchParams(window.location.search));
 
-  const setParams = (updates) => {
+  const setParams = useCallback((updates) => {
     const next = new URLSearchParams(window.location.search);
     Object.entries(updates).forEach(([k, v]) =>
       v == null ? next.delete(k) : next.set(k, String(v))
     );
     const qs = next.toString();
-    const base = window.location.pathname;
-    navigate(qs ? `${base}?${qs}` : base, { replace: true });
-  };
+    const newUrl = qs
+      ? `${window.location.pathname}?${qs}`
+      : window.location.pathname;
+    window.history.replaceState({}, '', newUrl);
+    forceUpdate((n) => n + 1);
+  }, []);
 
   return [params, setParams];
 }

--- a/src/utils/ogMetaTags.js
+++ b/src/utils/ogMetaTags.js
@@ -16,7 +16,10 @@ export function updateOGMetaTags(poem) {
   const description = poem.arabic
     ? poem.arabic.split('\n').slice(0, 2).join(' ')
     : 'Discover classical and modern Arabic poetry';
-  const url = poem.id ? `${window.location.origin}/poem/${poem.id}` : window.location.origin;
+  const qs = window.location.search;
+  const url = poem.id
+    ? `${window.location.origin}/poem/${poem.id}${qs}`
+    : `${window.location.origin}${qs}`;
   const ogImage = poem.id
     ? `${window.location.origin}/api/og/${poem.id}`
     : `${window.location.origin}/favicon.svg`;


### PR DESCRIPTION
## Summary

- **`useQueryParams.js`**: Replaced wouter's `navigate()` with `window.history.replaceState` for writing query params. Wouter's `navigate()` treats the full string (including `?...`) as a pathname, so query params never made it into `window.location.search`. A local state counter drives re-renders since `window.location.search` is not reactive.
- **`app.jsx`**: Navigate calls that update the URL when loading a DB poem now preserve the existing query string (`window.location.search`), so selecting a poet sets `?poet=X` and subsequent poem loads keep that param in the URL.
- **`ogMetaTags.js`**: Share URLs now include `window.location.search` so the `?poet=` filter is carried through to shared links.

## Test plan

- [ ] Select a poet filter — URL should update to `/?poet=Nizar+Qabbani` (or equivalent)
- [ ] Click "next poem" — URL should become `/poem/123?poet=Nizar+Qabbani`
- [ ] Copy/share URL — the share link should include `?poet=`
- [ ] Load a deep link `/?poet=Nizar+Qabbani` — poet filter should be restored on mount
- [ ] Select "All" poets — `?poet=` should be removed from the URL
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)