### PR TITLE
docs(skills): add professional-readme skill

### DIFF
--- a/.claude/skills/professional-readme/SKILL.md
+++ b/.claude/skills/professional-readme/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: professional-readme
+description: Produce a professional, product-grade README led by a custom brand-matched header banner. Researches ground truth from the codebase (no stale claims), extracts the project's visual identity, renders a reproducible header image, and writes an emoji-free, accurate README. Use when asked to redesign, professionalize, or create a README, or to make a repo "look like a real product".
+user_invocable: true
+---
+
+# Professional README
+
+Turn a repo's README into something that reads like a well-developed product: a custom
+brand-matched header banner, an accurate feature set drawn from the actual code, and clean,
+emoji-free prose. This skill encodes the principles and the hard-won gotchas from doing it well.
+
+## Invocation
+
+When the user runs `/professional-readme` (or asks to professionalize/redesign a README),
+execute the workflow below. Confirm two creative choices up front if unclear: the **header
+visual direction** and **how aggressively to trim non-product sections** (e.g. dev notes,
+raw TODO lists).
+
+## Guiding principles
+
+1. **Ground truth over the old README.** Existing READMEs drift. Treat the *code* as the
+   source of truth and verify every claim before writing it.
+2. **The banner is brand-matched, not stock.** Pull the real palette, fonts, and motifs from
+   the codebase so the header looks like it belongs to the product.
+3. **No emojis. No invented metrics.** Every number must be traceable to code, tests, or
+   config. If you can't verify it, don't claim it.
+4. **Reproducible artifacts.** The banner ships with its source + a render script so anyone
+   can regenerate it.
+
+## Step 1 — Establish ground truth
+
+Do not trust the current README's claims. Explore the codebase (launch parallel read-only
+explore agents when scope is uncertain) and pin down:
+
+- **Core entities / scale.** Real counts (records, users, items) — find where they actually
+  come from. Watch for figures that are *gated/filtered* vs *raw totals*; state the one users
+  actually experience and say so. Distinguish hardcoded constants from live values.
+- **Implemented features.** Walk components/routes/services/stores and list what genuinely
+  exists. Keep an explicit **"do NOT claim"** list of things that are stubbed, planned, or
+  removed.
+- **Tech stack.** Read `package.json` / lockfile / manifests for real versions and libraries
+  (state management, routing, build tool, test runners). Don't guess.
+- **Provenance & services.** Data sources, external APIs, auth providers, hosting.
+- **Live URLs.** Search code, configs, OG meta, CI for the deployed URL(s); verify they resolve.
+- **Voice / philosophy.** Mine prompts, comments, and copy for the product's intent — useful
+  for an honest "why this exists" section.
+
+Cross-check the final draft against `server`/backend code, `package.json`, and `src/` so
+nothing contradicts the codebase. **Verify external links resolve** (e.g. `curl -sI` for a
+200) before committing them.
+
+## Step 2 — Extract the visual identity
+
+From the codebase (design tokens, theme files, CSS variables, tailwind config, favicon,
+splash/onboarding components), capture:
+
+- **Palette** — exact hex values for primary/accent/background.
+- **Typography** — the brand display fonts (and where they're used).
+- **Motif/logo** — the icon, wordmark composition, any signature background (patterns,
+  gradients, generative art). Reuse the *actual* construction where feasible.
+
+## Step 3 — Build the custom header banner
+
+Render an HTML banner to PNG with the **pre-installed Chromium via playwright-core**. Use the
+templates in this skill's `assets/` as a starting point:
+
+- `assets/banner-template.html` — banner scaffold (palette vars, vendored `@font-face`,
+  wordmark, tagline, optional generative background). Adapt colors/fonts/motif to the project.
+- `assets/render-banner.mjs` — element-clip render script (see gotchas for *why* element-clip).
+
+Workflow:
+
+1. Adapt the template to the project's identity (Step 2). Keep a tagline and, optionally, a
+   short keyword triad that reflects the *experience*, not just properties.
+2. **Vendor the fonts.** Download the brand woff2 files and reference them locally via
+   `@font-face` so the render is reproducible offline (and survives proxies that block the
+   Google Fonts CSS endpoint). OFL/open fonts are fine to commit.
+3. Render: `node assets/render-banner.mjs` (after `npm install --no-save playwright-core`).
+   Output goes under `.github/assets/`.
+4. **Inspect the PNG visually** and iterate on sizing, balance, and legibility. The wordmark
+   should fill the banner; content should be vertically balanced with no dead/black band.
+5. Embed centered in the README:
+   `<p align="center"><img src="./.github/assets/<name>.png" alt="<Project> — <tagline>" width="100%"></p>`
+
+## Step 4 — Write the README
+
+Recommended structure (drop sections that don't apply):
+
+1. **Header banner** + centered title, one-line tagline, and a row of **shields.io badges**
+   (live demo, CI status, key stack, license *only if a LICENSE exists*). Image badges, not emojis.
+2. **Philosophy / why it exists** — short prose; the problem it solves.
+3. **Core domain** — the data/library/engine, with accurate scale and provenance.
+4. **Headline feature(s)** — give the standout capability its own section with detail.
+5. **Features** — grouped, scannable, only what's real.
+6. **Tech stack** — corrected versions and libraries.
+7. **Architecture** — concise; how the pieces fit.
+8. **Getting started** — install, configure (env table), run.
+9. **Testing**, **Deployment** — accurate commands and env-by-service tables.
+10. **Roadmap** — convert any raw TODO checklist to clean prose; cut dev-only notes.
+11. **Acknowledgements** — datasets, libraries, font/designers.
+
+Fix the project-structure tree to match the real layout.
+
+## Step 5 — Commit and open a PR
+
+- Conventional commit: `docs(readme): ...` (or `docs: ...`). Include co-author/session
+  trailers if the repo convention requires them.
+- Commit the README, the banner PNG, the banner source, the render script, and vendored fonts.
+  Do **not** commit `node_modules` (playwright-core is a `--no-save` dev-only dependency).
+- Push to a feature branch and open a PR. Don't merge unless asked.
+
+## Gotchas (the expensive lessons)
+
+- **GitHub caches README images (camo).** After you fix a banner, GitHub's image proxy keeps
+  serving the *old* image under the same URL — it looks like your fix didn't apply. **Bust the
+  cache by renaming the image file** (e.g. `header.png` → `header-banner.png`) and updating the
+  README `<img src>`. A query string on a relative repo path won't reliably bust it.
+- **Headless screenshots bleed the page body.** Driving raw Chromium with
+  `--window-size`/`--screenshot` can capture a viewport taller than your banner, so the body
+  shows through as a flat dark/black band at the bottom. **Screenshot the banner *element*
+  with a clip** (playwright-core `locator('#banner').screenshot(...)`) so output dimensions
+  always equal the element. The provided `render-banner.mjs` does this.
+- **Fonts over a proxy.** Sandboxed/proxied environments often fail TLS to Google Fonts inside
+  the browser. `curl` (which trusts the proxy CA) can still fetch the woff2 — download and
+  vendor them locally.
+- **Gated vs total counts.** If the product only serves a filtered subset, the headline number
+  should reflect what users actually see (and note the gating), not the raw table size.
+- **Don't over-trim shared features.** Removing a "mode" or surface doesn't necessarily remove
+  the capabilities layered on it — keep the ones that still apply, reframed correctly.
+- **Render at 2x.** Use `deviceScaleFactor: 2` so the banner stays crisp when GitHub scales it.

--- a/.claude/skills/professional-readme/assets/banner-template.html
+++ b/.claude/skills/professional-readme/assets/banner-template.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<!--
+  README header banner TEMPLATE.
+
+  Adapt to the project's identity:
+    1. Replace the palette variables with the repo's real tokens.
+    2. Vendor the brand fonts as woff2 next to this file and update @font-face.
+    3. Replace the wordmark, tagline, and (optional) keyword triad.
+    4. Swap or tune the generative background for the project's motif.
+
+  Render with render-banner.mjs (screenshots the #banner element at 2x).
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<style>
+  /* Vendor brand fonts locally so the render is reproducible offline. */
+  @font-face {
+    font-family: 'BrandDisplay';
+    font-weight: 700;
+    font-display: block;
+    src: url('./BrandDisplay.woff2') format('woff2');
+  }
+  @font-face {
+    font-family: 'BrandText';
+    font-weight: 400;
+    font-display: block;
+    src: url('./BrandText.woff2') format('woff2');
+  }
+  :root {
+    /* TODO: replace with the project's real tokens */
+    --accent: #c5a059;            /* primary brand / wordmark color */
+    --accent-foil: linear-gradient(135deg, #b8922e 0%, #c5a059 30%, #e2c67a 55%, #c5a059 75%, #a07d38 100%);
+    --brand: #2e5090;             /* secondary brand */
+    --brand-light: #4a7cc9;       /* pattern / glow */
+    --bg-top: #0e1018;
+    --bg-mid: #0c0c0e;
+    --bg-bottom: #08080a;         /* keep a darker grounding so it doesn't wash flat */
+    --cream: #d4d0c8;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { background: #000; }
+  #banner {
+    position: relative;
+    width: 1280px;
+    height: 400px;            /* tune so content fills with balanced margins */
+    overflow: hidden;
+    background:
+      radial-gradient(120% 135% at 50% -25%, rgba(46,80,144,0.42) 0%, rgba(30,58,110,0.16) 34%, rgba(12,12,14,0) 62%),
+      radial-gradient(85% 110% at 50% 122%, rgba(197,160,89,0.10) 0%, rgba(12,12,14,0) 58%),
+      linear-gradient(180deg, var(--bg-top) 0%, var(--bg-mid) 50%, var(--bg-bottom) 100%);
+    font-family: 'BrandText', serif;
+  }
+  /* Optional generative motif layer (swap path-builder in the script below). */
+  #pattern {
+    position: absolute; inset: 0;
+    -webkit-mask-image: radial-gradient(125% 130% at 50% 50%, transparent 0%, transparent 28%, rgba(0,0,0,0.7) 56%, #000 100%);
+    mask-image: radial-gradient(125% 130% at 50% 50%, transparent 0%, transparent 28%, rgba(0,0,0,0.7) 56%, #000 100%);
+  }
+  #banner::before, #banner::after {
+    content: ""; position: absolute; left: 0; right: 0; height: 1px;
+    background: linear-gradient(90deg, transparent 8%, rgba(197,160,89,0.55) 50%, transparent 92%);
+  }
+  #banner::before { top: 0; }  #banner::after { bottom: 0; }
+
+  #content {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    z-index: 2;
+  }
+  #wordmark { display: flex; align-items: center; gap: 1.15rem; line-height: 1; }
+  .display {
+    font-family: 'BrandDisplay', sans-serif; font-weight: 700; font-size: 7rem;
+    background: var(--accent-foil);
+    -webkit-background-clip: text; background-clip: text;
+    -webkit-text-fill-color: transparent; color: transparent;
+    filter: drop-shadow(0 0 40px rgba(197,160,89,0.30));
+    padding-bottom: 0.12em;
+  }
+  .subname { font-family: 'BrandText', serif; font-size: 6rem; letter-spacing: -0.03em; color: var(--cream); }
+  #rule {
+    width: 420px; height: 1px; margin: 1.7rem 0 1.25rem;
+    background: linear-gradient(90deg, transparent, rgba(197,160,89,0.35) 18%, var(--accent) 50%, rgba(197,160,89,0.35) 82%, transparent);
+  }
+  #tagline { font-family: 'BrandText', serif; font-size: 2.2rem; color: rgba(226,222,212,0.88); }
+  #triad {
+    margin-top: 1rem; font-family: 'BrandText', serif; font-size: 1.45rem;
+    letter-spacing: 0.32em; text-transform: uppercase; color: rgba(197,160,89,0.82);
+  }
+</style>
+</head>
+<body>
+  <div id="banner">
+    <svg id="pattern" viewBox="0 0 1280 400" preserveAspectRatio="xMidYMid slice" xmlns="http://www.w3.org/2000/svg"></svg>
+    <div id="content">
+      <div id="wordmark">
+        <span class="display">Brand</span>
+        <span class="subname">name</span>
+      </div>
+      <div id="rule"></div>
+      <div id="tagline">A one-line tagline that captures the experience</div>
+      <div id="triad">First &nbsp;&middot;&nbsp; Second &nbsp;&middot;&nbsp; Third</div>
+    </div>
+  </div>
+
+<script>
+/* Optional motif: a simple eightfold star (octagram {8/3}) tessellation in the
+   brand-light color. Replace with the project's own generative construction, or
+   delete the #pattern svg + this script for a clean gradient-only banner. */
+(function () {
+  const svg = document.getElementById('pattern');
+  if (!svg) return;
+  const W = 1280, H = 400, s = 96, R = s * 0.5, TAU = Math.PI * 2, segs = [];
+  const star = (cx, cy, rad) => {
+    const p = [];
+    for (let i = 0; i < 8; i++) { const a = (i / 8) * TAU - Math.PI / 8; p.push([cx + rad * Math.cos(a), cy + rad * Math.sin(a)]); }
+    let i = 0;
+    for (let k = 0; k < 8; k++) { const j = (i + 3) % 8; segs.push([...p[i], ...p[j]]); i = j; }
+  };
+  for (let r = -1; r < Math.ceil(H / s) + 1; r++)
+    for (let c = -1; c < Math.ceil(W / s) + 1; c++)
+      star(c * s + s / 2, r * s + s / 2, R * 0.92);
+  const d = segs.map(([x1, y1, x2, y2]) => `M${x1.toFixed(2)},${y1.toFixed(2)}L${x2.toFixed(2)},${y2.toFixed(2)}`).join('');
+  const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+  path.setAttribute('d', d);
+  path.setAttribute('fill', 'none');
+  path.setAttribute('stroke', '#4a7cc9');
+  path.setAttribute('stroke-width', '1');
+  path.setAttribute('stroke-opacity', '0.32');
+  svg.appendChild(path);
+})();
+</script>
+</body>
+</html>

--- a/.claude/skills/professional-readme/assets/render-banner.mjs
+++ b/.claude/skills/professional-readme/assets/render-banner.mjs
@@ -1,0 +1,43 @@
+// Generic README banner renderer.
+//
+// Renders an HTML banner to PNG using playwright-core driving a Chromium binary.
+// Screenshots the #banner ELEMENT (not the window) at 2x device scale, so the
+// output dimensions always match the banner exactly — this avoids the common bug
+// where raw `--window-size`/`--screenshot` captures a viewport taller than the
+// banner and the page body bleeds through as a dark band at the bottom.
+//
+// Setup (once):  npm install --no-save playwright-core
+// Usage:         node render-banner.mjs [input.html] [output.png]
+// Defaults:      input  = ./banner.source.html
+//                output = ./banner.png
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { chromium } from 'playwright-core';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const html = resolve(here, process.argv[2] || 'banner.source.html');
+const out = resolve(here, process.argv[3] || 'banner.png');
+
+// Locate a Chromium binary. Prefers Playwright's browser cache; falls back to
+// letting playwright-core resolve its own bundled browser if none is found.
+function findChrome() {
+  const root = process.env.PLAYWRIGHT_BROWSERS_PATH || '/opt/pw-browsers';
+  if (!existsSync(root)) return undefined;
+  const dir = readdirSync(root).find((d) => d.startsWith('chromium-'));
+  if (!dir) return undefined;
+  const bin = resolve(root, dir, 'chrome-linux', 'chrome');
+  return existsSync(bin) ? bin : undefined;
+}
+
+const executablePath = findChrome();
+const browser = await chromium.launch({
+  ...(executablePath ? { executablePath } : {}),
+  args: ['--no-sandbox', '--disable-gpu'],
+});
+const page = await browser.newPage({ deviceScaleFactor: 2 });
+await page.goto(pathToFileURL(html).href, { waitUntil: 'networkidle' });
+await page.evaluate(() => document.fonts.ready);
+await page.locator('#banner').screenshot({ path: out });
+await browser.close();
+console.log(`Rendered ${out}`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ VERCEL_TOKEN                    // For Vercel CLI
 
 **Agents:** `test-orchestrator`, `test-suite-maintainer`, `test-coverage-reviewer`, `ci-test-guardian`, `git-workflow-manager`, `worktree-manager`, `github-issue-manager`, `docs-sync-reviewer`, `ui-ux-reviewer`, `design-review-agent`, `design-sprint-lead`, `design-generator`, `design-reviewer`, `design-review-setup`, `scroll-animation-designer`
 
-**Skills (`.claude/skills/`):** `/design-sprint`, `/screenshot-audit`, `/commit-push`
+**Skills (`.claude/skills/`):** `/design-sprint`, `/screenshot-audit`, `/commit-push`, `/professional-readme`
 
 **Maintenance Rule -- MANDATORY when creating or modifying agents:**
 1. Update `.cursor/rules/agents.mdc` -- keep the Agent Registry table, coordination flow, and file list in sync


### PR DESCRIPTION
Adds a reusable `/professional-readme` skill that generalizes the workflow and principles from this repo's README redesign, so the same product-grade result is repeatable on any repo.

## What's included

- **`.claude/skills/professional-readme/SKILL.md`** — the playbook:
  - **Ground-truth research** — treat the code (not the old README) as source of truth; verify every claim; keep an explicit "do NOT claim" list; distinguish gated vs total counts.
  - **Visual-identity extraction** — pull the real palette, fonts, and motif from the codebase so the banner is brand-matched, not stock.
  - **Reproducible banner** — render HTML → PNG via the pre-installed Chromium.
  - **README structure** — banner + badges, philosophy, domain, headline feature, grouped features, stack, architecture, getting started, testing, deployment, roadmap, acknowledgements.
  - **Gotchas** — the expensive lessons: GitHub camo image caching (rename to bust), headless-screenshot body-bleed (screenshot the element with a clip), vendoring fonts past a proxy, gated vs total counts, render at 2x.
- **`assets/render-banner.mjs`** — reusable playwright-core element-clip renderer (smoke-tested).
- **`assets/banner-template.html`** — adaptable banner scaffold (palette vars, vendored `@font-face`, wordmark/tagline/triad, star-tessellation motif).
- Registered the skill in `CLAUDE.md`.

No application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_