### PR TITLE
ci: add HTML preview links bot

### DIFF
--- a/.github/workflows/html-preview-links.yml
+++ b/.github/workflows/html-preview-links.yml
@@ -1,0 +1,89 @@
+name: HTML Preview Links
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  post-preview-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post or update HTML preview links
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MARKER = '<!-- html-preview-bot -->';
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const branch = pr.head.ref;
+            const sha = pr.head.sha.slice(0, 7);
+
+            // ── 1. Get all files changed in the PR ──────────────────────────
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: pr.number, per_page: 100 }
+            );
+
+            const htmlFiles = files
+              .filter(f => f.filename.endsWith('.html'))
+              .filter(f => !f.filename.includes('node_modules/'))
+              .filter(f => f.status !== 'removed');
+
+            // ── 2. Find existing bot comment ────────────────────────────────
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pr.number, per_page: 100 }
+            );
+            const existing = comments.find(c => c.body.includes(MARKER));
+
+            // ── 3. Build comment body ────────────────────────────────────────
+            let body;
+
+            if (htmlFiles.length === 0) {
+              // No HTML files — only update if a bot comment already exists
+              if (!existing) return;
+              body = [
+                MARKER,
+                `> HTML files removed in \`${sha}\``,
+              ].join('\n');
+            } else {
+              const baseUrl = `https://htmlpreview.github.io/?https://github.com/${owner}/${repo}/blob/${branch}`;
+              const rows = htmlFiles.map(f => {
+                const url = `${baseUrl}/${f.filename}`;
+                const short = f.filename.replace(/^design-review\//, '').replace(/^docs\/design\//, 'docs/');
+                const badge = f.status === 'added' ? ' ✦' : '';
+                return `| \`${f.filename}\`${badge} | [open ↗](${url}) |`;
+              });
+
+              body = [
+                MARKER,
+                `## HTML Previews`,
+                ``,
+                `Branch: \`${branch}\` · commit \`${sha}\``,
+                ``,
+                `| File | Preview |`,
+                `|---|---|`,
+                ...rows,
+                ``,
+                `<sub>✦ newly added · links update automatically on each commit</sub>`,
+              ].join('\n');
+            }
+
+            // ── 4. Create or update ──────────────────────────────────────────
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: pr.number,
+                body,
+              });
+            }


### PR DESCRIPTION
Adds a GitHub Action that automatically posts htmlpreview.github.io links as a PR comment whenever HTML files are changed.

This helps reviewers quickly preview HTML design artifacts without cloning the branch.