### PR TITLE
fix(tts): mid-recitation engine/voice switch — abort generation, iOS silent play, accurate estimate

### DIFF
--- a/src/components/DebugPanel.jsx
+++ b/src/components/DebugPanel.jsx
@@ -8,6 +8,7 @@ import { useUIStore, CATEGORY_MAP } from '../stores/uiStore';
 import { usePoemStore } from '../stores/poemStore';
 import { useAudioStore } from '../stores/audioStore';
 import { API_MODELS } from '../services/gemini.js';
+import { abortPlay } from '../stores/actions/togglePlay.js';
 import { cacheOperations, CACHE_CONFIG } from '../services/cache.js';
 
 const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3001';
@@ -96,6 +97,24 @@ const DebugPanel = ({ controlBarRef }) => {
   }, [panelOpen, errorCount]);
   const unreadErrors = errorCount - lastViewedErrors.current;
 
+  // Stop playback and cancel any in-flight Live stream before switching engine or
+  // voice. abortPlay() invalidates the in-flight generation's playId so it releases
+  // the play guard (isTogglingPlay) and stops streaming. Without it, switching
+  // mid-recitation leaves an orphaned stream holding the guard, and the next play is
+  // rejected as "Play toggle already in progress" with no audio (#560, #558).
+  const stopAndResetAudio = () => {
+    abortPlay();
+    const { player, resetAudio } = useAudioStore.getState();
+    if (player) {
+      try {
+        player.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    resetAudio();
+  };
+
   const handleTtsModelToggle = async () => {
     const cycle = { pro: 'flash', flash: 'live', live: 'pro' };
     const next = cycle[ttsModel] || 'pro';
@@ -123,10 +142,8 @@ const DebugPanel = ({ controlBarRef }) => {
     if (poem?.id) {
       await cacheOperations.delete(CACHE_CONFIG.stores.audio, poem.id);
     }
-    // Reset audio state
-    const { player, resetAudio } = useAudioStore.getState();
-    if (player) try { player.stop(); } catch {}
-    resetAudio();
+    // Cancel any in-flight stream + reset, so the next play isn't blocked (#560).
+    stopAndResetAudio();
   };
 
   const handleSubmitBug = async () => {
@@ -329,17 +346,10 @@ const DebugPanel = ({ controlBarRef }) => {
                 onChange={(e) => {
                   useUIStore.getState().setLiveVoice(e.target.value);
                   useUIStore.getState().addLog('Settings', `Live voice → ${e.target.value}`, 'user');
-                  // Reset loaded audio so the next Listen regenerates in the new voice
-                  // (otherwise the resume-from-blob path would replay the old voice).
-                  const { player, resetAudio } = useAudioStore.getState();
-                  if (player) {
-                    try {
-                      player.stop();
-                    } catch {
-                      /* already stopped */
-                    }
-                  }
-                  resetAudio();
+                  // Cancel any in-flight stream + reset loaded audio so the next Listen
+                  // regenerates in the new voice and isn't blocked as "already in
+                  // progress" (otherwise resume-from-blob replays the old voice) (#558).
+                  stopAndResetAudio();
                 }}
                 className="flex-1 text-[0.6rem] font-mono rounded px-1.5 py-0.5 cursor-pointer"
                 style={{ background: 'rgba(251,146,60,0.1)', border: '1px solid rgba(251,146,60,0.3)', color: 'rgb(251,146,60)' }}

--- a/src/stores/actions/togglePlay.js
+++ b/src/stores/actions/togglePlay.js
@@ -44,12 +44,21 @@ const TTS_LOADING_MESSAGES = [
 ];
 
 /**
- * Create a Sonner toast with a countdown timer for TTS generation.
- * Format: "Recitation ready in Xs" title, "Preparing N lines" description cycling with fun messages.
- * Returns { dismiss } function for cleanup. Auto-dismisses if isGenerating
- * goes false externally (e.g. poem navigation).
+ * Create a Sonner toast for TTS generation.
+ *
+ * Two shapes:
+ *  - countdown (default): "Recitation ready in Xs" ticking down to "Almost ready...".
+ *    Right for REST and buffered paths, which must generate the whole clip before
+ *    playback, so the wait is real and roughly predictable (~0.06 s/char).
+ *  - indeterminate: "Starting recitation…" with no number. Right for the Live stream,
+ *    which plays its first words in ~1s — there's no meaningful countdown, and the
+ *    first-sound handler dismisses it. Showing a full-generation countdown there
+ *    (e.g. "ready in 59s") was just wrong.
+ *
+ * Returns { dismiss } for cleanup. Auto-dismisses if isGenerating goes false
+ * externally (e.g. poem navigation).
  */
-function createProgressToast(estimatedSeconds, arabicText) {
+function createProgressToast(estimatedSeconds, arabicText, { indeterminate = false } = {}) {
   const toastId = `tts-progress-${Date.now()}`;
   const startTime = Date.now();
   const lineCount = arabicText ? arabicText.split('\n').filter((l) => l.trim()).length : 0;
@@ -58,18 +67,23 @@ function createProgressToast(estimatedSeconds, arabicText) {
       ? `Preparing ${lineCount} line${lineCount !== 1 ? 's' : ''}`
       : 'Preparing recitation';
 
-  toast.loading(`Recitation ready in ${estimatedSeconds}s`, {
-    id: toastId,
-    description: lineInfo,
-    duration: Infinity,
-    icon: createElement(
+  const bounceIcon = () =>
+    createElement(
       motion.div,
       {
         animate: { y: [0, -5, 0] },
         transition: { repeat: Infinity, duration: 0.55, ease: 'easeInOut' },
       },
       createElement(Rabbit, { size: 16 })
-    ),
+    );
+
+  const STARTING = 'Starting recitation…';
+
+  toast.loading(indeterminate ? STARTING : `Recitation ready in ${estimatedSeconds}s`, {
+    id: toastId,
+    description: lineInfo,
+    duration: Infinity,
+    icon: bounceIcon(),
   });
 
   const interval = setInterval(() => {
@@ -81,39 +95,22 @@ function createProgressToast(estimatedSeconds, arabicText) {
     }
 
     const elapsed = Math.floor((Date.now() - startTime) / 1000);
-    const remaining = estimatedSeconds - elapsed;
-    const msgIndex = Math.floor(elapsed / 5) % TTS_LOADING_MESSAGES.length;
-    const subtitle = TTS_LOADING_MESSAGES[msgIndex];
+    const subtitle = TTS_LOADING_MESSAGES[Math.floor(elapsed / 5) % TTS_LOADING_MESSAGES.length];
 
-    if (remaining > 0) {
-      toast.loading(`Recitation ready in ${remaining}s`, {
-        id: toastId,
-        description: subtitle,
-        duration: Infinity,
-        icon: createElement(
-          motion.div,
-          {
-            animate: { y: [0, -5, 0] },
-            transition: { repeat: Infinity, duration: 0.55, ease: 'easeInOut' },
-          },
-          createElement(Rabbit, { size: 16 })
-        ),
-      });
+    let label;
+    if (indeterminate) {
+      label = STARTING;
     } else {
-      toast.loading('Almost ready...', {
-        id: toastId,
-        description: subtitle,
-        duration: Infinity,
-        icon: createElement(
-          motion.div,
-          {
-            animate: { y: [0, -5, 0] },
-            transition: { repeat: Infinity, duration: 0.55, ease: 'easeInOut' },
-          },
-          createElement(Rabbit, { size: 16 })
-        ),
-      });
+      const remaining = estimatedSeconds - elapsed;
+      label = remaining > 0 ? `Recitation ready in ${remaining}s` : 'Almost ready...';
     }
+
+    toast.loading(label, {
+      id: toastId,
+      description: subtitle,
+      duration: Infinity,
+      icon: bounceIcon(),
+    });
   }, 1000);
 
   let dismissed = false;
@@ -484,12 +481,23 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
     );
     setError(null);
 
-    // Show progress toast with estimated countdown
+    // Progress toast. Live streams first sound in ~1s, so it gets an indeterminate
+    // "Starting recitation…" (dismissed on first sound) instead of a misleading
+    // full-generation countdown. REST / buffered must generate the whole clip first,
+    // so they get the real countdown. If Live falls back to REST below, the toast is
+    // swapped for a countdown at that point.
+    const willStream =
+      ttsMode === 'live' &&
+      (!isIOS() || (typeof navigator !== 'undefined' && 'audioSession' in navigator));
     const estSeconds = estimateTTSSeconds(arabicTextChars);
-    const progress = createProgressToast(estSeconds, current?.arabic);
+    let progress = willStream
+      ? createProgressToast(0, current?.arabic, { indeterminate: true })
+      : createProgressToast(estSeconds, current?.arabic);
     addLog(
       'Audio',
-      `Estimated generation time: ~${estSeconds}s for ${arabicTextChars} Arabic chars`,
+      willStream
+        ? 'Live streaming — first sound expected in ~1s'
+        : `Estimated generation time: ~${estSeconds}s for ${arabicTextChars} Arabic chars`,
       'info'
     );
 
@@ -504,7 +512,7 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
       // gesture set navigator.audioSession.type='playback' above, so Web Audio
       // plays through the hardware silent switch (verified on device). Old iOS
       // without the Audio Session API falls through to the HLS/buffered path below.
-      if (ttsMode === 'live' && (!isIOS() || (typeof navigator !== 'undefined' && 'audioSession' in navigator))) {
+      if (willStream) {
         try {
           const liveText = getLiveContent(current);
           addLog(
@@ -625,6 +633,14 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
           );
           ttsMode = 'rest';
         }
+      }
+
+      // Live streaming was attempted but yielded no audio (we're now in the buffered
+      // path, which generates the whole clip before playback). Swap the indeterminate
+      // "Starting…" toast for an accurate countdown on that real wait.
+      if (willStream && !b64) {
+        progress.dismiss();
+        progress = createProgressToast(estSeconds, current?.arabic);
       }
 
       // ── Try selected mode first; on any failure (429, 404, network, etc.)

--- a/src/stores/actions/togglePlay.js
+++ b/src/stores/actions/togglePlay.js
@@ -140,6 +140,12 @@ let _currentPlayId = 0;
  * background (orphaned audio + wasted quota).
  */
 let _currentStreamAbort = null;
+// Buffered (non-streaming) generation fetch in flight — the REST generateContent
+// call and the buffered Live fallback. Held at module scope so abortPlay() can
+// cancel it. Without this, a long REST generation (~30s) kept the play guard held,
+// so switching engine/voice mid-buffer rejected the next play as "already in
+// progress" until the fetch finished (#560, #562, #563).
+let _currentGenAbort = null;
 function abortCurrentStream() {
   if (_currentStreamAbort) {
     try {
@@ -149,12 +155,21 @@ function abortCurrentStream() {
     }
     _currentStreamAbort = null;
   }
+  if (_currentGenAbort) {
+    try {
+      _currentGenAbort.abort();
+    } catch {
+      /* already aborted */
+    }
+    _currentGenAbort = null;
+  }
 }
 
 /**
  * Invalidate any in-flight togglePlay so it won't start playback after a swipe,
- * and cancel any streaming session in flight.
- * Call this alongside resetAudio() in the carousel swipe handlers.
+ * and cancel any streaming OR buffered generation in flight.
+ * Call this alongside resetAudio() in the carousel swipe handlers, and when
+ * switching engine/voice mid-recitation.
  */
 export function abortPlay() {
   _currentPlayId++;
@@ -651,6 +666,13 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
       const MODES = ttsMode === 'live' ? ['live', 'rest'] : ['rest', 'live'];
       let modeIdx = 0;
 
+      // One abort controller for whichever buffered fetch runs, held at module scope
+      // so abortPlay() (engine/voice switch, swipe) can cancel it and release the
+      // play guard promptly — instead of waiting out a ~30s generation (#562, #563).
+      const genAbort = new AbortController();
+      _currentGenAbort = genAbort;
+      const genTimeoutId = setTimeout(() => genAbort.abort(), 120_000);
+
       while (modeIdx < MODES.length && !b64) {
         const mode = MODES[modeIdx];
         ttsModel = mode === 'live' ? 'Live 3.1' : API_MODELS.tts;
@@ -668,6 +690,7 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
             const liveRes = await fetch(`${apiUrl}/api/ai/live-tts`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
+              signal: genAbort.signal,
               body: JSON.stringify({
                 text: liveText,
                 voiceName: liveVoice,
@@ -726,23 +749,16 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
               },
             });
             const url = `${apiUrl}/api/ai/${API_MODELS.tts}/generateContent`;
-            const ttsAbortController = new AbortController();
-            const ttsTimeoutId = setTimeout(() => ttsAbortController.abort(), 120_000);
-            let fallbackResult;
-            try {
-              fallbackResult = await fetchTTSWithFallback(
-                url,
-                {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: requestBody,
-                  signal: ttsAbortController.signal,
-                },
-                { addLog, label: 'Audio API' }
-              );
-            } finally {
-              clearTimeout(ttsTimeoutId);
-            }
+            const fallbackResult = await fetchTTSWithFallback(
+              url,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: requestBody,
+                signal: genAbort.signal,
+              },
+              { addLog, label: 'Audio API' }
+            );
             const res = fallbackResult.res;
             ttsModel = fallbackResult.model;
 
@@ -773,10 +789,23 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
             addLog('Audio API', `[${ttsModel}] Success via REST API`, 'success');
           }
         } catch (modeError) {
+          // Superseded by a newer play / engine or voice switch — abortPlay() bumped
+          // the play id and aborted the fetch. Stop entirely; don't try the next mode.
+          if (_currentPlayId !== playId) break;
           addLog('Audio API', `[${ttsModel}] ${modeError.message} — trying next mode`, 'warning');
           modeIdx++; // try the other mode
-          // Reset ttsModel label for the next attempt
         }
+      }
+
+      clearTimeout(genTimeoutId);
+      if (_currentGenAbort === genAbort) _currentGenAbort = null;
+
+      // Superseded mid-generation (engine/voice switch or swipe aborted the fetch) —
+      // bail quietly. The finally releases the play guard, so the next play works
+      // immediately instead of being rejected as "already in progress" (#562, #563).
+      if (_currentPlayId !== playId) {
+        progress.dismiss();
+        return;
       }
 
       const apiTime = performance.now() - apiStart;

--- a/src/stores/actions/togglePlay.js
+++ b/src/stores/actions/togglePlay.js
@@ -194,29 +194,99 @@ const isIOS = () =>
  * The word-highlight system uses wall-clock time, not AudioContext.currentTime, so
  * it works identically with this player.
  */
+// iOS only lets an <audio> element be played programmatically once it has had
+// play() called on it inside a user gesture. The REST path builds its player AFTER
+// the multi-second TTS generation await — long past the gesture — so the first
+// play()'s NotAllowedError was swallowed and nothing sounded, while the wall-clock
+// read-along still advanced (so it LOOKED like it was playing). A pause+play then
+// worked because that ran in a fresh gesture.
+//
+// Fix: keep ONE <audio> element, bless it with a silent clip inside the play
+// gesture (unlockIOSAudioElement, called before generation), and reuse that same
+// blessed element for playback. iOS keeps the element user-activated for its
+// lifetime, so the later programmatic play() after generation is allowed.
+let _iosAudioEl = null;
+let _iosSilentUrl = null;
+
+function getIOSAudioEl() {
+  if (!_iosAudioEl) {
+    const a = document.createElement('audio');
+    a.setAttribute('playsinline', '');
+    a.preload = 'auto';
+    _iosAudioEl = a;
+  }
+  return _iosAudioEl;
+}
+
+function iosSilentUrl() {
+  if (_iosSilentUrl) return _iosSilentUrl;
+  try {
+    // ~50ms of silence (zeroed PCM16 @ 24kHz) wrapped as a WAV blob.
+    const b64 = btoa(String.fromCharCode.apply(null, new Uint8Array(2400)));
+    const blob = pcm16ToWav(b64);
+    if (blob) _iosSilentUrl = URL.createObjectURL(blob);
+  } catch {
+    /* leave null — unlock becomes a best-effort no-op */
+  }
+  return _iosSilentUrl;
+}
+
+/** Bless the reusable iOS <audio> element inside a user gesture. No-op off iOS. */
+function unlockIOSAudioElement() {
+  if (!isIOS()) return;
+  const a = getIOSAudioEl();
+  const silent = iosSilentUrl();
+  if (!silent) return;
+  try {
+    a.muted = true;
+    a.src = silent;
+    const settle = () => {
+      try {
+        a.pause();
+        a.currentTime = 0;
+      } catch {
+        /* ignore */
+      }
+      a.muted = false;
+    };
+    const p = a.play();
+    if (p && typeof p.then === 'function') p.then(settle).catch(settle);
+    else settle();
+  } catch {
+    a.muted = false;
+  }
+}
+
 function createHTMLAudioPlayer(url) {
   return new Promise((resolve) => {
-    const audio = document.createElement('audio');
-    audio.setAttribute('playsinline', '');
-    audio.preload = 'auto';
+    // Reuse the gesture-blessed element so play() after the generation await works.
+    const audio = getIOSAudioEl();
+    audio.muted = false;
     audio.src = url;
 
     const player = {
       onstop: null,
       start(_time, offset = 0) {
-        audio.currentTime = offset;
+        try {
+          audio.currentTime = offset;
+        } catch {
+          /* currentTime may throw before metadata loads */
+        }
         audio.play().catch(() => {});
       },
       stop() {
         audio.pause();
-        audio.currentTime = 0;
+        try {
+          audio.currentTime = 0;
+        } catch {
+          /* ignore */
+        }
         this.onstop?.();
       },
     };
 
-    audio.addEventListener('ended', () => {
-      player.onstop?.();
-    });
+    // Property assignment (not addEventListener) so reuse doesn't stack handlers.
+    audio.onended = () => player.onstop?.();
 
     // Blob URLs are local — loadeddata fires near-instantly. 500 ms timeout as a
     // safety net on older iOS where canplaythrough/loadeddata can be delayed.
@@ -328,6 +398,10 @@ export async function togglePlay({ audioRef, isTogglingPlay, current, addLog, tr
     try {
       if ('audioSession' in navigator) navigator.audioSession.type = 'playback';
     } catch { /* older iOS without the Audio Session API → buffered fallback still works */ }
+    // Bless the reusable <audio> element NOW, inside the gesture, so the REST
+    // path's play() after the generation await is allowed (otherwise silent first
+    // play; #...). Web Audio (Live) doesn't need this, but it's a cheap no-op there.
+    unlockIOSAudioElement();
   }
   // Unlock the AudioContext after the user gesture (now on iOS too).
   await toneStart();


### PR DESCRIPTION
Fixes #560, Fixes #558, Fixes #562, Fixes #563

Three related defects in the "switch engine/voice mid-recitation, then play" flow, plus an estimate accuracy fix. All surface on iPhone.

## 1. Next play rejected "already in progress" (#560, #558, #562, #563)

Switching the engine (Live ↔ flash/pro) or voice mid-recitation left the in-flight generation running. The orphaned generator held the play guard (`isTogglingPlay`), so the next play (even switching back to Live) was rejected with `Play toggle already in progress — skipping` and no audio.

Done in two parts:
- **Stream:** the DebugPanel engine toggle and voice dropdown now call `abortPlay()` first (shared `stopAndResetAudio()`), same as the voice pill's `cycleVoice`.
- **Buffered/REST:** the earlier fix only cancelled the SSE *stream*. A REST/buffered generation is a single long fetch (~30s, see #563 logs) that `abortPlay()` couldn't reach, so it kept the guard held until the fetch finished. Now the buffered generation's `AbortController` is held at module scope so `abortCurrentStream` (via `abortPlay`) cancels it; on abort the play id no longer matches, the generator breaks out (doesn't fall through to the next mode) and bails quietly, and the `finally` releases the guard immediately.

## 2. iOS REST first play silent (read-along moves, no sound)

On iOS the REST path built its `<audio>` element *after* the multi-second generation await — past the user gesture — so `play()` was silently rejected while the wall-clock read-along kept moving. Fix: bless one reusable `<audio>` element inside the gesture (before generation) and reuse it.

## 3. Recitation estimate wrong for Live

The "ready in Xs" countdown used the REST full-generation figure for every engine, so Live briefly flashed "ready in 59s" before dismissing at ~1s. Live now shows an indeterminate "Starting recitation…" (dismissed on first sound); REST keeps the real countdown; a Live→REST fallback swaps to a countdown.

## Verification

- Build clean; full unit suite shows the same 6 pre-existing environmental failures as clean `main`, zero new (505 passing).
- iOS-behavior changes (#1 buffered abort, #2) can't be device-tested from here. Please verify on iPhone: Live → switch to flash mid-play → press play → audio sounds immediately; switch engine/voice mid-buffer → next play works (no "already in progress"); switch back to Live → works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)