### PR TITLE
perf(insights): minimize model thinking to cut translation TTFT ~15x

### DIFF
--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -13,7 +13,10 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 export const API_MODELS = {
   tts: 'gemini-2.5-flash-preview-tts',
   ttsFallback: 'gemini-2.5-pro-preview-tts',
-  textDefaults: ['gemini-2.5-flash', 'gemini-2.0-flash', 'gemini-1.5-flash'],
+  // Fallback list, used only when the ListModels API is unavailable. Newest first.
+  // Both confirmed serving generateContent (2026-06); gemini-2.0-flash and
+  // gemini-1.5-flash were retired (404) and were removed.
+  textDefaults: ['gemini-3.5-flash', 'gemini-2.5-flash'],
 };
 
 /**
@@ -170,22 +173,43 @@ export const discoverTextModels = async (addLog) => {
 };
 
 /**
+ * Thinking control by model family. Deep "thinking" stalls the first streamed
+ * token: profiling production (2026-06) showed insights TTFT of ~15s warm
+ * (~27s cold) where the model emitted nothing, then streamed the whole answer
+ * in ~2s. Minimizing thinking drops first-token latency to ~1s with no
+ * meaningful quality loss for translation/analysis.
+ *
+ * Gemini 3.x uses `thinkingLevel` ('minimal' = lowest latency); 2.5 uses
+ * `thinkingBudget` (0 disables). Older families don't support thinking and
+ * 400 on the field, so they get nothing. Returns a spreadable fragment so the
+ * caller merges it into an existing generationConfig.
+ */
+export const thinkingConfigFor = (model = '') => {
+  if (/gemini-3/.test(model)) return { thinkingConfig: { thinkingLevel: 'minimal' } };
+  if (/gemini-2\.5/.test(model)) return { thinkingConfig: { thinkingBudget: 0 } };
+  return {};
+};
+
+/**
  * Fetch from a Gemini text endpoint with automatic model fallback.
  * Uses the dynamically discovered model list (ranked newest/cheapest first).
  * Retries on HTTP 404/410 (model unavailable/deprecated); throws immediately on other errors.
  *
- * @param {string}   endpoint - Gemini method segment, e.g. 'generateContent' or 'streamGenerateContent'
- * @param {string}   body     - Pre-serialised JSON request body
+ * @param {string} endpoint - Gemini method segment, e.g. 'generateContent' or 'streamGenerateContent'
+ * @param {string|function(string):string} bodyOrBuilder - Pre-serialised JSON request body,
+ *   OR a builder `(model) => jsonString` invoked per attempt so the body can vary by model
+ *   (e.g. model-specific thinking config). A plain string is reused for every attempt.
  * @param {string}   label    - Human-readable prefix for the thrown error message
  * @param {Function} addLog   - Component logging helper
  * @returns {Promise<Response>} Resolved Response with ok === true
  */
-export const geminiTextFetch = async (endpoint, body, label, addLog) => {
+export const geminiTextFetch = async (endpoint, bodyOrBuilder, label, addLog) => {
   const log = typeof addLog === 'function' ? addLog : () => {};
   const models = await discoverTextModels(log);
   for (let i = 0; i < models.length; i++) {
     const model = models[i];
     if (i > 0) log('Model Fallback', `Trying fallback: ${model}`, 'warning');
+    const body = typeof bodyOrBuilder === 'function' ? bodyOrBuilder(model) : bodyOrBuilder;
     const res = await fetch(`${apiUrl}/api/ai/${model}/${endpoint}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/src/services/prefetch.js
+++ b/src/services/prefetch.js
@@ -9,7 +9,7 @@
 
 import { FEATURES } from '../constants/index.js';
 import { INSIGHTS_SYSTEM_PROMPT, getTTSContent } from '../prompts';
-import { API_MODELS, TTS_CONFIG, geminiTextFetch, fetchTTSWithFallback, canPrefetchTts } from './gemini.js';
+import { API_MODELS, TTS_CONFIG, geminiTextFetch, thinkingConfigFor, fetchTTSWithFallback, canPrefetchTts } from './gemini.js';
 import { CACHE_CONFIG, cacheOperations } from './cache.js';
 import { pcm16ToWav } from '../utils/audio.js';
 
@@ -253,13 +253,17 @@ export const prefetchManager = {
       }
 
       const apiStart = performance.now();
-      const prefetchBody = JSON.stringify({
-        contents: [{ parts: [{ text: promptText }] }],
-        systemInstruction: { parts: [{ text: INSIGHTS_SYSTEM_PROMPT }] },
-      });
+      // Per-model body so thinking config matches the model family — same
+      // latency fix as the foreground insights path. See thinkingConfigFor().
+      const buildPrefetchBody = (model) =>
+        JSON.stringify({
+          contents: [{ parts: [{ text: promptText }] }],
+          systemInstruction: { parts: [{ text: INSIGHTS_SYSTEM_PROMPT }] },
+          generationConfig: { ...thinkingConfigFor(model) },
+        });
       const res = await geminiTextFetch(
         'generateContent',
-        prefetchBody,
+        buildPrefetchBody,
         'Prefetch Insights',
         addLog
       );

--- a/src/stores/actions/analyzePoem.js
+++ b/src/stores/actions/analyzePoem.js
@@ -5,7 +5,7 @@ import { useUIStore } from '../uiStore';
 import { useModalStore } from '../modalStore';
 import { INSIGHTS_SYSTEM_PROMPT, RATCHET_SYSTEM_PROMPT } from '../../prompts';
 import { parseInsight } from '../../utils/insightParser';
-import { geminiTextFetch } from '../../services/gemini.js';
+import { geminiTextFetch, thinkingConfigFor } from '../../services/gemini.js';
 import { cacheOperations, CACHE_CONFIG } from '../../services/cache.js';
 import { saveTranslation } from '../../services/database.js';
 
@@ -172,14 +172,19 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
       let firstChunkTime = null;
       let chunkCount = 0;
 
-      const insightsStreamBody = JSON.stringify({
-        contents: [{ parts: [{ text: promptText }] }],
-        systemInstruction: { parts: [{ text: activeSystemPrompt }] },
-        generationConfig: { maxOutputTokens: 8192 },
-      });
+      // Body is built per-model so thinking config matches the model family
+      // (3.x → thinkingLevel, 2.5 → thinkingBudget). Minimizing thinking is the
+      // single biggest translation latency win: first streamed token drops from
+      // ~15s warm (~27s cold) to ~1s. See thinkingConfigFor().
+      const buildInsightsBody = (model) =>
+        JSON.stringify({
+          contents: [{ parts: [{ text: promptText }] }],
+          systemInstruction: { parts: [{ text: activeSystemPrompt }] },
+          generationConfig: { maxOutputTokens: 8192, ...thinkingConfigFor(model) },
+        });
       const res = await geminiTextFetch(
         'streamGenerateContent',
-        insightsStreamBody,
+        buildInsightsBody,
         'Insights failed',
         addLog
       );

--- a/src/test/gemini-thinking.test.js
+++ b/src/test/gemini-thinking.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { thinkingConfigFor } from '../services/gemini.js';
+
+/**
+ * thinkingConfigFor picks the right "minimize thinking" knob per model family.
+ * Minimizing thinking is the insights/translation latency fix: it drops
+ * time-to-first-streamed-token from ~15s warm to ~1s (profiled 2026-06).
+ * The field name differs by family, so a wrong field would 400 the request.
+ */
+describe('thinkingConfigFor', () => {
+  it('uses thinkingLevel:minimal for Gemini 3.x models', () => {
+    expect(thinkingConfigFor('gemini-3.5-flash')).toEqual({
+      thinkingConfig: { thinkingLevel: 'minimal' },
+    });
+    expect(thinkingConfigFor('gemini-3-flash-preview')).toEqual({
+      thinkingConfig: { thinkingLevel: 'minimal' },
+    });
+  });
+
+  it('uses thinkingBudget:0 for Gemini 2.5 models', () => {
+    expect(thinkingConfigFor('gemini-2.5-flash')).toEqual({
+      thinkingConfig: { thinkingBudget: 0 },
+    });
+    expect(thinkingConfigFor('gemini-2.5-pro')).toEqual({
+      thinkingConfig: { thinkingBudget: 0 },
+    });
+  });
+
+  it('returns an empty object for models without thinking support', () => {
+    // Older families 400 on the thinking field, so they must get nothing.
+    expect(thinkingConfigFor('gemini-2.0-flash')).toEqual({});
+    expect(thinkingConfigFor('gemini-1.5-flash')).toEqual({});
+    expect(thinkingConfigFor('')).toEqual({});
+    expect(thinkingConfigFor()).toEqual({});
+  });
+
+  it('returns a fresh spreadable object each call (no shared mutation)', () => {
+    const a = thinkingConfigFor('gemini-3.5-flash');
+    const b = thinkingConfigFor('gemini-3.5-flash');
+    expect(a).not.toBe(b);
+    const merged = { maxOutputTokens: 8192, ...thinkingConfigFor('gemini-2.5-flash') };
+    expect(merged).toEqual({ maxOutputTokens: 8192, thinkingConfig: { thinkingBudget: 0 } });
+  });
+});


### PR DESCRIPTION
## What
Translation/interpretation streamed nothing for ~15s warm (~27s on a cold Render backend), then emitted the whole answer in ~2s. The model was *thinking* before the first token. This minimizes thinking so the first streamed word arrives in ~1s.

## Evidence (production `gemini-3.5-flash`, profiled 2026-06)
| request | first token | total |
|---|---|---|
| heavy ~2k-tok prompt, default thinking | 14.8s | 26.4s |
| heavy ~2k-tok prompt, thinking minimized | **1.1s** | ~8–10s |

Since insights stream into the UI chunk-by-chunk, the user sees translation text at ~1s instead of ~27s.

## Changes
- `thinkingConfigFor(model)`: `thinkingLevel:'minimal'` for 3.x, `thinkingBudget:0` for 2.5, nothing for older families (which 400 on the field).
- `geminiTextFetch` now accepts a per-model body builder so the thinking field matches whichever model is chosen from the fallback chain.
- Applied to both insights paths: foreground stream (`analyzePoem.js`) and background prefetch (`prefetch.js`).
- Refreshed stale `textDefaults`: `gemini-2.0-flash` and `gemini-1.5-flash` are retired (confirmed 404); defaults are now `gemini-3.5-flash`, `gemini-2.5-flash` (both confirmed serving `generateContent`).
- Unit test for `thinkingConfigFor`.

## Verify
- Lint clean; `src/test/gemini-thinking.test.js` passes.
- Heads up: `main` currently has 18 pre-existing unit failures (localStorage/seenPoems setup, PlayControls) fixed only on the unmerged `chore/cicd-ux-regression-suite` branch (`70f6329`). Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)