### PR TITLE
feat(tts): voice cycle pill next to Listen

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -48,6 +48,7 @@ import {
   CATEGORIES,
   FONTS,
   nextVoice,
+  voiceGender,
 } from './constants/index.js';
 import { usePoemStore } from './stores/poemStore';
 import { useAudioStore } from './stores/audioStore';
@@ -1768,7 +1769,10 @@ export default function DiwanApp() {
                   className={`min-h-[44px] flex items-center gap-1.5 pl-3 pr-3.5 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-xs font-medium tracking-wide hover:bg-white/10 active:scale-95 transition-all duration-150`}
                   style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
                 >
-                  <Mic size={16} className="opacity-70" />
+                  <Mic
+                    size={16}
+                    style={{ color: voiceGender(liveVoice) === 'f' ? '#c084fc' : '#60a5fa' }}
+                  />
                   {liveVoice}
                 </button>
               </div>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -15,6 +15,7 @@ import {
   X,
   Rabbit,
   Heart,
+  Mic,
 } from 'lucide-react';
 import { track } from '@vercel/analytics';
 import Sentry from './sentry.js';
@@ -46,6 +47,7 @@ import {
   GOLD,
   CATEGORIES,
   FONTS,
+  nextVoice,
 } from './constants/index.js';
 import { usePoemStore } from './stores/poemStore';
 import { useAudioStore } from './stores/audioStore';
@@ -227,6 +229,8 @@ export default function DiwanApp() {
   const audioError = useAudioStore((s) => s.error);
   const setAudioError = useAudioStore((s) => s.setError);
   const audioPlayer = useAudioStore((s) => s.player);
+  const liveVoice = useUIStore((s) => s.liveVoice);
+  const setLiveVoice = useUIStore((s) => s.setLiveVoice);
   const highlightStyle = useUIStore((s) => s.highlightStyle);
   const hasAutoLoaded = useRef(false);
   const longPressTimer = useRef(null);
@@ -930,6 +934,23 @@ export default function DiwanApp() {
 
   const togglePlay = () =>
     togglePlayAction({ audioRef, isTogglingPlay, current: displayedPoem, addLog, track });
+
+  // Cycle the reading voice (the pill next to Listen). Voice is part of the audio
+  // cache key, so the next play regenerates in the new voice on its own — we just
+  // drop any stale in-memory audio so the UI reflects the change immediately.
+  const cycleVoice = () => {
+    const next = nextVoice(liveVoice);
+    setLiveVoice(next);
+    const { player, resetAudio } = useAudioStore.getState();
+    if (player) {
+      try {
+        player.stop();
+      } catch {}
+    }
+    resetAudio();
+    addLog('Settings', `Voice → ${next}`, 'user');
+    track?.('voice_change', { voice: next });
+  };
 
   const handleAnalyze = () => {
     // When in carousel mode, record which poem we're explaining so the patching
@@ -1718,19 +1739,33 @@ export default function DiwanApp() {
                       onVerseChange={setCurrentVerseIndex}
                     />
                   ) : (
-                    <motion.button
+                    <motion.div
                       key="listen-trigger"
                       initial={{ opacity: 0, y: 8 }}
                       animate={{ opacity: 1, y: 0 }}
                       exit={{ opacity: 0, y: 8 }}
                       transition={{ duration: 0.2, ease: 'easeOut' }}
-                      onClick={togglePlay}
-                      aria-label="Start recitation"
-                      className={`px-6 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-sm font-medium tracking-wide hover:bg-white/10 transition-all duration-150`}
-                      style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
+                      className="flex items-center gap-2"
                     >
-                      Listen
-                    </motion.button>
+                      <button
+                        onClick={togglePlay}
+                        aria-label="Start recitation"
+                        className={`px-6 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-sm font-medium tracking-wide hover:bg-white/10 transition-all duration-150`}
+                        style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
+                      >
+                        Listen
+                      </button>
+                      <button
+                        onClick={cycleVoice}
+                        aria-label={`Reading voice: ${liveVoice}. Tap to change.`}
+                        title="Change reading voice"
+                        className={`flex items-center gap-1.5 pl-2.5 pr-3 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-xs font-medium tracking-wide hover:bg-white/10 transition-all duration-150`}
+                        style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
+                      >
+                        <Mic size={13} className="opacity-70" />
+                        {liveVoice}
+                      </button>
+                    </motion.div>
                   )}
                 </AnimatePresence>
               </div>

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -936,12 +936,15 @@ export default function DiwanApp() {
     togglePlayAction({ audioRef, isTogglingPlay, current: displayedPoem, addLog, track });
 
   // Cycle the reading voice (the pill next to Listen). Voice is part of the audio
-  // cache key, so the next play regenerates in the new voice on its own — we just
-  // drop any stale in-memory audio so the UI reflects the change immediately.
+  // cache key, so playback regenerates in the new voice. If audio is currently
+  // playing or generating, stop it and restart in the new voice so the change is
+  // immediate; otherwise just drop any stale in-memory audio.
   const cycleVoice = () => {
     const next = nextVoice(liveVoice);
     setLiveVoice(next);
-    const { player, resetAudio } = useAudioStore.getState();
+    const { isPlaying: playing, isGenerating, player, resetAudio } = useAudioStore.getState();
+    const wasActive = playing || isGenerating;
+    abortPlay(); // cancel any in-flight Live stream / generation
     if (player) {
       try {
         player.stop();
@@ -950,6 +953,8 @@ export default function DiwanApp() {
     resetAudio();
     addLog('Settings', `Voice → ${next}`, 'user');
     track?.('voice_change', { voice: next });
+    // Restart in the new voice once the reset has settled.
+    if (wasActive) setTimeout(() => togglePlay(), 0);
   };
 
   const handleAnalyze = () => {
@@ -1721,7 +1726,7 @@ export default function DiwanApp() {
           >
             {/* Highlight mode: Listen (one-shot) → PlayControlsStrip (exclusive) */}
             {highlightStyle !== 'none' && (
-              <div className="mb-2 flex justify-center">
+              <div className="mb-2 flex flex-wrap items-center justify-center gap-2">
                 <AnimatePresence mode="wait">
                   {isPlaying || isGeneratingAudio || audioPlayer !== null ? (
                     <PlayControlsStrip
@@ -1739,35 +1744,33 @@ export default function DiwanApp() {
                       onVerseChange={setCurrentVerseIndex}
                     />
                   ) : (
-                    <motion.div
+                    <motion.button
                       key="listen-trigger"
                       initial={{ opacity: 0, y: 8 }}
                       animate={{ opacity: 1, y: 0 }}
                       exit={{ opacity: 0, y: 8 }}
                       transition={{ duration: 0.2, ease: 'easeOut' }}
-                      className="flex items-center gap-2"
+                      onClick={togglePlay}
+                      aria-label="Start recitation"
+                      className={`min-h-[44px] px-6 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-sm font-medium tracking-wide hover:bg-white/10 active:scale-95 transition-all duration-150`}
+                      style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
                     >
-                      <button
-                        onClick={togglePlay}
-                        aria-label="Start recitation"
-                        className={`px-6 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-sm font-medium tracking-wide hover:bg-white/10 transition-all duration-150`}
-                        style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
-                      >
-                        Listen
-                      </button>
-                      <button
-                        onClick={cycleVoice}
-                        aria-label={`Reading voice: ${liveVoice}. Tap to change.`}
-                        title="Change reading voice"
-                        className={`flex items-center gap-1.5 pl-2.5 pr-3 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-xs font-medium tracking-wide hover:bg-white/10 transition-all duration-150`}
-                        style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
-                      >
-                        <Mic size={13} className="opacity-70" />
-                        {liveVoice}
-                      </button>
-                    </motion.div>
+                      Listen
+                    </motion.button>
                   )}
                 </AnimatePresence>
+                {/* Voice cycle pill — persistent so the voice can be changed mid-playback
+                    (tapping restarts in the new voice). 44px target per the design spec. */}
+                <button
+                  onClick={cycleVoice}
+                  aria-label={`Reading voice: ${liveVoice}. Tap to change.`}
+                  title="Change reading voice"
+                  className={`min-h-[44px] flex items-center gap-1.5 pl-3 pr-3.5 py-2 rounded-full border ${theme.border} ${DESIGN.glass} ${GOLD.goldText} font-brand-en text-xs font-medium tracking-wide hover:bg-white/10 active:scale-95 transition-all duration-150`}
+                  style={{ boxShadow: '0 4px 24px rgba(0,0,0,0.4)' }}
+                >
+                  <Mic size={16} className="opacity-70" />
+                  {liveVoice}
+                </button>
               </div>
             )}
             <div

--- a/src/components/DebugPanel.jsx
+++ b/src/components/DebugPanel.jsx
@@ -3,6 +3,7 @@ import { Bug, X, Copy, Check, Zap, Radio, Wifi } from 'lucide-react';
 import Sentry from '../sentry.js';
 import { FEATURES } from '../constants/features.js';
 import { THEME } from '../constants/theme.js';
+import { VOICE_CATALOG } from '../constants/voices.js';
 import { useUIStore, CATEGORY_MAP } from '../stores/uiStore';
 import { usePoemStore } from '../stores/poemStore';
 import { useAudioStore } from '../stores/audioStore';
@@ -344,22 +345,14 @@ const DebugPanel = ({ controlBarRef }) => {
                 style={{ background: 'rgba(251,146,60,0.1)', border: '1px solid rgba(251,146,60,0.3)', color: 'rgb(251,146,60)' }}
               >
                 <optgroup label="♀ Female">
-                  {[
-                    { n: 'Zephyr', d: 'Bright' }, { n: 'Kore', d: 'Firm' }, { n: 'Leda', d: 'Youthful' },
-                    { n: 'Aoede', d: 'Breezy' }, { n: 'Callirrhoe', d: 'Easy-going' }, { n: 'Autonoe', d: 'Bright' },
-                    { n: 'Despina', d: 'Smooth' }, { n: 'Erinome', d: 'Clear' }, { n: 'Laomedeia', d: 'Upbeat' },
-                    { n: 'Achernar', d: 'Soft' }, { n: 'Pulcherrima', d: 'Forward' }, { n: 'Achird', d: 'Friendly' },
-                    { n: 'Schedar', d: 'Even' }, { n: 'Vindemiatrix', d: 'Gentle' }, { n: 'Sulafat', d: 'Warm' },
-                  ].map(v => <option key={v.n} value={v.n}>{v.n} — {v.d}</option>)}
+                  {VOICE_CATALOG.filter((v) => v.gender === 'f').map((v) => (
+                    <option key={v.name} value={v.name}>{v.name} — {v.descriptor}</option>
+                  ))}
                 </optgroup>
                 <optgroup label="♂ Male">
-                  {[
-                    { n: 'Orus', d: 'Firm' }, { n: 'Puck', d: 'Upbeat' }, { n: 'Charon', d: 'Informative' },
-                    { n: 'Fenrir', d: 'Excitable' }, { n: 'Enceladus', d: 'Breathy' }, { n: 'Iapetus', d: 'Clear' },
-                    { n: 'Umbriel', d: 'Easy-going' }, { n: 'Algieba', d: 'Smooth' }, { n: 'Algenib', d: 'Gravelly' },
-                    { n: 'Rasalgethi', d: 'Informative' }, { n: 'Alnilam', d: 'Firm' }, { n: 'Gacrux', d: 'Mature' },
-                    { n: 'Zubenelgenubi', d: 'Casual' }, { n: 'Sadachbia', d: 'Lively' }, { n: 'Sadaltager', d: 'Knowledgeable' },
-                  ].map(v => <option key={v.n} value={v.n}>{v.n} — {v.d}</option>)}
+                  {VOICE_CATALOG.filter((v) => v.gender === 'm').map((v) => (
+                    <option key={v.name} value={v.name}>{v.name} — {v.descriptor}</option>
+                  ))}
                 </optgroup>
               </select>
             </div>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,4 +3,4 @@ export { DESIGN, BRAND, BRAND_HEADER, POEM_META } from './design.js';
 export { THEME, GOLD } from './theme.js';
 export { CATEGORIES } from './poets.js';
 export { FONTS } from './fonts.js';
-export { VOICE_SHORTLIST, DEFAULT_VOICE, nextVoice } from './voices.js';
+export { VOICE_CATALOG, DEFAULT_VOICE, nextVoice, voiceGender, voiceInfo } from './voices.js';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,3 +3,4 @@ export { DESIGN, BRAND, BRAND_HEADER, POEM_META } from './design.js';
 export { THEME, GOLD } from './theme.js';
 export { CATEGORIES } from './poets.js';
 export { FONTS } from './fonts.js';
+export { VOICE_SHORTLIST, DEFAULT_VOICE, nextVoice } from './voices.js';

--- a/src/constants/voices.js
+++ b/src/constants/voices.js
@@ -1,0 +1,29 @@
+/**
+ * Voice options for the one-tap voice cycle pill next to Listen.
+ *
+ * This is a curated shortlist — a few good Gemini prebuilt voices users can flip
+ * between without leaving the reading view. The full 30-voice list still lives in
+ * the DebugPanel for power users. Keep the shortlist small: the pill cycles in
+ * order, so 4 is about the most that feels like a "toggle" rather than a menu.
+ */
+export const VOICE_SHORTLIST = [
+  { name: 'Orus', descriptor: 'Firm' },
+  { name: 'Kore', descriptor: 'Firm' },
+  { name: 'Charon', descriptor: 'Informative' },
+  { name: 'Leda', descriptor: 'Youthful' },
+];
+
+/** The voice used until the listener picks another. First entry of the shortlist. */
+export const DEFAULT_VOICE = VOICE_SHORTLIST[0].name;
+
+/**
+ * Next voice in the cycle. A voice not in the shortlist (e.g. one set from the
+ * DebugPanel) restarts the cycle at the first entry, so the pill never gets stuck.
+ *
+ * @param {string} current - the currently selected voice name
+ * @returns {string} the next voice name
+ */
+export function nextVoice(current) {
+  const i = VOICE_SHORTLIST.findIndex((v) => v.name === current);
+  return VOICE_SHORTLIST[(i + 1) % VOICE_SHORTLIST.length].name;
+}

--- a/src/constants/voices.js
+++ b/src/constants/voices.js
@@ -1,29 +1,69 @@
 /**
- * Voice options for the one-tap voice cycle pill next to Listen.
+ * Voice catalog for the voice-cycle pill next to Listen.
  *
- * This is a curated shortlist — a few good Gemini prebuilt voices users can flip
- * between without leaving the reading view. The full 30-voice list still lives in
- * the DebugPanel for power users. Keep the shortlist small: the pill cycles in
- * order, so 4 is about the most that feels like a "toggle" rather than a menu.
+ * The full set of Gemini prebuilt voices, grouped female-first then male (same
+ * order as the DebugPanel picker). The pill cycles through every voice in this
+ * order, one per tap. Each entry carries a `gender` so the pill can tint its
+ * icon (female vs male) as a quick visual cue.
  */
-export const VOICE_SHORTLIST = [
-  { name: 'Orus', descriptor: 'Firm' },
-  { name: 'Kore', descriptor: 'Firm' },
-  { name: 'Charon', descriptor: 'Informative' },
-  { name: 'Leda', descriptor: 'Youthful' },
+export const VOICE_CATALOG = [
+  // Female
+  { name: 'Zephyr', descriptor: 'Bright', gender: 'f' },
+  { name: 'Kore', descriptor: 'Firm', gender: 'f' },
+  { name: 'Leda', descriptor: 'Youthful', gender: 'f' },
+  { name: 'Aoede', descriptor: 'Breezy', gender: 'f' },
+  { name: 'Callirrhoe', descriptor: 'Easy-going', gender: 'f' },
+  { name: 'Autonoe', descriptor: 'Bright', gender: 'f' },
+  { name: 'Despina', descriptor: 'Smooth', gender: 'f' },
+  { name: 'Erinome', descriptor: 'Clear', gender: 'f' },
+  { name: 'Laomedeia', descriptor: 'Upbeat', gender: 'f' },
+  { name: 'Achernar', descriptor: 'Soft', gender: 'f' },
+  { name: 'Pulcherrima', descriptor: 'Forward', gender: 'f' },
+  { name: 'Achird', descriptor: 'Friendly', gender: 'f' },
+  { name: 'Schedar', descriptor: 'Even', gender: 'f' },
+  { name: 'Vindemiatrix', descriptor: 'Gentle', gender: 'f' },
+  { name: 'Sulafat', descriptor: 'Warm', gender: 'f' },
+  // Male
+  { name: 'Orus', descriptor: 'Firm', gender: 'm' },
+  { name: 'Puck', descriptor: 'Upbeat', gender: 'm' },
+  { name: 'Charon', descriptor: 'Informative', gender: 'm' },
+  { name: 'Fenrir', descriptor: 'Excitable', gender: 'm' },
+  { name: 'Enceladus', descriptor: 'Breathy', gender: 'm' },
+  { name: 'Iapetus', descriptor: 'Clear', gender: 'm' },
+  { name: 'Umbriel', descriptor: 'Easy-going', gender: 'm' },
+  { name: 'Algieba', descriptor: 'Smooth', gender: 'm' },
+  { name: 'Algenib', descriptor: 'Gravelly', gender: 'm' },
+  { name: 'Rasalgethi', descriptor: 'Informative', gender: 'm' },
+  { name: 'Alnilam', descriptor: 'Firm', gender: 'm' },
+  { name: 'Gacrux', descriptor: 'Mature', gender: 'm' },
+  { name: 'Zubenelgenubi', descriptor: 'Casual', gender: 'm' },
+  { name: 'Sadachbia', descriptor: 'Lively', gender: 'm' },
+  { name: 'Sadaltager', descriptor: 'Knowledgeable', gender: 'm' },
 ];
 
-/** The voice used until the listener picks another. First entry of the shortlist. */
-export const DEFAULT_VOICE = VOICE_SHORTLIST[0].name;
+/** The voice used until the listener picks another. */
+export const DEFAULT_VOICE = 'Orus';
+
+const _byName = new Map(VOICE_CATALOG.map((v) => [v.name, v]));
+
+/** Full catalog entry for a voice name, or null if not in the catalog. */
+export function voiceInfo(name) {
+  return _byName.get(name) || null;
+}
+
+/** 'f' | 'm' for a voice name, or null if unknown. */
+export function voiceGender(name) {
+  return _byName.get(name)?.gender ?? null;
+}
 
 /**
- * Next voice in the cycle. A voice not in the shortlist (e.g. one set from the
- * DebugPanel) restarts the cycle at the first entry, so the pill never gets stuck.
+ * Next voice in the cycle. A voice not in the catalog restarts the cycle at the
+ * first entry, so the pill never gets stuck.
  *
  * @param {string} current - the currently selected voice name
  * @returns {string} the next voice name
  */
 export function nextVoice(current) {
-  const i = VOICE_SHORTLIST.findIndex((v) => v.name === current);
-  return VOICE_SHORTLIST[(i + 1) % VOICE_SHORTLIST.length].name;
+  const i = VOICE_CATALOG.findIndex((v) => v.name === current);
+  return VOICE_CATALOG[(i + 1) % VOICE_CATALOG.length].name;
 }

--- a/src/services/prefetch.js
+++ b/src/services/prefetch.js
@@ -59,9 +59,11 @@ export const prefetchManager = {
         return;
       }
 
-      // Check cache first - don't prefetch if already cached. Prefetch always uses
-      // the REST engine + default voice, so key the cache the same way playback does.
-      const audioKey = audioCacheKey(poemId, 'rest', TTS_CONFIG.voiceName);
+      // Check cache first - don't prefetch if already cached. Prefetch uses the REST
+      // engine and the listener's selected voice, so key the cache the same way
+      // playback does — otherwise a voice change would make every prefetch a miss.
+      const voiceName = useUIStore.getState().liveVoice;
+      const audioKey = audioCacheKey(poemId, 'rest', voiceName);
       const cached = await cacheOperations.get(CACHE_CONFIG.stores.audio, audioKey, addLog);
       if (cached?.blob) {
         if (addLog)
@@ -81,7 +83,7 @@ export const prefetchManager = {
           responseModalities: TTS_CONFIG.responseModalities,
           speechConfig: {
             voiceConfig: {
-              prebuiltVoiceConfig: { voiceName: TTS_CONFIG.voiceName },
+              prebuiltVoiceConfig: { voiceName },
             },
           },
         },

--- a/src/stores/actions/togglePlay.js
+++ b/src/stores/actions/togglePlay.js
@@ -341,8 +341,10 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
     // Same poem in a different voice/engine must regenerate, not replay stale audio.
     let ttsMode = useUIStore.getState().ttsMode;
     const { liveVoice, liveTemperature } = useUIStore.getState();
-    const keyFor = (mode) =>
-      audioCacheKey(current?.id, mode, mode === 'live' ? liveVoice : TTS_CONFIG.voiceName);
+    // Both engines use the listener's selected voice, so the cache key keys on it
+    // regardless of mode — switching voice (or engine) regenerates rather than
+    // replaying stale audio in the wrong voice.
+    const keyFor = (mode) => audioCacheKey(current?.id, mode, liveVoice);
 
     // CHECK CACHE
     if (FEATURES.caching && current?.id) {
@@ -629,7 +631,7 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
               generationConfig: {
                 responseModalities: TTS_CONFIG.responseModalities,
                 speechConfig: {
-                  voiceConfig: { prebuiltVoiceConfig: { voiceName: TTS_CONFIG.voiceName } },
+                  voiceConfig: { prebuiltVoiceConfig: { voiceName: liveVoice } },
                 },
               },
             });

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { FEATURES } from '../constants/features';
 import { THEME } from '../constants/theme';
 import { FONTS } from '../constants/fonts';
+import { DEFAULT_VOICE } from '../constants/voices';
 
 const MAX_LOGS = 200;
 
@@ -24,6 +25,22 @@ const persistTtsMode = (mode) => {
   } catch {}
 };
 
+// Selected speaking voice. Driven by the voice-cycle pill next to Listen (and the
+// DebugPanel picker). Remembered across reloads so a listener's choice sticks.
+const TTS_VOICE_KEY = 'tts-voice';
+const loadLiveVoice = () => {
+  try {
+    const v = localStorage.getItem(TTS_VOICE_KEY);
+    if (v) return v;
+  } catch {}
+  return DEFAULT_VOICE;
+};
+const persistLiveVoice = (voice) => {
+  try {
+    localStorage.setItem(TTS_VOICE_KEY, voice);
+  } catch {}
+};
+
 export const CATEGORY_MAP = {
   user: { color: '#00bcd4', prefix: 'USER' },
   request: { color: '#ff9800', prefix: '  →' },
@@ -42,7 +59,7 @@ const initialState = {
   showDebugLogs: FEATURES.debug,
   ratchetMode: false, // Ratchet Mode: explains poems in Gen Z / gangster slang
   ttsMode: loadTtsMode(), // 'rest' | 'live' — defaults to 'live' (streaming)
-  liveVoice: 'Orus',
+  liveVoice: loadLiveVoice(), // selected speaking voice, persisted (default DEFAULT_VOICE)
   liveTemperature: 0,
   highlightStyle: 'pill', // 'none' | 'glow' | 'underline' | 'pill' | 'focus-blur'
   logs: [],
@@ -75,7 +92,10 @@ export const useUIStore = create((set, get) => ({
     persistTtsMode(ttsMode);
     set({ ttsMode });
   },
-  setLiveVoice: (liveVoice) => set({ liveVoice }),
+  setLiveVoice: (liveVoice) => {
+    persistLiveVoice(liveVoice);
+    set({ liveVoice });
+  },
   setLiveTemperature: (liveTemperature) => set({ liveTemperature }),
   setHighlightStyle: (highlightStyle) => set({ highlightStyle }),
   setDarkMode: (darkMode) => set({ darkMode }),

--- a/src/test/voices.test.js
+++ b/src/test/voices.test.js
@@ -1,50 +1,63 @@
 import { describe, it, expect } from 'vitest';
-import { VOICE_SHORTLIST, DEFAULT_VOICE, nextVoice } from '../constants/voices.js';
+import { VOICE_CATALOG, DEFAULT_VOICE, nextVoice, voiceGender } from '../constants/voices.js';
 
-describe('voice shortlist', () => {
-  it('has at least two distinct voices to cycle between', () => {
-    expect(VOICE_SHORTLIST.length).toBeGreaterThanOrEqual(2);
-    const names = VOICE_SHORTLIST.map((v) => v.name);
-    expect(new Set(names).size).toBe(names.length); // no duplicates
+describe('voice catalog', () => {
+  it('has voices to cycle between with no duplicates', () => {
+    expect(VOICE_CATALOG.length).toBeGreaterThanOrEqual(2);
+    const names = VOICE_CATALOG.map((v) => v.name);
+    expect(new Set(names).size).toBe(names.length);
   });
 
-  it('every entry has a name and a descriptor', () => {
-    for (const v of VOICE_SHORTLIST) {
+  it('every entry has a name, descriptor, and a valid gender', () => {
+    for (const v of VOICE_CATALOG) {
       expect(typeof v.name).toBe('string');
       expect(v.name.length).toBeGreaterThan(0);
       expect(typeof v.descriptor).toBe('string');
       expect(v.descriptor.length).toBeGreaterThan(0);
+      expect(['f', 'm']).toContain(v.gender);
     }
   });
 
-  it('DEFAULT_VOICE is the first shortlist entry', () => {
-    expect(DEFAULT_VOICE).toBe(VOICE_SHORTLIST[0].name);
+  it('DEFAULT_VOICE is a real catalog entry', () => {
+    expect(VOICE_CATALOG.some((v) => v.name === DEFAULT_VOICE)).toBe(true);
+  });
+});
+
+describe('voiceGender', () => {
+  it('returns the gender for a known voice', () => {
+    expect(voiceGender('Kore')).toBe('f');
+    expect(voiceGender('Orus')).toBe('m');
+  });
+
+  it('returns null for an unknown voice', () => {
+    expect(voiceGender('NotAVoice')).toBeNull();
+    expect(voiceGender(undefined)).toBeNull();
   });
 });
 
 describe('nextVoice', () => {
-  it('advances to the next voice in order', () => {
-    for (let i = 0; i < VOICE_SHORTLIST.length - 1; i++) {
-      expect(nextVoice(VOICE_SHORTLIST[i].name)).toBe(VOICE_SHORTLIST[i + 1].name);
+  it('advances to the next voice in order, through the whole catalog', () => {
+    for (let i = 0; i < VOICE_CATALOG.length - 1; i++) {
+      expect(nextVoice(VOICE_CATALOG[i].name)).toBe(VOICE_CATALOG[i + 1].name);
     }
   });
 
   it('wraps around from the last voice to the first', () => {
-    const last = VOICE_SHORTLIST[VOICE_SHORTLIST.length - 1].name;
-    expect(nextVoice(last)).toBe(VOICE_SHORTLIST[0].name);
+    const last = VOICE_CATALOG[VOICE_CATALOG.length - 1].name;
+    expect(nextVoice(last)).toBe(VOICE_CATALOG[0].name);
   });
 
-  it('restarts the cycle for a voice not in the shortlist (e.g. a DebugPanel pick)', () => {
-    expect(nextVoice('Zephyr')).toBe(VOICE_SHORTLIST[0].name);
-    expect(nextVoice(undefined)).toBe(VOICE_SHORTLIST[0].name);
-    expect(nextVoice('')).toBe(VOICE_SHORTLIST[0].name);
+  it('restarts the cycle for a voice not in the catalog', () => {
+    expect(nextVoice('NotAVoice')).toBe(VOICE_CATALOG[0].name);
+    expect(nextVoice(undefined)).toBe(VOICE_CATALOG[0].name);
+    expect(nextVoice('')).toBe(VOICE_CATALOG[0].name);
   });
 
-  it('cycles through the entire shortlist and returns to the start', () => {
-    let voice = DEFAULT_VOICE;
-    for (let i = 0; i < VOICE_SHORTLIST.length; i++) {
+  it('cycles through the entire catalog and returns to the start', () => {
+    let voice = VOICE_CATALOG[0].name;
+    for (let i = 0; i < VOICE_CATALOG.length; i++) {
       voice = nextVoice(voice);
     }
-    expect(voice).toBe(DEFAULT_VOICE);
+    expect(voice).toBe(VOICE_CATALOG[0].name);
   });
 });

--- a/src/test/voices.test.js
+++ b/src/test/voices.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { VOICE_SHORTLIST, DEFAULT_VOICE, nextVoice } from '../constants/voices.js';
+
+describe('voice shortlist', () => {
+  it('has at least two distinct voices to cycle between', () => {
+    expect(VOICE_SHORTLIST.length).toBeGreaterThanOrEqual(2);
+    const names = VOICE_SHORTLIST.map((v) => v.name);
+    expect(new Set(names).size).toBe(names.length); // no duplicates
+  });
+
+  it('every entry has a name and a descriptor', () => {
+    for (const v of VOICE_SHORTLIST) {
+      expect(typeof v.name).toBe('string');
+      expect(v.name.length).toBeGreaterThan(0);
+      expect(typeof v.descriptor).toBe('string');
+      expect(v.descriptor.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('DEFAULT_VOICE is the first shortlist entry', () => {
+    expect(DEFAULT_VOICE).toBe(VOICE_SHORTLIST[0].name);
+  });
+});
+
+describe('nextVoice', () => {
+  it('advances to the next voice in order', () => {
+    for (let i = 0; i < VOICE_SHORTLIST.length - 1; i++) {
+      expect(nextVoice(VOICE_SHORTLIST[i].name)).toBe(VOICE_SHORTLIST[i + 1].name);
+    }
+  });
+
+  it('wraps around from the last voice to the first', () => {
+    const last = VOICE_SHORTLIST[VOICE_SHORTLIST.length - 1].name;
+    expect(nextVoice(last)).toBe(VOICE_SHORTLIST[0].name);
+  });
+
+  it('restarts the cycle for a voice not in the shortlist (e.g. a DebugPanel pick)', () => {
+    expect(nextVoice('Zephyr')).toBe(VOICE_SHORTLIST[0].name);
+    expect(nextVoice(undefined)).toBe(VOICE_SHORTLIST[0].name);
+    expect(nextVoice('')).toBe(VOICE_SHORTLIST[0].name);
+  });
+
+  it('cycles through the entire shortlist and returns to the start', () => {
+    let voice = DEFAULT_VOICE;
+    for (let i = 0; i < VOICE_SHORTLIST.length; i++) {
+      voice = nextVoice(voice);
+    }
+    expect(voice).toBe(DEFAULT_VOICE);
+  });
+});


### PR DESCRIPTION
## What

A one-tap **voice pill** beside the Listen trigger that cycles the reading voice through a curated shortlist: **Orus → Kore → Charon → Leda** (loops).

Before this, the only way to change the speaking voice was the DebugPanel's 30-voice dropdown — invisible to real users. And REST playback was hardcoded to `Fenrir`, so the picker only ever affected Live mode.

## Changes

- **`constants/voices.js`** (new) — curated shortlist + `nextVoice()` cycle helper (unknown/off-list voice restarts the cycle). Unit-tested.
- **`uiStore.js`** — the selected voice now **persists** across reloads (localStorage key `tts-voice`); was in-memory only.
- **`togglePlay.js` + `prefetch.js`** — both the audio cache key and the TTS request body use the selected voice, regardless of engine. Side effect: default REST voice changes from `Fenrir` to `Orus`, matching Live.
- **`app.jsx`** — pill renders next to the highlight-mode Listen trigger (🎙 + voice name), cycles on tap, drops stale in-memory audio so the next play regenerates in the new voice (the cache key already includes voice).

## Tests

- 7 new unit tests for `nextVoice` cycling + shortlist invariants — green.
- Full suite: same 6 pre-existing environmental failures as clean `main` (localStorage/server not available in bare local runs; pass in CI), **zero new failures**.
- Production build clean.

## Known follow-ups (in progress on this branch)

Per design review:
- **In-play cycling** — tapping the voice during playback should stop and restart in the new voice (currently the pill is hidden during playback).
- **Touch target** — bump the pill to the 44px minimum per the design spec (currently ~34px).
- Voice labels are Gemini codenames; readability is an open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)