### PR TITLE
feat(debug): copy logs to clipboard (replaces clear button)

### DIFF
--- a/src/components/DebugPanel.jsx
+++ b/src/components/DebugPanel.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Bug, X, Trash2, Zap, Radio, Wifi } from 'lucide-react';
+import { Bug, X, Copy, Check, Zap, Radio, Wifi } from 'lucide-react';
 import Sentry from '../sentry.js';
 import { FEATURES } from '../constants/features.js';
 import { THEME } from '../constants/theme.js';
@@ -13,7 +13,42 @@ const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 const DebugPanel = ({ controlBarRef }) => {
   const logs = useUIStore((s) => s.logs);
-  const onClear = () => useUIStore.getState().clearLogs();
+  const [copied, setCopied] = useState(false);
+
+  // Serialize the whole log to plain text and copy it to the clipboard.
+  const onCopyLogs = async () => {
+    const text = logs
+      .map((l) => `${l.time || l.rel || ''} [${(l.type || 'info').toUpperCase()}] [${l.label}] ${l.msg}`)
+      .join('\n');
+    const ok = await (async () => {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch {
+        // Fallback for non-secure contexts / older browsers
+        try {
+          const ta = document.createElement('textarea');
+          ta.value = text;
+          ta.style.position = 'fixed';
+          ta.style.opacity = '0';
+          document.body.appendChild(ta);
+          ta.select();
+          const done = document.execCommand('copy');
+          document.body.removeChild(ta);
+          return done;
+        } catch {
+          return false;
+        }
+      }
+    })();
+    useUIStore
+      .getState()
+      .addLog('Debug', ok ? `Copied ${logs.length} log lines to clipboard` : 'Copy failed', ok ? 'success' : 'error');
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
   const darkMode = useUIStore((s) => s.darkMode);
   const visible = useUIStore((s) => s.showDebugLogs);
   const currentFont = useUIStore((s) => s.font);
@@ -195,11 +230,12 @@ const DebugPanel = ({ controlBarRef }) => {
           </span>
           <div className="flex items-center gap-1.5">
             <button
-              onClick={onClear}
-              className="p-1 transition-colors text-gold/30 hover:text-gold/70"
-              title="Clear logs"
+              onClick={onCopyLogs}
+              disabled={logs.length === 0}
+              className="p-1 transition-colors text-gold/30 hover:text-gold/70 disabled:opacity-30"
+              title={copied ? 'Copied!' : 'Copy logs to clipboard'}
             >
-              <Trash2 size={11} />
+              {copied ? <Check size={11} className="text-emerald-400" /> : <Copy size={11} />}
             </button>
             <button
               onClick={() => setPanelOpen(false)}


### PR DESCRIPTION
Stacked on #550.

Replaces the debug log panel's trash/clear button with a **copy to clipboard** button that serializes the entire log to plain text:

```
<time> [TYPE] [label] message
```

- Uses `navigator.clipboard.writeText`, falls back to a hidden `textarea` + `execCommand('copy')` for non-secure contexts
- Transient ✓ check icon on success; logs a `Copied N log lines` line
- Disabled when there are no logs

Trivial UI swap. Lint clean (0 errors). Not browser-tested (servers were down); the logic is straightforward but worth an eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)