### PR TITLE
fix(pwa): force-clear stale precache so new releases reach open devices

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -106,6 +106,21 @@ async function checkForNewRelease() {
     // Guard against reload loops if the new bundle somehow still reports the old id.
     if (sessionStorage.getItem('reloaded-for-build') === buildId) return;
     sessionStorage.setItem('reloaded-for-build', buildId);
+    // A plain reload can still be served the OLD precached bundle by a stale
+    // service worker. Force past it: pull the new SW and drop the workbox
+    // precache (old hashed JS/CSS), so the reload fetches the fresh bundle.
+    try {
+      if ('serviceWorker' in navigator) {
+        const regs = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(regs.map((r) => r.update().catch(() => {})));
+      }
+      if (window.caches) {
+        const keys = await caches.keys();
+        await Promise.all(
+          keys.filter((k) => /workbox|precache|html-navigation/i.test(k)).map((k) => caches.delete(k))
+        );
+      }
+    } catch { /* best-effort — reload anyway */ }
     window.location.reload();
   } catch {
     /* offline or version.json missing (e.g. dev) — ignore */


### PR DESCRIPTION
## Problem

The app already polls `/version.json` and reloads open devices when a new build deploys (shipped with #554). But on a version mismatch it did a plain `window.location.reload()` — which a **stale service worker can still answer with the OLD precached bundle**, so the device reloads into the same old code. This is the iOS-Safari "refresh doesn't help" case: the SW keeps serving its precache.

## Fix

On detecting a new `buildId`, before reloading: pull the new service worker (`registration.update()`) and delete the workbox **precache + navigation cache**, so the reload actually fetches the fresh JS/CSS instead of the cached old bundle.

```js
// version mismatch →
await Promise.all(regs.map((r) => r.update()));
const keys = await caches.keys();
await Promise.all(keys.filter(k => /workbox|precache|html-navigation/i.test(k)).map(k => caches.delete(k)));
window.location.reload();
```

One file, `src/main.jsx`. Loop-guarded by the existing `sessionStorage` build marker.

## Effect

Every future deploy reliably reaches already-open devices, instead of depending on iOS to lazily swap the service worker. (The one-time transition for users still on a pre-`version.json` bundle is unaffected — those clients don't have the poll yet — but every release after they're current self-updates.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)