### PR TITLE
feat(islamic-patterns): add Featured section in mobile picker

### DIFF
--- a/design-review/islamic-patterns/generate.html
+++ b/design-review/islamic-patterns/generate.html
@@ -2658,6 +2658,21 @@ buildSidebar();
       }
     }
 
+    // Featured
+    {
+      const featured = FEATURED.map(name => {
+        const t = CATALOG.tilings.find(x => x.name === name); if (t) return { kind:'tiling', data:t };
+        const g = CATALOG.girihShapes.find(x => x.name === name); if (g) return { kind:'girih', data:g };
+        const tmpl = CATALOG.templates.find(x => x.name === name); if (tmpl) return { kind:'template', data:tmpl };
+        return null;
+      }).filter(Boolean).filter(it => matches(it.kind, it.data));
+      if (featured.length) {
+        appendGroupHeader(list, 'Featured', featured.length, 'var(--gold)');
+        for (const it of featured)
+          appendPickerItem(list, it.data.name, itemSubtitle(it.kind, it.data), it.kind, it.data);
+      }
+    }
+
     // Collections
     for (const col of COLLECTIONS) {
       const entries = col.items.map(e => {


### PR DESCRIPTION
## Summary

- Adds a **Featured** section in the mobile picker panel, sitting between "My Saved" and "Masterpieces"
- Pulls from the hardcoded `FEATURED` const (36 curated patterns), so it's always consistent regardless of user's saved set

## Test plan

- [ ] Open on mobile, tap the category label to open the picker
- [ ] "Featured" section appears above "Masterpieces" with 36 patterns
- [ ] Search filters Featured items correctly
- [ ] Tapping a Featured item renders it and closes the picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)