### PR TITLE
fix(crash): replace setRatchetToast with toast() in touch handler

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1306,8 +1306,17 @@ export default function DiwanApp() {
                     longPressTimer.current = setTimeout(() => {
                       const willEnable = !useUIStore.getState().ratchetMode;
                       useUIStore.getState().toggleRatchetMode();
-                      setRatchetToast(willEnable ? 'on' : 'off');
-                      setTimeout(() => setRatchetToast(null), 2500);
+                      if (willEnable) {
+                        toast('🔥 Ratchet Mode activated fr fr', {
+                          style: { background: 'linear-gradient(135deg, #ff5000, #ff9000)', color: 'white', border: 'none' },
+                          duration: 2500,
+                        });
+                      } else {
+                        toast('Back to scholarly mode', {
+                          style: { background: 'rgba(60,60,70,0.92)', color: 'white', border: 'none' },
+                          duration: 2500,
+                        });
+                      }
                       longPressTimer.current = null;
                     }, 2000);
                   }}


### PR DESCRIPTION
## Summary

- **Sentry crash fix**: `ReferenceError: Can't find variable: setRatchetToast` in production
- The fire button long-press touch handler (`onTouchStart`) was still calling `setRatchetToast()` which was deleted earlier in the sprint; the merge from PR #398 reintroduced the old code
- Replaced both calls with `toast()` from `sonner` (already imported at line 3), matching the pattern used by the already-fixed keyboard handler

## Changes

- `src/app.jsx` lines 1309-1310: removed `setRatchetToast(willEnable ? 'on' : 'off')` and `setTimeout(() => setRatchetToast(null), 2500)`, replaced with conditional `toast()` calls with matching styles
- Verified zero remaining references to `ratchetToast` or `setRatchetToast` in the file

## Test plan

- [ ] Long-press the fire button on a touch device — should show "🔥 Ratchet Mode activated fr fr" toast (orange gradient) when enabling
- [ ] Long-press again to disable — should show "Back to scholarly mode" toast (dark background)
- [ ] No `ReferenceError` in console on touch interaction
- [ ] Keyboard handler (existing) still works correctly alongside touch handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)