### PR TITLE
chore(scripts): add render:banner script (smoke test for README Auto-Update)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e:full": "playwright test --config=playwright.config.full.js",
     "smoke": "node scripts/smoke-deploy.mjs",
     "screenshots": "node scripts/capture-design-screenshots.js",
+    "render:banner": "node .github/assets/render-header.mjs",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write 'src/**/*.{js,jsx,json,css}'",


### PR DESCRIPTION
A small, real, reversible change to **smoke-test the README Auto-Update workflow** (PR #591).

## The change

Adds one npm script:

```json
"render:banner": "node .github/assets/render-header.mjs"
```

So the README header can be regenerated with `npm run render:banner` instead of the raw node command. Genuinely useful and self-contained.

## How to use it as a test

1. Merge **#591** first (puts the `README Auto-Update` workflow on `main`).
2. Then merge **this PR**.
3. Merging this touches `package.json` (a non-ignored path), so the workflow should trigger and:
   - run Claude Code with the `/professional-readme` skill,
   - update `README.md` to mention the new `npm run render:banner` command,
   - prepend an entry to `readme_ci_changelog.md` (why + before → after),
   - open a rolling **`chore/readme-autoupdate`** PR for your review.

## What to verify

- The `README Auto-Update` workflow ran on this merge (Actions tab).
- A `chore/readme-autoupdate` PR was opened with a sensible README edit and a changelog entry referencing this commit.
- Merging that bot PR (touches only `README.md` + `readme_ci_changelog.md`) does **not** re-trigger the workflow.

If the agent decides no README change is warranted, no bot PR is opened — that's the efficient no-op path, also worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_