### PR TITLE
fix(carousel): use poetArabic for API filter — English name caused 0 results

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -305,15 +305,17 @@ export default function DiwanApp() {
       return;
     }
 
-    // Determine which poet to fetch for
+    // Determine which poet to fetch for.
+    // The API filters by Arabic poet name (po.name column), so always use poetArabic.
     const targetPoet = selectedCategory !== 'All'
       ? selectedCategory
-      : current?.poet; // Use current poem's poet when "All" is selected
+      : current?.poetArabic; // Arabic name for API compatibility
 
     if (!targetPoet || !current?.id) return;
 
-    // For poet-selected mode, wait for matching poem before populating
-    if (selectedCategory !== 'All' && current.poet !== selectedCategory) return;
+    // For poet-selected mode, wait for matching poem before populating.
+    // Compare against poetArabic because selectedCategory holds Arabic names (CATEGORIES[x].id).
+    if (selectedCategory !== 'All' && current.poetArabic !== selectedCategory) return;
 
     let cancelled = false;
     clearCarouselPoems();
@@ -336,9 +338,11 @@ export default function DiwanApp() {
           analyzePoemAction({ current: firstNeedsTranslation, addLog, track });
         }
       }
-    }).catch(() => {});
+    }).catch((err) => {
+      if (FEATURES.logging) addLog('Carousel', `Failed to fetch poems: ${err.message}`, 'error');
+    });
     return () => { cancelled = true; };
-  }, [selectedCategory, useDatabase, current?.poet, current?.id]);
+  }, [selectedCategory, useDatabase, current?.poetArabic, current?.id]);
 
 
   // When interpretation arrives from an analysis triggered by a carousel poem, patch that
@@ -1191,11 +1195,13 @@ export default function DiwanApp() {
                       POEM_META={POEM_META}
                       DESIGN={DESIGN}
                       onLoadMore={() => {
-                        if (!current?.poet) return;
+                        if (!current?.poetArabic) return;
                         const existingIds = carouselPoems.map(p => p.id);
-                        fetchPoemsByPoet(current.poet, 3, existingIds).then((newPoems) => {
+                        fetchPoemsByPoet(current.poetArabic, 3, existingIds).then((newPoems) => {
                           newPoems.forEach(p => addCarouselPoem(p));
-                        }).catch(() => {});
+                        }).catch((err) => {
+                          if (FEATURES.logging) addLog('Carousel', `Load-more failed: ${err.message}`, 'error');
+                        });
                       }}
                     />
                   ) : (


### PR DESCRIPTION
## Root Cause

The carousel-populate effect passed `current?.poet` (English name, e.g. `"Al-Mutanabbi"`) to `fetchPoemsByPoet`, but the API's `/api/poems/random?poet=` endpoint filters by `po.name` — the **Arabic** name column. So every carousel fetch returned 0 poems.

There were three related bugs:

1. **`targetPoet` in All mode** — used `current?.poet` (English) → API returned nothing
2. **Poet-filter guard** (line 316) — compared `current.poet` (English, e.g. `"Al-Mutanabbi"`) against `selectedCategory` (Arabic, e.g. `"المتنبي"`) → always `true` → carousel never populated in poet-filter mode either
3. **Silent catch** — `.catch(() => {})` swallowed all errors, making the failure invisible

## Fix

- `targetPoet`: now uses `current?.poetArabic` in All mode
- Guard: compares `current.poetArabic !== selectedCategory` (both Arabic now)
- Effect dep array: switched to `current?.poetArabic`
- `onLoadMore` callback: also updated to use `current.poetArabic`
- Added `FEATURES.logging` error logging to both previously silent catch blocks

## Test plan
- [ ] In "All" mode: load a poem, confirm carousel dots appear and swipe shows different poems by the same poet
- [ ] Select a specific poet from the picker: confirm carousel populates with their poems
- [ ] Check browser console for `[Carousel:...]` logs — should see "Populated N poems" not errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)