### PR TITLE
fix(ux): re-trigger verse fade-up animation on carousel slide change

### DIFF
--- a/src/components/PoemCarousel.jsx
+++ b/src/components/PoemCarousel.jsx
@@ -39,6 +39,7 @@ const PoemCarousel = ({
     duration: 25,
   });
 
+  const [activeIndex, setActiveIndex] = useState(currentIndex);
   const [showSwipeHint, setShowSwipeHint] = useState(true);
   const [hasSwiped, setHasSwiped] = useState(false);
   const [canScrollPrev, setCanScrollPrev] = useState(false);
@@ -61,6 +62,7 @@ const PoemCarousel = ({
   const onSelect = useCallback(() => {
     if (!emblaApi) return;
     const idx = emblaApi.selectedScrollSnap();
+    setActiveIndex(idx);
     onSlideChange(idx);
     setHasSwiped(true);
     setShowSwipeHint(false);
@@ -165,9 +167,9 @@ const PoemCarousel = ({
                   <div className="flex flex-col gap-5 md:gap-7">
                     {versePairs.map((pair, idx) => (
                       <div
-                        key={`${poem.id}-${idx}`}
-                        className="flex flex-col gap-0.5 verse-fade-up"
-                        style={{ animationDelay: `${idx * 80}ms` }}
+                        key={`${poem.id}-${idx}${slideIdx === activeIndex ? '-active' : ''}`}
+                        className={`flex flex-col gap-0.5 ${slideIdx === activeIndex ? 'verse-fade-up' : 'opacity-100'}`}
+                        style={slideIdx === activeIndex ? { animationDelay: `${idx * 80}ms` } : undefined}
                       >
                         <p
                           dir="rtl"


### PR DESCRIPTION
## Summary

- Tracks `activeIndex` in local state, updated via Embla's `onSelect` callback
- `verse-fade-up` class is now only applied to verses on the active slide; other slides render with `opacity-100`
- Verse div key includes an `-active` suffix for the active slide — forces React to remount those divs on each slide change, re-triggering the CSS animation

## Test plan

- [ ] Load the carousel with multiple poems by the same poet
- [ ] Confirm the first poem's verses animate in with `verse-fade-up` on initial load
- [ ] Swipe to the next poem — verify verses animate in fresh (not instant)
- [ ] Swipe back — verify animation fires again
- [ ] Confirm non-active slides remain fully visible (no flash of invisible content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)