### PR TITLE
feat(ux): add saved poems book icon to control bar

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -13,6 +13,7 @@ import {
   Paintbrush,
   Check,
   X,
+  BookOpen,
 } from 'lucide-react';
 import { track } from '@vercel/analytics';
 import Sentry from './sentry.js';
@@ -1359,6 +1360,21 @@ export default function DiwanApp() {
                   className={`font-brand-en text-[0.53rem] font-bold tracking-[0.08em] uppercase opacity-60 whitespace-nowrap ${GOLD.goldText}`}
                 >
                   Explain
+                </span>
+              </div>
+
+              <div className="flex flex-col items-center gap-0.5 min-w-[52px]">
+                <button
+                  onClick={handleOpenSavedPoems}
+                  aria-label="View saved poems"
+                  className={`min-w-[46px] min-h-[46px] p-[11px] bg-transparent border-none cursor-pointer transition-all duration-200 flex items-center justify-center rounded-full ${GOLD.goldHoverBg} hover:scale-105`}
+                >
+                  <BookOpen className={GOLD.goldText} size={21} />
+                </button>
+                <span
+                  className={`font-brand-en text-[0.53rem] font-bold tracking-[0.08em] uppercase opacity-60 whitespace-nowrap ${GOLD.goldText}`}
+                >
+                  Library
                 </span>
               </div>
 


### PR DESCRIPTION
## Summary

- Adds a `BookOpen` (Library) button to the bottom control bar, placed between the Explain button and the SavePoemButton
- Tapping the button opens the saved poems view for authenticated users
- For unauthenticated users, it opens the sign-in/auth modal instead
- Uses the existing `handleOpenSavedPoems` handler which already implements the auth-gate logic and Vercel analytics tracking (`saved_poems_opened`)
- Styled consistently with the other control bar buttons: same size (`46x46px`), gold color scheme (`GOLD.goldText`, `GOLD.goldHoverBg`), `text-[0.53rem]` label

## Test plan

- [ ] Tap Library button while logged in → saved poems view opens
- [ ] Tap Library button while logged out → auth/login modal appears
- [ ] Verify button appearance matches other control bar buttons (size, color, hover effect)
- [ ] Verify label "Library" renders at `text-[0.53rem]` matching other labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)