### PR TITLE
fix(prefetch): stop infinite 429 retry loop in audio prefetch

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -968,7 +968,7 @@ export default function DiwanApp() {
       clearTimeout(prefetchCurrentAudio);
       clearTimeout(prefetchCurrentInsights);
     };
-  }, [current?.id, currentIndex, filtered]);
+  }, [current?.id]);
 
   // Keep-alive ping to prevent Render free tier from sleeping (15 min idle timeout)
   // Pings every 10 minutes to keep backend awake

--- a/src/services/prefetch.js
+++ b/src/services/prefetch.js
@@ -17,6 +17,9 @@ import { usePoemStore } from '../stores/poemStore';
 
 const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
+// Track poem IDs that hit quota errors — never retry these in this session
+const _quotaExhaustedIds = new Set();
+
 export const prefetchManager = {
   /**
    * Prefetch audio for a poem (generate and cache in background).
@@ -24,6 +27,9 @@ export const prefetchManager = {
   prefetchAudio: async (poemId, poem, addLog) => {
     if (!FEATURES.prefetching || !FEATURES.caching) return;
     if (!poemId || !poem?.arabic) return;
+
+    // Skip if quota was exhausted for this poem earlier in the session
+    if (_quotaExhaustedIds.has(poemId)) return;
 
     try {
       // Check if already generating - silently skip
@@ -87,6 +93,16 @@ export const prefetchManager = {
 
       if (!res.ok) {
         const errorText = await res.text();
+        if (res.status === 429 || res.status === 403) {
+          _quotaExhaustedIds.add(poemId);
+          if (addLog)
+            addLog(
+              'Prefetch Audio',
+              `❌ [${ttsModel}] HTTP ${res.status} — quota exhausted, skipping future prefetch for poem ${poemId}`,
+              'error'
+            );
+          return;
+        }
         if (addLog)
           addLog(
             'Prefetch Audio',


### PR DESCRIPTION
## Summary
- Fixes Sentry issue #416: audio prefetch retrying endlessly on HTTP 429 (quota exceeded)
- Two root causes: unstable `filtered` array ref in useEffect deps + no memory of past quota failures
- Both TTS models exhausted? Poem is marked in `_quotaExhaustedIds` and never retried this session

## Root Cause

**Bug 1 — app.jsx useEffect deps (`src/app.jsx`)**
The prefetch `useEffect` had `[current?.id, currentIndex, filtered]` as deps. `filtered` is computed via `usePoemStore.getState().filteredPoems()` inline on each render — a new array reference every time — making the effect re-run on every render and re-schedule the 2s prefetch timer constantly.

**Bug 2 — no quota memory in prefetch.js (`src/services/prefetch.js`)**
After a 429, `removeActiveAudio` in `finally` cleared the in-flight marker. The next effect re-run scheduled a fresh attempt with no knowledge of the previous failure.

## Fix
- `src/app.jsx:971`: narrow deps to `[current?.id]` — only re-run when the poem changes
- `src/services/prefetch.js`: add module-level `_quotaExhaustedIds` Set; on 429/403, add `poemId` and skip all future prefetch attempts for that poem in this session

## Test plan
- [ ] Navigate to a poem while offline/rate-limited — prefetch fires once, logs quota error, never repeats
- [ ] Navigate to a different poem — prefetch fires for the new poem (different ID)
- [ ] Navigate back to the rate-limited poem — prefetch is skipped silently
- [ ] Click play on a rate-limited poem — `doGenerate()` still fires (user-initiated, handled separately with toast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)