### PR TITLE
ci(html-preview): revert to htmlpreview.github.io

### DIFF
--- a/.github/workflows/html-preview-links.yml
+++ b/.github/workflows/html-preview-links.yml
@@ -51,7 +51,7 @@ jobs:
                 `> HTML files removed in \`${sha}\``,
               ].join('\n');
             } else {
-              const baseUrl = `https://raw.githack.com/${owner}/${repo}/${branch}`;
+              const baseUrl = `https://htmlpreview.github.io/?https://github.com/${owner}/${repo}/blob/${branch}`;
               // Group by directory
               const byDir = {};
               for (const f of htmlFiles) {


### PR DESCRIPTION
Revert githack — htmlpreview works fine, slash-in-branch-name was not the issue.