### PR TITLE
feat(live-tts): stream PCM for ~1s time-to-first-sound + voice-aware cache

### DIFF
--- a/server.js
+++ b/server.js
@@ -949,221 +949,265 @@ app.post('/api/ai/:model/:action', async (req, res) => {
 // ═══════════════════════════════════════════════════════════════
 app.post('/api/ai/live-tts', async (req, res) => {
   const LIVE_MODEL = 'models/gemini-3.1-flash-live-preview';
-  const WS_TOTAL_TIMEOUT = 60000; // 60s hard ceiling
-  const WS_FIRST_CHUNK_TIMEOUT = 20000; // fail fast if model never starts responding
+  const WS_FIRST_CHUNK_TIMEOUT = 20000; // fail fast if the model never starts responding
+  const WS_IDLE_TIMEOUT = 25000; // after audio starts, no chunk for this long = stalled
+  // Per-request wall-clock ceiling. Streaming keeps the HTTP connection alive with
+  // flowing data, so it can run long (a multi-minute recitation). The buffering path
+  // holds one silent request open, so it gets a tighter cap to stay under proxy limits.
+  const WS_MAX_STREAM = 180000;
+  const WS_MAX_BUFFER = 90000;
 
-  try {
-    if (!GEMINI_API_KEY) {
-      return res.status(503).json({ error: 'AI features unavailable: no API key configured' });
-    }
-    const { text, voiceName, systemInstruction, temperature } = req.body || {};
-    if (!text || typeof text !== 'string' || !text.trim()) {
-      return res.status(400).json({ error: 'Missing or empty "text" field' });
-    }
+  if (!GEMINI_API_KEY) {
+    return res.status(503).json({ error: 'AI features unavailable: no API key configured' });
+  }
+  const { text, voiceName, systemInstruction, temperature } = req.body || {};
+  if (!text || typeof text !== 'string' || !text.trim()) {
+    return res.status(400).json({ error: 'Missing or empty "text" field' });
+  }
 
-    const voice = voiceName || 'Fenrir';
-    const temp = temperature != null ? parseFloat(temperature) : 0;
+  const voice = voiceName || 'Fenrir';
+  const temp = temperature != null ? parseFloat(temperature) : 0;
+  const streaming = req.query.stream === '1' || req.query.stream === 'sse';
 
-    log.info(
-      'Live TTS',
-      `Request | model: ${LIVE_MODEL} | voice: ${voice} | temp: ${temp} | text: ${text.length} chars`
-    );
+  log.info(
+    'Live TTS',
+    `Request | model: ${LIVE_MODEL} | voice: ${voice} | temp: ${temp} | text: ${text.length} chars | mode: ${streaming ? 'stream' : 'buffer'}`
+  );
 
-    const wsUrl = `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=${GEMINI_API_KEY}`;
+  const wsUrl = `wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent?key=${GEMINI_API_KEY}`;
+  const t0 = Date.now();
+  const ms = () => `+${Date.now() - t0}ms`;
 
-    const t0 = Date.now();
-    const ms = () => `+${Date.now() - t0}ms`;
+  /**
+   * Open one Live API WebSocket session and drive callbacks as audio arrives.
+   * Shared by the streaming (SSE) and buffering (JSON) paths so the protocol
+   * handling lives in one place.
+   *
+   * Contract: `onFail` only fires BEFORE any audio chunk (so a caller can safely
+   * fall back to REST). Once the first chunk has arrived, every terminal event
+   * (turnComplete, interrupt, ws-close, idle, max) resolves through `onDone` with
+   * whatever audio was received — partial audio is still usable.
+   *
+   * @returns {() => void} canceller that closes the socket (for client disconnects)
+   */
+  const runSession = ({ maxMs, onFirstChunk, onChunk, onDone, onFail }) => {
+    let settled = false;
+    let chunkCount = 0;
+    let firstChunkTimer = null;
+    let idleTimer = null;
 
-    const audioChunks = await new Promise((resolve, reject) => {
-      const chunks = [];
-      let settled = false;
-      let firstChunkTimer = null;
+    const clearTimers = () => {
+      clearTimeout(firstChunkTimer);
+      clearTimeout(idleTimer);
+      clearTimeout(maxTimer);
+    };
+    const done = (reason) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      try {
+        ws.close();
+      } catch {}
+      onDone(reason, chunkCount);
+    };
+    const fail = (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimers();
+      try {
+        ws.close();
+      } catch {}
+      onFail(err, chunkCount);
+    };
+    // Past the first chunk, "stop" means "we're done with what we have", never a hard fail.
+    const stop = (reason, err) => (chunkCount > 0 ? done(reason) : fail(err));
 
-      // Single settle helper prevents double-resolve/reject
-      const settle = (fn) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(totalTimeout);
-        clearTimeout(firstChunkTimer);
-        fn();
-      };
+    const maxTimer = setTimeout(() => {
+      log.error('Live TTS', `Max ${maxMs}ms reached (${ms()}) | ${chunkCount} chunks`);
+      stop('max-duration', new Error(`Live TTS exceeded ${Math.round(maxMs / 1000)}s`));
+    }, maxMs);
+    const resetIdle = () => {
+      clearTimeout(idleTimer);
+      idleTimer = setTimeout(() => {
+        log.error('Live TTS', `Idle ${WS_IDLE_TIMEOUT}ms, no new chunk (${ms()}) | ${chunkCount} chunks`);
+        stop('idle', new Error('Live TTS stalled'));
+      }, WS_IDLE_TIMEOUT);
+    };
 
-      const totalTimeout = setTimeout(() => {
-        log.error('Live TTS', `Hard timeout after 60s (${ms()}) | ${chunks.length} chunks so far`);
-        settle(() => {
-          ws.close();
-          reject(new Error('Live TTS timed out after 60s'));
-        });
-      }, WS_TOTAL_TIMEOUT);
+    const ws = new WebSocket(wsUrl);
 
-      const ws = new WebSocket(wsUrl);
-
-      ws.on('open', () => {
-        log.info('Live TTS', `WS connected (${ms()})`);
-
-        const setupMsg = {
-          setup: {
-            model: LIVE_MODEL,
-            generationConfig: {
-              responseModalities: ['AUDIO'],
-              speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } } },
-              ...(temp !== 0 ? { temperature: temp } : {}),
-            },
-            systemInstruction: {
-              parts: [
-                {
-                  text:
-                    systemInstruction ||
-                    'You are a text-to-speech reader. Read aloud the exact text provided by the user, word for word, with no additions, commentary, questions, or paraphrasing. Do not respond conversationally. Only speak the text as given.',
-                },
-              ],
-            },
+    ws.on('open', () => {
+      log.info('Live TTS', `WS connected (${ms()})`);
+      const setupMsg = {
+        setup: {
+          model: LIVE_MODEL,
+          generationConfig: {
+            responseModalities: ['AUDIO'],
+            speechConfig: { voiceConfig: { prebuiltVoiceConfig: { voiceName: voice } } },
+            ...(temp !== 0 ? { temperature: temp } : {}),
           },
-        };
-        log.debug(
-          'Live TTS',
-          `Setup msg sent | voice: ${voice} | modalities: AUDIO | temp: ${temp}`
-        );
-        ws.send(JSON.stringify(setupMsg));
-      });
-
-      ws.on('message', (raw) => {
-        try {
-          const msg = JSON.parse(raw.toString());
-          const msgKeys = Object.keys(msg).join(', ');
-          log.debug('Live TTS', `← ${msgKeys} (${ms()})`);
-
-          // ── Setup complete — send the poem text ──────────────────────────
-          if (msg.setupComplete !== undefined) {
-            log.info(
-              'Live TTS',
-              `Setup complete (${ms()}) | sending ${text.length}-char text | voice: ${voice}`
-            );
-
-            // Start a fast-fail timer — if no audio arrives within 20s the model isn't responding
-            firstChunkTimer = setTimeout(() => {
-              log.error(
-                'Live TTS',
-                `No audio chunk received after 20s — aborting (model may not support format)`
-              );
-              settle(() => {
-                ws.close();
-                reject(new Error('Live TTS: no audio data within 20s'));
-              });
-            }, WS_FIRST_CHUNK_TIMEOUT);
-
-            // clientContent + turnComplete:true is the correct format for native-audio models
-            // to receive a complete text turn and immediately start generating audio.
-            ws.send(
-              JSON.stringify({
-                clientContent: {
-                  turns: [{ role: 'user', parts: [{ text }] }],
-                  turnComplete: true,
-                },
-              })
-            );
-            return;
-          }
-
-          // ── API-level error ──────────────────────────────────────────────
-          if (msg.error) {
-            const errMsg = msg.error?.message || JSON.stringify(msg.error);
-            log.error('Live TTS', `API error (${ms()}): ${errMsg}`);
-            settle(() => {
-              ws.close();
-              reject(new Error(`Gemini Live API error: ${errMsg}`));
-            });
-            return;
-          }
-
-          // ── Audio / text parts ───────────────────────────────────────────
-          if (msg.serverContent?.modelTurn?.parts) {
-            for (const part of msg.serverContent.modelTurn.parts) {
-              if (part.inlineData?.data) {
-                if (chunks.length === 0) {
-                  clearTimeout(firstChunkTimer); // cancel the no-audio timer
-                  log.info(
-                    'Live TTS',
-                    `First audio chunk arrived (${ms()}) | mime: ${part.inlineData.mimeType || 'audio/pcm'}`
-                  );
-                }
-                chunks.push(part.inlineData.data);
-                log.debug(
-                  'Live TTS',
-                  `Chunk #${chunks.length}: ${part.inlineData.data.length} b64 chars (${ms()})`
-                );
-              } else if (part.text) {
-                log.debug('Live TTS', `Text part: "${part.text.substring(0, 80)}" (${ms()})`);
-              }
-            }
-          }
-
-          // ── Turn complete — all audio received ───────────────────────────
-          if (msg.serverContent?.turnComplete) {
-            log.info('Live TTS', `Turn complete (${ms()}) | ${chunks.length} chunks total`);
-            settle(() => {
-              ws.close();
-              resolve(chunks);
-            });
-          }
-
-          // ── Interrupted (model stopped mid-response) ─────────────────────
-          if (msg.serverContent?.interrupted) {
-            log.error('Live TTS', `Session interrupted by model (${ms()})`);
-            settle(() => {
-              ws.close();
-              if (chunks.length > 0)
-                resolve(chunks); // partial audio is still usable
-              else reject(new Error('Live TTS session interrupted before any audio'));
-            });
-          }
-        } catch (e) {
-          log.error('Live TTS', `Message parse error: ${e.message}`);
-        }
-      });
-
-      ws.on('error', (err) => {
-        log.error('Live TTS', `WS error (${ms()}): ${err.message}`);
-        settle(() => reject(err));
-      });
-
-      ws.on('close', (code, reason) => {
-        const reasonStr = reason?.toString() || '';
-        log.info(
-          'Live TTS',
-          `WS closed (${ms()}) | code: ${code}${reasonStr ? ` | reason: ${reasonStr}` : ''}`
-        );
-        if (!settled) {
-          settle(() => {
-            if (chunks.length > 0) resolve(chunks);
-            else
-              reject(
-                new Error(
-                  `WebSocket closed unexpectedly: code=${code}${reasonStr ? ` (${reasonStr})` : ''}`
-                )
-              );
-          });
-        }
-      });
+          systemInstruction: {
+            parts: [
+              {
+                text:
+                  systemInstruction ||
+                  'You are a text-to-speech reader. Read aloud the exact text provided by the user, word for word, with no additions, commentary, questions, or paraphrasing. Do not respond conversationally. Only speak the text as given.',
+              },
+            ],
+          },
+        },
+      };
+      ws.send(JSON.stringify(setupMsg));
     });
 
-    if (!audioChunks.length) {
-      return res.status(500).json({ error: 'No audio data received from Live API' });
-    }
+    ws.on('message', (raw) => {
+      try {
+        const msg = JSON.parse(raw.toString());
 
-    // Decode each base64 chunk to binary, concat, re-encode.
-    // Simple string join is wrong when chunks have base64 padding ('=') in the middle.
-    const combined = Buffer.concat(audioChunks.map((b64) => Buffer.from(b64, 'base64')));
-    const combinedBase64 = combined.toString('base64');
-    log.info(
-      'Live TTS',
-      `Done (${ms()}) | ${audioChunks.length} chunks | ${combined.length} bytes PCM | voice: ${voice}`
-    );
-    res.json({ audioData: combinedBase64 });
-  } catch (error) {
-    log.error('Live TTS', `Failed: ${error.message}`);
-    res.status(500).json({ error: `Live TTS failed: ${error.message}` });
+        // ── Setup complete — send the poem text ──────────────────────────
+        if (msg.setupComplete !== undefined) {
+          log.info('Live TTS', `Setup complete (${ms()}) | sending ${text.length}-char text`);
+          firstChunkTimer = setTimeout(() => {
+            log.error('Live TTS', `No audio within 20s — aborting (${ms()})`);
+            fail(new Error('Live TTS: no audio data within 20s'));
+          }, WS_FIRST_CHUNK_TIMEOUT);
+          // clientContent + turnComplete:true is the correct format for native-audio
+          // models: deliver a complete text turn and immediately start generating audio.
+          ws.send(
+            JSON.stringify({
+              clientContent: { turns: [{ role: 'user', parts: [{ text }] }], turnComplete: true },
+            })
+          );
+          return;
+        }
+
+        // ── API-level error ──────────────────────────────────────────────
+        if (msg.error) {
+          const errMsg = msg.error?.message || JSON.stringify(msg.error);
+          log.error('Live TTS', `API error (${ms()}): ${errMsg}`);
+          stop('api-error', new Error(`Gemini Live API error: ${errMsg}`));
+          return;
+        }
+
+        // ── Audio / text parts ───────────────────────────────────────────
+        if (msg.serverContent?.modelTurn?.parts) {
+          for (const part of msg.serverContent.modelTurn.parts) {
+            if (part.inlineData?.data) {
+              if (chunkCount === 0) {
+                clearTimeout(firstChunkTimer);
+                log.info(
+                  'Live TTS',
+                  `First audio chunk (${ms()}) | mime: ${part.inlineData.mimeType || 'audio/pcm'}`
+                );
+                if (onFirstChunk) onFirstChunk(part.inlineData.mimeType);
+              }
+              chunkCount++;
+              onChunk(part.inlineData.data);
+              resetIdle();
+            }
+          }
+        }
+
+        // ── Turn complete — all audio received ───────────────────────────
+        if (msg.serverContent?.turnComplete) {
+          log.info('Live TTS', `Turn complete (${ms()}) | ${chunkCount} chunks total`);
+          done('complete');
+        }
+
+        // ── Interrupted (model stopped mid-response) ─────────────────────
+        if (msg.serverContent?.interrupted) {
+          log.error('Live TTS', `Session interrupted by model (${ms()})`);
+          stop('interrupted', new Error('Live TTS session interrupted before any audio'));
+        }
+      } catch (e) {
+        log.error('Live TTS', `Message parse error: ${e.message}`);
+      }
+    });
+
+    ws.on('error', (err) => {
+      log.error('Live TTS', `WS error (${ms()}): ${err.message}`);
+      stop('ws-error', err);
+    });
+
+    ws.on('close', (code, reason) => {
+      const reasonStr = reason?.toString() || '';
+      log.info('Live TTS', `WS closed (${ms()}) | code: ${code}${reasonStr ? ` | ${reasonStr}` : ''}`);
+      stop('ws-close', new Error(`WebSocket closed: code=${code}${reasonStr ? ` (${reasonStr})` : ''}`));
+    });
+
+    return () => {
+      try {
+        ws.close();
+      } catch {}
+    };
+  };
+
+  // ── Streaming path: forward each PCM chunk as an SSE event ─────────────────
+  // First sound reaches the listener in ~1s instead of waiting for the whole
+  // recitation to synthesize. Removes the old 60s buffer ceiling that 500'd long poems.
+  if (streaming) {
+    res.setHeader('Content-Type', 'text/event-stream; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no'); // disable proxy buffering (nginx/Render)
+    if (typeof res.flushHeaders === 'function') res.flushHeaders();
+
+    const sse = (obj) => {
+      try {
+        res.write(`data: ${JSON.stringify(obj)}\n\n`);
+      } catch {}
+    };
+
+    const cancel = runSession({
+      maxMs: WS_MAX_STREAM,
+      onFirstChunk: (mime) =>
+        sse({ meta: { sampleRate: 24000, mimeType: mime || 'audio/pcm;rate=24000' } }),
+      onChunk: (b64) => sse({ chunk: b64 }),
+      onDone: (reason, n) => {
+        log.info('Live TTS', `Stream done (${ms()}) | ${n} chunks | reason: ${reason} | voice: ${voice}`);
+        sse({ done: true, chunks: n, reason });
+        try {
+          res.end();
+        } catch {}
+      },
+      onFail: (err, n) => {
+        log.error('Live TTS', `Stream failed (${ms()}): ${err.message} | ${n} chunks`);
+        sse({ error: err.message });
+        try {
+          res.end();
+        } catch {}
+      },
+    });
+
+    // If the listener navigates away / closes the tab, stop the upstream session.
+    res.on('close', () => cancel());
+    return;
   }
+
+  // ── Buffering path (legacy/iOS/safety): collect all chunks, return one blob ──
+  const chunks = [];
+  runSession({
+    maxMs: WS_MAX_BUFFER,
+    onChunk: (b64) => chunks.push(b64),
+    onDone: () => {
+      if (!chunks.length) {
+        if (!res.headersSent) res.status(500).json({ error: 'No audio data received from Live API' });
+        return;
+      }
+      // Decode each base64 chunk to binary, concat, re-encode. A plain string join
+      // is wrong when chunks carry base64 padding ('=') in the middle.
+      const combined = Buffer.concat(chunks.map((b64) => Buffer.from(b64, 'base64')));
+      log.info(
+        'Live TTS',
+        `Done (${ms()}) | ${chunks.length} chunks | ${combined.length} bytes PCM | voice: ${voice}`
+      );
+      res.json({ audioData: combined.toString('base64') });
+    },
+    onFail: (err) => {
+      log.error('Live TTS', `Failed: ${err.message}`);
+      if (!res.headersSent) res.status(500).json({ error: `Live TTS failed: ${err.message}` });
+    },
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════

--- a/src/components/DebugPanel.jsx
+++ b/src/components/DebugPanel.jsx
@@ -285,7 +285,21 @@ const DebugPanel = ({ controlBarRef }) => {
               <span className="text-[0.5625rem] font-brand-en uppercase tracking-widest font-semibold opacity-50 flex-shrink-0">Voice</span>
               <select
                 value={liveVoice}
-                onChange={(e) => { useUIStore.getState().setLiveVoice(e.target.value); useUIStore.getState().addLog('Settings', `Live voice → ${e.target.value}`, 'user'); }}
+                onChange={(e) => {
+                  useUIStore.getState().setLiveVoice(e.target.value);
+                  useUIStore.getState().addLog('Settings', `Live voice → ${e.target.value}`, 'user');
+                  // Reset loaded audio so the next Listen regenerates in the new voice
+                  // (otherwise the resume-from-blob path would replay the old voice).
+                  const { player, resetAudio } = useAudioStore.getState();
+                  if (player) {
+                    try {
+                      player.stop();
+                    } catch {
+                      /* already stopped */
+                    }
+                  }
+                  resetAudio();
+                }}
                 className="flex-1 text-[0.6rem] font-mono rounded px-1.5 py-0.5 cursor-pointer"
                 style={{ background: 'rgba(251,146,60,0.1)', border: '1px solid rgba(251,146,60,0.3)', color: 'rgb(251,146,60)' }}
               >

--- a/src/components/DebugPanel.jsx
+++ b/src/components/DebugPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Bug, X, Trash2, Zap, Radio, Wifi } from 'lucide-react';
+import { Bug, X, Copy, Check, Zap, Radio, Wifi } from 'lucide-react';
 import Sentry from '../sentry.js';
 import { FEATURES } from '../constants/features.js';
 import { THEME } from '../constants/theme.js';
@@ -13,7 +13,42 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 const DebugPanel = ({ controlBarRef }) => {
   const logs = useUIStore((s) => s.logs);
-  const onClear = () => useUIStore.getState().clearLogs();
+  const [copied, setCopied] = useState(false);
+
+  // Serialize the whole log to plain text and copy it to the clipboard.
+  const onCopyLogs = async () => {
+    const text = logs
+      .map((l) => `${l.time || l.rel || ''} [${(l.type || 'info').toUpperCase()}] [${l.label}] ${l.msg}`)
+      .join('\n');
+    const ok = await (async () => {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch {
+        // Fallback for non-secure contexts / older browsers
+        try {
+          const ta = document.createElement('textarea');
+          ta.value = text;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          const done = document.execCommand('copy');
+          document.body.removeChild(ta);
+          return done;
+        } catch {
+          return false;
+        }
+      }
+    })();
+    useUIStore
+      .getState()
+      .addLog('Debug', ok ? `Copied ${logs.length} log lines to clipboard` : 'Copy failed', ok ? 'success' : 'error');
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
   const darkMode = useUIStore((s) => s.darkMode);
   const visible = useUIStore((s) => s.showDebugLogs);
   const currentFont = useUIStore((s) => s.font);
@@ -195,11 +230,12 @@ const DebugPanel = ({ controlBarRef }) => {
           </span>
           <div className="flex items-center gap-1.5">
             <button
-              onClick={onClear}
-              className="p-1 transition-colors text-gold/30 hover:text-gold/70"
-              title="Clear logs"
+              onClick={onCopyLogs}
+              disabled={logs.length === 0}
+              className="p-1 transition-colors text-gold/30 hover:text-gold/70 disabled:opacity-30"
+              title={copied ? 'Copied!' : 'Copy logs to clipboard'}
             >
-              <Trash2 size={11} />
+              {copied ? <Check size={11} className="text-emerald-400" /> : <Copy size={11} />}
             </button>
             <button
               onClick={() => setPanelOpen(false)}

--- a/src/services/cache.js
+++ b/src/services/cache.js
@@ -21,6 +21,18 @@ export const CACHE_CONFIG = {
 };
 
 /**
+ * Build the audio-cache key for a poem. Includes the TTS mode and voice so that
+ * switching the voice (or engine) regenerates instead of replaying stale audio
+ * in the previous voice. Same poem + same mode + same voice = cache hit.
+ *
+ * @param {string|number} poemId
+ * @param {string} mode  - 'live' | 'rest'
+ * @param {string} voice - voice name (e.g. 'Orus', 'Fenrir')
+ */
+export const audioCacheKey = (poemId, mode, voice) =>
+  `${poemId}::${mode || 'rest'}::${voice || 'default'}`;
+
+/**
  * Initialize IndexedDB cache database.
  * Creates object stores for audio, insights, and poems if they don't exist.
  */

--- a/src/services/prefetch.js
+++ b/src/services/prefetch.js
@@ -10,7 +10,7 @@
 import { FEATURES } from '../constants/index.js';
 import { INSIGHTS_SYSTEM_PROMPT, getTTSContent } from '../prompts';
 import { API_MODELS, TTS_CONFIG, geminiTextFetch, thinkingConfigFor, fetchTTSWithFallback, canPrefetchTts } from './gemini.js';
-import { CACHE_CONFIG, cacheOperations } from './cache.js';
+import { CACHE_CONFIG, cacheOperations, audioCacheKey } from './cache.js';
 import { pcm16ToWav } from '../utils/audio.js';
 
 import { usePoemStore } from '../stores/poemStore';
@@ -54,8 +54,10 @@ export const prefetchManager = {
         return;
       }
 
-      // Check cache first - don't prefetch if already cached
-      const cached = await cacheOperations.get(CACHE_CONFIG.stores.audio, poemId, addLog);
+      // Check cache first - don't prefetch if already cached. Prefetch always uses
+      // the REST engine + default voice, so key the cache the same way playback does.
+      const audioKey = audioCacheKey(poemId, 'rest', TTS_CONFIG.voiceName);
+      const cached = await cacheOperations.get(CACHE_CONFIG.stores.audio, audioKey, addLog);
       if (cached?.blob) {
         if (addLog)
           addLog('Prefetch Audio', `Audio already cached for poem ${poemId} - skipping`, 'info');
@@ -168,8 +170,8 @@ export const prefetchManager = {
           const audioDuration = samples / 24000;
           const tokensPerSecond = (estimatedTokens / (apiTime / 1000)).toFixed(1);
 
-          // Cache the blob
-          await cacheOperations.set(CACHE_CONFIG.stores.audio, poemId, {
+          // Cache the blob under the same REST+voice key playback reads.
+          await cacheOperations.set(CACHE_CONFIG.stores.audio, audioKey, {
             blob,
             metadata: {
               poet: poem.poet,

--- a/src/stores/actions/togglePlay.js
+++ b/src/stores/actions/togglePlay.js
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 import { Rabbit } from 'lucide-react';
 import { motion } from 'framer-motion';
-import { Player, start as toneStart } from 'tone';
+import { Player, start as toneStart, getContext } from 'tone';
 import { toast } from 'sonner';
 import Sentry from '../../sentry.js';
 import { FEATURES } from '../../constants/features';
@@ -11,8 +11,14 @@ import { usePoemStore } from '../poemStore';
 import { useUIStore } from '../uiStore';
 import { getTTSContent, LIVE_SYSTEM_INSTRUCTION, getLiveContent } from '../../prompts';
 import { API_MODELS, TTS_CONFIG, fetchTTSWithFallback } from '../../services/gemini.js';
-import { cacheOperations, CACHE_CONFIG } from '../../services/cache.js';
+import { cacheOperations, CACHE_CONFIG, audioCacheKey } from '../../services/cache.js';
 import { pcm16ToWav } from '../../utils/audio.js';
+import {
+  createStreamingPlayer,
+  consumeSSE,
+  pcmBase64ToInt16,
+  concatPcmBase64,
+} from '../../utils/liveAudioStream.js';
 
 const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
@@ -302,10 +308,17 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
   const playId = ++_currentPlayId;
 
   const doGenerate = async () => {
+    // Resolve the selected engine + voice up front so the cache key reflects them.
+    // Same poem in a different voice/engine must regenerate, not replay stale audio.
+    let ttsMode = useUIStore.getState().ttsMode;
+    const { liveVoice, liveTemperature } = useUIStore.getState();
+    const keyFor = (mode) =>
+      audioCacheKey(current?.id, mode, mode === 'live' ? liveVoice : TTS_CONFIG.voiceName);
+
     // CHECK CACHE
     if (FEATURES.caching && current?.id) {
       const cacheStart = performance.now();
-      const cached = await cacheOperations.get(CACHE_CONFIG.stores.audio, current.id, addLog);
+      const cached = await cacheOperations.get(CACHE_CONFIG.stores.audio, keyFor(ttsMode), addLog);
       const cacheTime = performance.now() - cacheStart;
 
       if (cached?.blob) {
@@ -356,7 +369,6 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
     // Mark in-flight
     usePoemStore.getState().addActiveAudio(current?.id);
 
-    let ttsMode = useUIStore.getState().ttsMode;
     const arabicTextChars = current?.arabic?.length || 0;
 
     const modelLabel = ttsMode === 'live' ? 'Live 3.1' : API_MODELS.tts;
@@ -381,6 +393,117 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
       let b64;
       let ttsModel;
 
+      // ── Live streaming fast-path (desktop/Android) ──────────────────────────
+      // Play PCM chunks as they arrive from /api/ai/live-tts?stream=1 — first sound
+      // in ~1s instead of waiting for the whole recitation. iOS keeps the buffered
+      // HTMLAudio path below (the hardware silent switch mutes Web Audio).
+      if (ttsMode === 'live' && !isIOS()) {
+        try {
+          const liveText = getLiveContent(current);
+          addLog(
+            'Audio API',
+            `[Live 3.1] Streaming → voice: ${liveVoice} | temp: ${liveTemperature} | ${liveText.length} chars`,
+            'request'
+          );
+          const streamPlayer = createStreamingPlayer(getContext().rawContext);
+          const pcmB64 = [];
+          let sampleRate = 24000;
+          let firstSound = false;
+          let streamErr = null;
+
+          const liveRes = await fetch(`${apiUrl}/api/ai/live-tts?stream=1`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              text: liveText,
+              voiceName: liveVoice,
+              temperature: liveTemperature,
+              systemInstruction: LIVE_SYSTEM_INSTRUCTION,
+            }),
+          });
+          if (!liveRes.ok || !liveRes.body) {
+            throw new Error(`Live stream HTTP ${liveRes.status}`);
+          }
+
+          await consumeSSE(liveRes.body.getReader(), {
+            onMeta: (m) => {
+              if (m.sampleRate) sampleRate = m.sampleRate;
+            },
+            onChunk: (chunkB64) => {
+              // Swipe/navigation guard — stop feeding if the user moved on.
+              if (_currentPlayId !== playId) {
+                streamPlayer.stop();
+                return;
+              }
+              pcmB64.push(chunkB64);
+              streamPlayer.pushChunk(pcmBase64ToInt16(chunkB64));
+              if (!firstSound) {
+                firstSound = true;
+                const t = ((performance.now() - apiStart) / 1000).toFixed(2);
+                addLog('Audio API', `[Live 3.1] ▶ First sound (${t}s) | voice: ${liveVoice}`, 'success');
+                progress.dismiss('Recitation ready');
+                setPlayer(streamPlayer);
+                startPlayer(streamPlayer, 0);
+                setPlaying(true);
+                setGenerating(false);
+              }
+            },
+            onDone: () => streamPlayer.markInputDone(),
+            onError: (msg) => {
+              streamErr = msg;
+            },
+          });
+
+          // User navigated away mid-stream — bail without caching/playing.
+          if (_currentPlayId !== playId) {
+            streamPlayer.stop();
+            return;
+          }
+
+          if (firstSound) {
+            // Build one WAV from the collected PCM for caching + resume-from-blob.
+            const blob = pcm16ToWav(concatPcmBase64(pcmB64), sampleRate);
+            if (blob) {
+              setUrl(URL.createObjectURL(blob));
+              if (FEATURES.caching && current?.id) {
+                await cacheOperations.set(
+                  CACHE_CONFIG.stores.audio,
+                  keyFor('live'),
+                  {
+                    blob,
+                    metadata: {
+                      poet: current.poet,
+                      title: current.title,
+                      size: blob.size,
+                      model: 'Live 3.1',
+                      voice: liveVoice,
+                    },
+                  },
+                  addLog
+                );
+                addLog('Audio Cache', `Live audio cached (voice: ${liveVoice})`, 'success');
+              }
+            }
+            return; // success — finally{} resets generating/toggling flags
+          }
+
+          // Stream ended before any audio — fall through to REST.
+          addLog(
+            'Audio API',
+            `[Live 3.1] No audio${streamErr ? `: ${streamErr}` : ''} — falling back to REST`,
+            'warning'
+          );
+          ttsMode = 'rest';
+        } catch (streamError) {
+          addLog(
+            'Audio API',
+            `[Live 3.1] Stream failed: ${streamError.message} — falling back to REST`,
+            'warning'
+          );
+          ttsMode = 'rest';
+        }
+      }
+
       // ── Try selected mode first; on any failure (429, 404, network, etc.)
       //    fall back to the other mode once. This makes the app resilient when
       //    one path is rate-limited or unavailable (e.g. Live route not deployed
@@ -395,8 +518,7 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
 
         try {
           if (mode === 'live') {
-            // ── Live API path — WebSocket TTS via server endpoint ──
-            const { liveVoice, liveTemperature } = useUIStore.getState();
+            // ── Live API path — WebSocket TTS via server endpoint (buffered fallback) ──
             const liveText = getLiveContent(current);
             addLog(
               'Audio API',
@@ -580,7 +702,7 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
         const cacheStart = performance.now();
         await cacheOperations.set(
           CACHE_CONFIG.stores.audio,
-          current.id,
+          keyFor(ttsMode),
           {
             blob,
             metadata: {

--- a/src/test/liveAudioStream.test.js
+++ b/src/test/liveAudioStream.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { pcmBase64ToInt16, concatPcmBase64, consumeSSE } from '../utils/liveAudioStream.js';
+
+/** Encode an Int16Array (LE) to a base64 string, mirroring what the API sends. */
+function int16ToBase64(int16) {
+  const bytes = new Uint8Array(int16.buffer);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+/** A fake ReadableStream reader that yields the given byte slices in order. */
+function fakeReader(slices) {
+  const enc = new TextEncoder();
+  const queue = slices.map((s) => (typeof s === 'string' ? enc.encode(s) : s));
+  let i = 0;
+  return {
+    read() {
+      if (i < queue.length) return Promise.resolve({ value: queue[i++], done: false });
+      return Promise.resolve({ value: undefined, done: true });
+    },
+  };
+}
+
+describe('pcmBase64ToInt16', () => {
+  it('round-trips PCM16 samples', () => {
+    const samples = new Int16Array([0, 1, -1, 32767, -32768, 1234, -4321]);
+    const b64 = int16ToBase64(samples);
+    const decoded = pcmBase64ToInt16(b64);
+    expect(Array.from(decoded)).toEqual(Array.from(samples));
+  });
+
+  it('returns empty for empty input', () => {
+    expect(pcmBase64ToInt16(btoa(''))).toHaveLength(0);
+  });
+});
+
+describe('concatPcmBase64', () => {
+  it('concatenates chunks even when individual chunks have base64 padding', () => {
+    const a = new Int16Array([1, 2, 3]); // 6 bytes → base64 with padding
+    const b = new Int16Array([4, 5]); // 4 bytes
+    const combined = concatPcmBase64([int16ToBase64(a), int16ToBase64(b)]);
+    const decoded = pcmBase64ToInt16(combined);
+    expect(Array.from(decoded)).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe('consumeSSE', () => {
+  it('dispatches meta, chunk, and done events in order', async () => {
+    const events = [];
+    const stream = [
+      'data: {"meta":{"sampleRate":24000}}\n\n',
+      'data: {"chunk":"AAA="}\n\n',
+      'data: {"chunk":"AQA="}\n\n',
+      'data: {"done":true,"chunks":2,"reason":"complete"}\n\n',
+    ];
+    await consumeSSE(fakeReader(stream), {
+      onMeta: (m) => events.push(['meta', m.sampleRate]),
+      onChunk: (c) => events.push(['chunk', c]),
+      onDone: (d) => events.push(['done', d.chunks]),
+      onError: (e) => events.push(['error', e]),
+    });
+    expect(events).toEqual([
+      ['meta', 24000],
+      ['chunk', 'AAA='],
+      ['chunk', 'AQA='],
+      ['done', 2],
+    ]);
+  });
+
+  it('reassembles events split across reads', async () => {
+    const events = [];
+    // The chunk event is split mid-payload across three reads.
+    const stream = ['data: {"chu', 'nk":"XYZ="', '}\n\ndata: {"done":true}\n\n'];
+    await consumeSSE(fakeReader(stream), {
+      onChunk: (c) => events.push(['chunk', c]),
+      onDone: () => events.push(['done']),
+    });
+    expect(events).toEqual([['chunk', 'XYZ='], ['done']]);
+  });
+
+  it('surfaces an error event', async () => {
+    const events = [];
+    await consumeSSE(fakeReader(['data: {"error":"no audio within 20s"}\n\n']), {
+      onError: (e) => events.push(e),
+    });
+    expect(events).toEqual(['no audio within 20s']);
+  });
+});

--- a/src/utils/liveAudioStream.js
+++ b/src/utils/liveAudioStream.js
@@ -1,0 +1,199 @@
+/**
+ * Live TTS streaming helpers.
+ *
+ * The backend `/api/ai/live-tts?stream=1` endpoint forwards each PCM chunk from
+ * Google's Live API as an SSE event the moment it arrives. These helpers consume
+ * that stream and play the audio incrementally, so the first sound reaches the
+ * listener in ~1s instead of waiting for the whole recitation to synthesize.
+ *
+ * Audio format from the Live API: 16-bit signed little-endian PCM, mono, 24kHz.
+ */
+
+const DEFAULT_SAMPLE_RATE = 24000;
+
+/**
+ * Decode a base64 PCM16 chunk into an Int16Array of samples.
+ * Browsers are little-endian, matching the Live API's PCM byte order.
+ */
+export function pcmBase64ToInt16(b64) {
+  const bin = atob(b64);
+  const len = bin.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) bytes[i] = bin.charCodeAt(i);
+  // Trailing odd byte (shouldn't happen with PCM16) is dropped by the floor.
+  return new Int16Array(bytes.buffer, 0, Math.floor(len / 2));
+}
+
+/**
+ * Concatenate base64 PCM chunks into a single base64 string (for caching as one WAV).
+ * Decodes each chunk to bytes, concatenates, re-encodes — a plain string join is
+ * wrong because base64 padding ('=') can appear mid-stream.
+ */
+export function concatPcmBase64(chunks) {
+  const byteArrays = chunks.map((b64) => {
+    const bin = atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+    return arr;
+  });
+  const total = byteArrays.reduce((n, a) => n + a.length, 0);
+  const all = new Uint8Array(total);
+  let offset = 0;
+  for (const a of byteArrays) {
+    all.set(a, offset);
+    offset += a.length;
+  }
+  // Chunked btoa — avoids "Maximum call stack" on large buffers from String.fromCharCode(...spread).
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < all.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(null, all.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+/**
+ * Parse a Server-Sent Events stream from a ReadableStream reader, dispatching
+ * each `data:` JSON payload to the matching callback.
+ *
+ * Event shapes (from server.js live-tts streaming path):
+ *   { meta: { sampleRate, mimeType } }   — once, before the first chunk
+ *   { chunk: "<base64 pcm>" }            — per audio chunk
+ *   { done: true, chunks, reason }       — terminal success
+ *   { error: "<message>" }               — terminal failure
+ *
+ * @param {ReadableStreamDefaultReader<Uint8Array>} reader
+ * @param {{onMeta?, onChunk?, onDone?, onError?}} handlers
+ */
+export async function consumeSSE(reader, { onMeta, onChunk, onDone, onError } = {}) {
+  const decoder = new TextDecoder();
+  let buffer = '';
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    // SSE events are separated by a blank line.
+    let sep;
+    while ((sep = buffer.indexOf('\n\n')) !== -1) {
+      const rawEvent = buffer.slice(0, sep);
+      buffer = buffer.slice(sep + 2);
+      for (const line of rawEvent.split('\n')) {
+        if (!line.startsWith('data:')) continue;
+        const payload = line.slice(5).trim();
+        if (!payload) continue;
+        let evt;
+        try {
+          evt = JSON.parse(payload);
+        } catch {
+          continue;
+        }
+        if (evt.meta) onMeta?.(evt.meta);
+        else if (evt.chunk) onChunk?.(evt.chunk);
+        else if (evt.done) onDone?.(evt);
+        else if (evt.error) onError?.(evt.error);
+      }
+    }
+  }
+}
+
+/**
+ * A Web Audio player that accepts PCM chunks incrementally and schedules them
+ * back-to-back. Mimics the minimal player interface togglePlay expects
+ * (start / stop / onstop) so it drops into the existing playback + highlight flow.
+ *
+ * Pass an already-unlocked AudioContext (Tone's raw context, unlocked by the
+ * user gesture earlier in the click handler) so playback isn't blocked by
+ * browser autoplay policy.
+ *
+ * @param {AudioContext} ctx
+ * @param {{sampleRate?: number}} opts
+ */
+export function createStreamingPlayer(ctx, { sampleRate = DEFAULT_SAMPLE_RATE } = {}) {
+  let nextTime = 0; // ctx-time at which the next chunk should start
+  let pending = 0; // scheduled sources not yet finished
+  let inputDone = false;
+  let stopped = false;
+  let firstChunkAt = null; // ctx.currentTime of first scheduled chunk
+  const sources = new Set();
+  // All chunks fan through one gain node so the volume-detection analyser can
+  // tap a single output (matches the Tone.Player.connect() interface).
+  const output = ctx.createGain();
+  output.connect(ctx.destination);
+
+  const maybeEnd = () => {
+    if (inputDone && pending <= 0 && !stopped) {
+      stopped = true;
+      player.onstop?.();
+    }
+  };
+
+  const player = {
+    onstop: null,
+    /** Schedule one PCM16 chunk for playback. */
+    pushChunk(int16) {
+      if (stopped || int16.length === 0) return;
+      const buf = ctx.createBuffer(1, int16.length, sampleRate);
+      const ch = buf.getChannelData(0);
+      for (let i = 0; i < int16.length; i++) ch[i] = int16[i] / 32768;
+      const src = ctx.createBufferSource();
+      src.buffer = buf;
+      src.connect(output);
+      const now = ctx.currentTime;
+      // Small lead on the first chunk; resync if generation fell behind playback
+      // (an underrun leaves a gap rather than overlapping audio).
+      if (nextTime < now + 0.05) nextTime = now + 0.05;
+      if (firstChunkAt === null) firstChunkAt = nextTime;
+      src.start(nextTime);
+      nextTime += buf.duration;
+      pending++;
+      sources.add(src);
+      src.onended = () => {
+        sources.delete(src);
+        pending--;
+        maybeEnd();
+      };
+    },
+    /** Signal that no more chunks will arrive; player ends after the queue drains. */
+    markInputDone() {
+      inputDone = true;
+      maybeEnd();
+    },
+    /** Part of the Player interface. Playback already runs as chunks are pushed. */
+    start() {
+      if (ctx.state === 'suspended') ctx.resume?.();
+    },
+    /**
+     * Route output into a Tone node / AudioNode (volume-detection analyser).
+     * Tone wrappers expose the native node at `.input`; raw AudioNodes connect directly.
+     */
+    connect(dest) {
+      try {
+        output.connect(dest?.input ?? dest);
+      } catch {
+        /* analyser unavailable — audio still reaches the speakers via destination */
+      }
+      return this;
+    },
+    /** Stop immediately and fire onstop (pause / navigation). */
+    stop() {
+      if (stopped) {
+        // already ended naturally; still honor explicit stop semantics
+      }
+      stopped = true;
+      for (const s of sources) {
+        try {
+          s.stop();
+        } catch {
+          /* already stopped */
+        }
+      }
+      sources.clear();
+      this.onstop?.();
+    },
+    /** True once at least one chunk has been scheduled. */
+    get hasStarted() {
+      return firstChunkAt !== null;
+    },
+  };
+  return player;
+}


### PR DESCRIPTION
## The problem

Live mode buffered the **entire** recitation before playing anything. On a short poem you waited 16–45s of silence; on a long poem (824 chars) the synthesis blew past the server's 60s ceiling, returned a **500**, and fell back to REST — which is why "Listen" in Live mode produced a long stall and then the wrong voice (Fenrir).

The Render server logs showed the key fact: the Live API emits its **first audio chunk in ~0.8s, every time**. The server was throwing that head start away by buffering to `turnComplete`.

| poem | first chunk | finished | old result |
|---|---|---|---|
| 169 ch | +0.8s | +15.8s | played after 16s silence |
| 527 ch | +0.9s | +45.0s | played after 45s silence |
| 824 ch | +0.8s | never (60s) | **500 → REST/Fenrir** |

## The fix — stream the chunks

**Server** (`server.js` `/api/ai/live-tts`): new `?stream=1` mode forwards each PCM chunk as an SSE event as it arrives. First sound reaches the client in ~1s; the 60s ceiling is replaced by a per-chunk idle timeout so long poems finish. The buffering JSON path is kept for the iOS/safety fallback. Shared `runSession()` drives both; `onFail` only fires *before* any audio, so the client falls back to REST only when nothing played.

**Client**: new `src/utils/liveAudioStream.js` (SSE consumer + a 24kHz Web Audio scheduler that plays chunks back-to-back, resyncing on underrun, exposing the `start/stop/onstop/connect` Player interface so it drops into the existing playback + wall-clock read-along highlight). `togglePlay.js` streams via `?stream=1` on desktop/Android, starts playback on the first chunk, caches one WAV for resume; iOS keeps the buffered HTMLAudio path.

**Voice switching** (the "new voice replays old audio" bug): the audio cache key now includes mode + voice (`audioCacheKey`), used by both `togglePlay` and `prefetch` — same poem in a new voice regenerates, same voice is an instant cache hit. Changing the voice in the debug panel also resets loaded audio so the next play regenerates instead of resuming the previous voice's blob.

## Verified locally (seed pool + local backend, the Gemini key in `.env`)

- First sound **~0.85s** (was 8.5s buffered / 60s failure on long poems)
- `curl` the SSE endpoint: `META + chunk #1 @ 947ms`, streams to done
- Multiple voices: Zephyr / Charon / Sadachbia each regenerate with the correct voice; re-selecting a cached voice is an instant cache hit, no request
- Volume-pulse analyser works with the streaming player (`connect` implemented)
- Unit tests: PCM decode, chunk concat, SSE parse (incl. events split across reads) — 6/6 green

## Not yet verified — tracked in #549

iOS real-device (streaming is off on iOS by design), long-poem underrun/highlight-drift (generation runs ~0.8x realtime), abort-on-navigation, and prod end-to-end after deploy. See the checklist in #549.

Sibling PRs in this series: #546 (disable insights thinking, already live), #548 (stale-build smoke check, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)