### PR TITLE
fix(carousel): deduplicate explain calls — guard autoExplainPending with explainedPoemIds

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -495,7 +495,11 @@ export default function DiwanApp() {
   useEffect(() => {
     if (autoExplainPending && current?.id && !isFetching && !isInterpreting && !interpretation) {
       setAutoExplainPending(false);
+      // Guard with explainedPoemIds to prevent duplicate explains when the carousel
+      // populate effect (path 1) has already fired for this poem.
+      if (explainedPoemIds.current.has(current.id)) return;
       if (ratchetMode || !current?.cachedTranslation) {
+        explainedPoemIds.current.add(current.id);
         handleAnalyze();
       }
     }


### PR DESCRIPTION
## Summary

- Three separate code paths trigger `analyzePoemAction` for the same poem; path 2 (`autoExplainPending` effect) was not guarded by `explainedPoemIds`, causing duplicate AI calls and translation flicker
- Added `explainedPoemIds.current.has(current.id)` early-return guard to the `autoExplainPending` effect, matching the pattern already used by paths 1 and 3
- Also add `explainedPoemIds.current.add(current.id)` before `handleAnalyze()` in path 2 so the set stays consistent

## Root cause

`fetchFromDatabase` sets `autoExplainPending = true` when a poem has no `cachedTranslation`. This effect fires independently of the carousel populate effect and previously had no deduplication check, so both paths raced to call the Gemini API and the last response to arrive would overwrite the first, causing a visible flicker.

## Test plan

- [ ] Load a poem with no cached translation — observe translation appears once, no flicker
- [ ] Slide to a new poem — translation loads without duplication
- [ ] Toggle ratchet mode — explain fires once per poem
- [ ] `npm run build` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)