### PR TITLE
feat(ios): Live TTS plays through the silent switch (audioSession) + read-along to last word

### DIFF
--- a/src/hooks/useTTSHighlight.js
+++ b/src/hooks/useTTSHighlight.js
@@ -14,6 +14,14 @@ export const pauseOffset = { value: 0 };
  * onstop handler skips its setPlaying(false) call. Reset after startPlayer().
  */
 export const isSeeking = { value: false };
+/**
+ * Tracks whether the most recent stop was a user pause (freeze highlight in place)
+ * vs a natural end-of-playback (snap the highlight to the final word so the whole
+ * poem reads as completed). Set true in recordPause(), reset false when a loop
+ * starts. Without this, the rAF loop stops on end before the last word's timing
+ * window is reached and the read-along freezes one word short.
+ */
+export const lastStopWasPause = { value: false };
 
 /**
  * Start a Tone.Player from a given offset and record the wall-clock start time.
@@ -38,6 +46,7 @@ export function startPlayer(player, offset) {
  * will accumulate double elapsed time until startPlayer() fires. Only use for pause.
  */
 export function recordPause() {
+  lastStopWasPause.value = true; // this stop is a pause → freeze highlight, don't snap to end
   const elapsed = Date.now() / 1000 - playbackStartTime.value;
   const newOffset = pauseOffset.value + Math.max(0, elapsed);
   if (FEATURES.logging) console.log(`[Playback:recordPause] elapsed=${elapsed.toFixed(2)}s → offset=${newOffset.toFixed(2)}s`);
@@ -142,6 +151,7 @@ export function useTTSHighlight({ wordRefs, timings, totalDuration, wordOffsets 
 
   // Start the rAF loop — called when isPlaying becomes true
   function startLoop() {
+    lastStopWasPause.value = false; // fresh run; treat the next stop as a natural end unless a pause sets this
     // One-shot scroll on first frame — ensures the active word is visible
     // even if the user has scrolled away while paused.
     let firstTick = true;
@@ -242,7 +252,20 @@ export function useTTSHighlight({ wordRefs, timings, totalDuration, wordOffsets 
         startLoop();
       } else if (!isPlaying && wasPlaying) {
         stopLoop();
-        // Do NOT clear classes on pause — highlights freeze in place
+        // Natural end (not a user pause): snap the highlight to the final word so
+        // the whole poem reads as completed. The rAF loop can stop before the last
+        // word's timing window is reached when the duration estimate overshoots,
+        // which left the read-along frozen one word short.
+        if (!lastStopWasPause.value && wordRefs.length > 0) {
+          const last = wordRefs.length - 1;
+          for (let i = 0; i <= last; i++) {
+            const el = wordRefs[i]?.current;
+            if (!el) continue;
+            el.classList.remove('tts-active', 'tts-past');
+            el.classList.add(i === last ? 'tts-active' : 'tts-past');
+          }
+        }
+        // On a user pause, highlights freeze in place (no change).
       }
     });
 

--- a/src/stores/actions/togglePlay.js
+++ b/src/stores/actions/togglePlay.js
@@ -319,9 +319,18 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
     return;
   }
 
-  // Unlock AudioContext after user gesture so Tone.js can output audio.
-  // Skip on iOS — AudioContext is not used there; HTMLAudioElement handles playback.
-  if (!isIOS()) await toneStart();
+  // iOS: set the audio session to 'playback' inside the user gesture so Web Audio
+  // plays THROUGH the hardware silent switch (verified on a real iPhone). This lets
+  // iOS use the exact same smooth streaming player as desktop — no HLS, no stutter,
+  // ~1s first sound — instead of the silent-switch-muted Web Audio that forced the
+  // old HTMLAudio/HLS detours.
+  if (isIOS()) {
+    try {
+      if ('audioSession' in navigator) navigator.audioSession.type = 'playback';
+    } catch { /* older iOS without the Audio Session API → buffered fallback still works */ }
+  }
+  // Unlock the AudioContext after the user gesture (now on iOS too).
+  await toneStart();
 
   setGenerating(true);
 
@@ -413,11 +422,13 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
       let b64;
       let ttsModel;
 
-      // ── Live streaming fast-path (desktop/Android) ──────────────────────────
+      // ── Live streaming fast-path (all platforms) ────────────────────────────
       // Play PCM chunks as they arrive from /api/ai/live-tts?stream=1 — first sound
-      // in ~1s instead of waiting for the whole recitation. iOS keeps the buffered
-      // HTMLAudio path below (the hardware silent switch mutes Web Audio).
-      if (ttsMode === 'live' && !isIOS()) {
+      // in ~1s instead of waiting for the whole recitation. iOS is included: the
+      // gesture set navigator.audioSession.type='playback' above, so Web Audio
+      // plays through the hardware silent switch (verified on device). Old iOS
+      // without the Audio Session API falls through to the HLS/buffered path below.
+      if (ttsMode === 'live' && (!isIOS() || (typeof navigator !== 'undefined' && 'audioSession' in navigator))) {
         try {
           const liveText = getLiveContent(current);
           addLog(


### PR DESCRIPTION
## What

Makes **Live TTS actually live on iPhone**: audible through the hardware silent switch, ~1s to first sound, smooth (no stutter, no skipped words), complete to the last word, with the read-along highlight tracking it.

## Why it was broken

iOS mutes the **Web Audio API** when the hardware silent switch is on. The smooth desktop streaming path is Web-Audio-based, so it was gated off for iPhone (`!isIOS()`), and Live fell back to a buffered path that waited 10-40s — the dropoff problem in #554.

## The fix (2 files, ~42 lines)

- **`navigator.audioSession.type = 'playback'`** (Safari 16.4+) set inside the play gesture tells iOS to treat Web Audio as media playback, so it plays **through** the silent switch. Confirmed on a real iPhone (iOS 18.7): the Web Audio tone is silent without it, audible with it.
- With that, the **existing desktop streaming player is opened to iOS** (`togglePlay.js`). Same ~1s first sound, precise PCM scheduling (no live-edge underruns), and it already **caches** the audio so replays are instant and don't burn quota. Old iOS without the Audio Session API still falls back to buffered Live → REST (never silent).
- **`useTTSHighlight.js`**: snap the read-along to the final word on a natural end (distinguished from a user pause via `recordPause`), so it no longer freezes one word short when the duration estimate overshoots.

## What this replaced

An earlier HLS/ffmpeg approach (segment the Live PCM server-side, play via native `<audio>`). It worked but had structural issues on a near-real-time live stream — thin buffer → mid-poem underruns and word-skips — plus a heavy `ffmpeg-static` server dependency. The audioSession approach reuses the proven desktop path and has none of those problems. All of that detour (server routes, ffmpeg dep, probe page) is removed in this branch; net diff vs the base is just the two files above.

## Verified on device (iPhone, iOS 18.7, silent switch ON)
- Audible ✅, first sound ~1s ✅, no stutter/skip ✅, full poem incl. last word ✅, read-along reaches the last word ✅.

## Notes
- Stacked on #552 (base `fix/swipe-stop-playback`, which carries #553/#554). Retarget to `main` after #552 merges.

Refs #549, #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)