### PR TITLE
chore(deploy): detect stale backend builds (smoke check + /api/health commit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:e2e:debug": "playwright test --debug",
     "test:e2e:report": "playwright show-report",
     "test:e2e:full": "playwright test --config=playwright.config.full.js",
+    "smoke": "node scripts/smoke-deploy.mjs",
     "screenshots": "node scripts/capture-design-screenshots.js",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",

--- a/scripts/smoke-deploy.mjs
+++ b/scripts/smoke-deploy.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Post-deploy smoke check for the poetry-bil-araby API.
+ *
+ * Catches the failure mode that hid for ~2 months: a stale Render build that
+ * silently 404s newer endpoints (e.g. /api/ai/live-tts) while /api/health still
+ * returns 200. Run after a deploy, or in CI.
+ *
+ *   node scripts/smoke-deploy.mjs [baseUrl]
+ *   API_BASE=https://my-api.onrender.com node scripts/smoke-deploy.mjs
+ *   EXPECTED_COMMIT=$(git rev-parse HEAD) node scripts/smoke-deploy.mjs   # assert deployed SHA
+ *
+ * Exits non-zero if any check fails.
+ */
+const BASE = (process.argv[2] || process.env.API_BASE || 'https://poetry-bil-araby-2mb0.onrender.com').replace(/\/$/, '');
+const EXPECTED_COMMIT = process.env.EXPECTED_COMMIT || '';
+
+let failed = 0;
+const ok = (m) => console.log(`  ✓ ${m}`);
+const bad = (m) => {
+  console.error(`  ✗ ${m}`);
+  failed++;
+};
+
+const matches = (a, b) => a && b && (a.startsWith(b) || b.startsWith(a));
+
+async function main() {
+  console.log(`Smoke-testing ${BASE}`);
+
+  // 1. Health + deployed commit
+  try {
+    const r = await fetch(`${BASE}/api/health`);
+    const j = await r.json().catch(() => ({}));
+    if (r.ok) ok(`/api/health 200 (commit: ${j.commit ?? 'n/a'}, uptime ${Math.round(j.uptime || 0)}s)`);
+    else bad(`/api/health ${r.status}`);
+    if (EXPECTED_COMMIT) {
+      if (!j.commit || j.commit === 'unknown') bad(`deployed commit not reported — cannot confirm build (expected ${EXPECTED_COMMIT.slice(0, 8)})`);
+      else if (!matches(j.commit, EXPECTED_COMMIT)) bad(`STALE BUILD: deployed ${j.commit} != expected ${EXPECTED_COMMIT.slice(0, 8)}`);
+      else ok(`deployed commit matches expected (${j.commit.slice(0, 8)})`);
+    }
+  } catch (e) {
+    bad(`/api/health threw: ${e.message}`);
+  }
+
+  // 2. DB connectivity
+  try {
+    const r = await fetch(`${BASE}/api/health/full`);
+    const j = await r.json().catch(() => ({}));
+    if (r.ok && j.database === 'connected') ok(`/api/health/full DB connected (${j.totalPoems} poems)`);
+    else bad(`/api/health/full ${r.status} db=${j.database ?? 'n/a'}`);
+  } catch (e) {
+    bad(`/api/health/full threw: ${e.message}`);
+  }
+
+  // 3. Live TTS route present. An empty body should hit the handler's validation
+  //    (400) or the no-key guard (503) — NOT a 404, which means the deployed
+  //    build predates the endpoint. Cheap: no audio generated, no quota spent.
+  try {
+    const r = await fetch(`${BASE}/api/ai/live-tts`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    if (r.status === 404) bad(`/api/ai/live-tts 404 — endpoint missing (STALE BUILD)`);
+    else ok(`/api/ai/live-tts route present (HTTP ${r.status})`);
+  } catch (e) {
+    bad(`/api/ai/live-tts threw: ${e.message}`);
+  }
+
+  console.log(failed ? `\nFAILED (${failed} check${failed === 1 ? '' : 's'})` : `\nAll checks passed`);
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/server.js
+++ b/server.js
@@ -318,9 +318,16 @@ const validate = (req, res, next) => {
   next();
 };
 
-// Lightweight health check (no DB query — fast enough for Render's deploy probe)
+// Lightweight health check (no DB query — fast enough for Render's deploy probe).
+// `commit` exposes the deployed git SHA (Render sets RENDER_GIT_COMMIT) so drift
+// between the running build and main is detectable — a stale build silently
+// served an outdated API for ~2 months because nothing surfaced the version.
 app.get('/api/health', (req, res) => {
-  res.json({ status: 'ok', uptime: process.uptime() });
+  res.json({
+    status: 'ok',
+    uptime: process.uptime(),
+    commit: process.env.RENDER_GIT_COMMIT || process.env.GIT_COMMIT || 'unknown',
+  });
 });
 
 // Full health check with database connectivity


### PR DESCRIPTION
## Why

A stale Render build silently served an outdated API for **~2 months**. Newer endpoints (notably `POST /api/ai/live-tts`, merged 2026-04-03) returned **404** in production while `/api/health` still returned **200**, so nothing surfaced the drift. The frontend's "Live" TTS mode quietly 404'd and fell back to the slow non-streaming path.

This PR makes the deployed build **observable** and adds a **post-deploy gate** so the same failure can't hide again. It does not itself redeploy — that's the operational follow-up below.

## What

- **`/api/health` now returns `commit`** — Render's `RENDER_GIT_COMMIT` (falls back to `GIT_COMMIT`, else `'unknown'`). The running build's SHA is now comparable against `main`.
- **`scripts/smoke-deploy.mjs`** — dependency-free (Node built-in `fetch`) post-deploy check:
  1. `/api/health` 200, and with `EXPECTED_COMMIT` set, asserts the deployed SHA matches.
  2. `/api/health/full` reports DB connected.
  3. `/api/ai/live-tts` route is **present** — an empty-body `POST` should hit validation (`400`) or the no-key guard (`503`), **never `404`**. Cheap: no audio generated, no quota spent.
- **`npm run smoke`** wires it up.

## Verify

```bash
npm run smoke
# or assert the exact SHA after a deploy:
EXPECTED_COMMIT=$(git rev-parse origin/main) npm run smoke
```

Against current production this **correctly fails** on the live-tts `404`, proving the stale build.

## Operational follow-up (not in this PR)

Trigger a Render redeploy of `main` so `live-tts` exists in production, then re-run the smoke check to confirm `commit` matches and the route is present. Likely cause of the original drift: the service was created from the dashboard (not a Blueprint), so `render.yaml`'s `autoDeploy: true` is a no-op and the dashboard auto-deploy toggle governs.

## Notes

- CI on branches off `main` shows the 18 pre-existing unit failures fixed only on the unmerged `chore/cicd-ux-regression-suite` branch — unrelated to this change.
- Part of the live-TTS latency series. Sibling: #546 (disable thinking on insights/translation stream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)