### PR TITLE
fix(routing/ux): double fetch, URL query params, and back navigation

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -333,34 +333,6 @@ export default function DiwanApp() {
     return () => { cancelled = true; };
   }, [selectedCategory, useDatabase, current?.poet, current?.id]);
 
-  // Populate carousel from current poem's poet (works even when filter is "All")
-  useEffect(() => {
-    if (!FEATURES.prefetching || !useDatabase) return;
-    if (!current?.poet) return;
-    if (carouselPoems.length > 0) return; // already populated
-
-    let cancelled = false;
-    fetchPoemsByPoet(current.poet, 5, [current.id]).then((poems) => {
-      if (!cancelled && poems.length > 0) {
-        setCarouselPoems(poems);
-        // Auto-explain the first carousel poem on initial load if it has no translation.
-        // Guard with explainedPoemIds to ensure we only fire once per poem ID.
-        // Only add to explainedPoemIds if analyzePoem can actually start — if
-        // isInterpreting is true we skip marking, so the next populate can retry.
-        const first = poems[0];
-        if (first && !first.cachedTranslation && !first.english &&
-            !explainedPoemIds.current.has(first.id)) {
-          const { interpretation: interp, isInterpreting: interpreting } = usePoemStore.getState();
-          if (!interp && !interpreting) {
-            explainedPoemIds.current.add(first.id);
-            carouselExplainTargetId.current = first.id; // track which poem we're explaining
-            analyzePoemAction({ current: first, addLog, track });
-          }
-        }
-      }
-    }).catch(() => {});
-    return () => { cancelled = true; };
-  }, [current?.poet, current?.id, carouselPoems.length, useDatabase]);
 
   // When interpretation arrives from an analysis triggered by a carousel poem, patch that
   // poem's english field so PoemCarousel (which reads poem.english) can render the translation.
@@ -1520,7 +1492,7 @@ export default function DiwanApp() {
             }}
             onSelectPoet={(id) => {
               setSelectedCategory(id);
-              handleFetch();
+              // handleFetch() removed — selectedCategory effect handles it
             }}
           />
         )}


### PR DESCRIPTION
## Summary

- **Bug 2**: Removed explicit `handleFetch()` from `onSelectPoet` handler — the `selectedCategory` effect already triggers it, causing a double fetch and carousel flash. Also removed the duplicate second carousel-populate effect that was racing with effect #1 on poet change.
- **Bug 4**: All `navigate()` calls now preserve `window.location.search` so `?poet=` query params survive poem navigation (fixed in `fetchFromDatabase`, `fetchFromAI`, and the OAuth restore path).
- **Bug 5**: User-initiated navigations (Discover button DB load, saved poem selection) now push history entries instead of replacing — back button works. Non-user-initiated navigations (OAuth restore, AI fallback) correctly keep `replace: true`.

## Files changed

- `src/app.jsx` — removed `handleFetch()` from `onSelectPoet`, removed duplicate carousel effect, fixed OAuth restore navigate, fixed saved poem navigate
- `src/stores/actions/fetchPoem.js` — fixed `navigate` in `fetchFromDatabase` and `fetchFromAI`

## Test plan

- [ ] Select a poet in Discover drawer — verify only one fetch fires (no double flash)
- [ ] Select a poet, then press Discover — verify URL retains `?poet=` param
- [ ] Press Discover multiple times — verify browser Back button navigates through poem history
- [ ] Select a saved poem — verify Back button returns to previous poem
- [ ] OAuth sign-in flow — verify URL is restored correctly with `replace` (no extra history entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)