### PR TITLE
feat(tts): default to Live streaming engine (fast playback by default)

### DIFF
--- a/src/components/DebugPanel.jsx
+++ b/src/components/DebugPanel.jsx
@@ -63,7 +63,11 @@ const DebugPanel = ({ controlBarRef }) => {
   const liveVoice = useUIStore((s) => s.liveVoice);
   const liveTemperature = useUIStore((s) => s.liveTemperature);
   const [panelOpen, setPanelOpen] = useState(false);
-  const [ttsModel, setTtsModel] = useState(API_MODELS.tts.includes('pro') ? 'pro' : 'flash');
+  // Initialize the engine display from the actual ttsMode so the panel and playback
+  // agree (ttsMode defaults to 'live'). Falls back to the REST model label otherwise.
+  const [ttsModel, setTtsModel] = useState(() =>
+    useUIStore.getState().ttsMode === 'live' ? 'live' : API_MODELS.tts.includes('pro') ? 'pro' : 'flash'
+  );
   const [bugDescription, setBugDescription] = useState('');
   const [bugStatus, setBugStatus] = useState(null); // null | 'sending' | 'success' | 'error'
   const [bugError, setBugError] = useState('');

--- a/src/services/prefetch.js
+++ b/src/services/prefetch.js
@@ -14,6 +14,7 @@ import { CACHE_CONFIG, cacheOperations, audioCacheKey } from './cache.js';
 import { pcm16ToWav } from '../utils/audio.js';
 
 import { usePoemStore } from '../stores/poemStore';
+import { useUIStore } from '../stores/uiStore';
 
 const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
@@ -27,6 +28,10 @@ export const prefetchManager = {
   prefetchAudio: async (poemId, poem, addLog) => {
     if (!FEATURES.prefetching || !FEATURES.caching) return;
     if (!poemId || !poem?.arabic) return;
+
+    // The Live engine (default) streams in ~1s and keys its cache by voice, so this
+    // REST prefetch would never be played — skip it to avoid burning the daily REST quota.
+    if (useUIStore.getState().ttsMode === 'live') return;
 
     // Skip if quota was exhausted for this poem earlier in the session
     if (_quotaExhaustedIds.has(poemId)) return;

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -5,6 +5,23 @@ import { FONTS } from '../constants/fonts';
 
 const MAX_LOGS = 200;
 
+// TTS engine preference. Defaults to 'live' (streaming, first sound ~1s). The user's
+// explicit choice is remembered across reloads, but the debug-panel toggle always
+// switches it, so no one gets locked onto one engine.
+const TTS_MODE_KEY = 'tts-mode';
+const loadTtsMode = () => {
+  try {
+    const v = localStorage.getItem(TTS_MODE_KEY);
+    if (v === 'rest' || v === 'live') return v;
+  } catch {}
+  return 'live';
+};
+const persistTtsMode = (mode) => {
+  try {
+    localStorage.setItem(TTS_MODE_KEY, mode);
+  } catch {}
+};
+
 export const CATEGORY_MAP = {
   user: { color: '#00bcd4', prefix: 'USER' },
   request: { color: '#ff9800', prefix: '  →' },
@@ -22,7 +39,7 @@ const initialState = {
   showTransliteration: false,
   showDebugLogs: FEATURES.debug,
   ratchetMode: false, // Ratchet Mode: explains poems in Gen Z / gangster slang
-  ttsMode: 'rest', // 'rest' | 'live'
+  ttsMode: loadTtsMode(), // 'rest' | 'live' — defaults to 'live' (streaming)
   liveVoice: 'Orus',
   liveTemperature: 0,
   highlightStyle: 'pill', // 'none' | 'glow' | 'underline' | 'pill' | 'focus-blur'
@@ -52,7 +69,10 @@ const initialState = {
 export const useUIStore = create((set, get) => ({
   ...initialState,
 
-  setTtsMode: (ttsMode) => set({ ttsMode }),
+  setTtsMode: (ttsMode) => {
+    persistTtsMode(ttsMode);
+    set({ ttsMode });
+  },
   setLiveVoice: (liveVoice) => set({ liveVoice }),
   setLiveTemperature: (liveTemperature) => set({ liveTemperature }),
   setHighlightStyle: (highlightStyle) => set({ highlightStyle }),


### PR DESCRIPTION
## Why

The streaming work (#550) made Live mode give first sound in ~1s. But the app **defaulted to REST** (buffered, 10-40s) and **reset to REST on every reload**, with the engine toggle buried in the debug panel. So users kept landing on the slow path without realizing — which is why "Listen" still felt slow even after streaming shipped.

## What

- **Default `ttsMode` is now `'live'`** (`uiStore`).
- **The choice persists** to `localStorage` and restores on load, so switching engines is remembered across reloads. The toggle always changes it, so no one gets locked onto one engine.
- **DebugPanel** initializes its engine display from `ttsMode` so the panel and playback agree.
- **prefetch** skips the background REST audio prefetch when Live is active — that audio is keyed by voice and never played on the Live path, so prefetching it only burned the daily REST quota.

## Verified (live, headed browser)

On a fresh load with cleared storage:
- Defaults to **Live 3.1**, no manual toggle
- Listen → **first sound 0.85s**
- Switch to REST → reload → **stays REST** (remembered)
- Switch back to Live → reload → **stays Live** (remembered)

So: Live by default, freely switchable, never stuck either way.

Lint clean (0 errors). Independent of the open swipe-fix PR #552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)