### PR TITLE
refactor(ux): polish InsightOverlay layout and dividers

### DIFF
--- a/src/components/InsightOverlay.jsx
+++ b/src/components/InsightOverlay.jsx
@@ -33,7 +33,7 @@ export default function InsightOverlay({
         >
           <Drawer.Handle
             className="mx-auto mt-3 mb-1 w-8 h-[3px] rounded-full"
-            style={{ background: 'rgba(197,160,89,0.7)' }}
+            style={{ background: 'rgba(255,255,255,0.4)' }}
           />
 
           {/* Header — centered poem title */}


### PR DESCRIPTION
## Summary
- Centered poem title in header (Arabic first, English second)
- Removed close button, blue sectionLine gradients, gold-structural solid border
- Consistent goldRule gradient dividers between all sections
- Centered poet name (Arabic first, English second) above The Author section
- Uniform py-5 spacing throughout

Follows up on #389.

## Test plan
- [ ] Verify no blue lines visible next to section labels
- [ ] Both dividers (Translation→Depth, Depth→Author) are identical gold gradients
- [ ] Poem title centered in header, poet name centered above Author
- [ ] Swipe down to dismiss still works (no close button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)