### PR TITLE
test(app): fix the one flaky Unit Tests failure (default-poem first render)

### DIFF
--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -16,13 +16,18 @@ import {
 // Mock Vaul so its Portal renders inline in jsdom (no real DOM portals)
 vi.mock('vaul', () => ({
   Drawer: {
-    Root: ({ children, open, ...props }) => open ? <div data-testid="drawer-root">{children}</div> : null,
+    Root: ({ children, open, ...props }) =>
+      open ? <div data-testid="drawer-root">{children}</div> : null,
     Portal: ({ children }) => <div>{children}</div>,
     Overlay: (props) => <div data-testid="drawer-overlay" {...props} />,
     Content: ({ children, ...props }) => <div data-testid="drawer-content">{children}</div>,
     Handle: (props) => <div data-testid="drawer-handle" {...props} />,
     Close: ({ children }) => children,
-    Title: ({ children, className, ...props }) => <h2 className={className} {...props}>{children}</h2>,
+    Title: ({ children, className, ...props }) => (
+      <h2 className={className} {...props}>
+        {children}
+      </h2>
+    ),
   },
 }));
 
@@ -72,14 +77,18 @@ describe('DiwanApp', () => {
   // ── Feature 1: Poem loads with correct structure ──────────────────────
 
   describe('Poem Structure', () => {
-    it('renders the default poem with Arabic text longer than 10 characters', () => {
+    it('renders the default poem with Arabic text longer than 10 characters', async () => {
+      // This is the first DiwanApp mount in the file; the poem's verses can paint a
+      // tick after mount, so mock the auto-load fetch and await the rtl verses rather
+      // than querying synchronously (which flaked only for this first-render case).
+      mockAutoLoadFetch();
       render(<DiwanApp />);
-      // The default poem's Arabic text is rendered across verse lines with dir="rtl"
-      const rtlElements = document.querySelectorAll('p[dir="rtl"]');
-      expect(rtlElements.length).toBeGreaterThan(0);
+      await waitFor(() =>
+        expect(document.querySelectorAll('p[dir="rtl"]').length).toBeGreaterThan(0)
+      );
 
       // Gather all Arabic verse text
-      const arabicText = Array.from(rtlElements)
+      const arabicText = Array.from(document.querySelectorAll('p[dir="rtl"]'))
         .map((el) => el.textContent)
         .join('');
       expect(arabicText.length).toBeGreaterThan(10);
@@ -338,9 +347,12 @@ describe('DiwanApp', () => {
         await userEvent.click(screen.getByLabelText('Discover new poem'));
 
         // Auto-explain pre-fetches insight in background; open overlay to view it
-        await waitFor(() => expect(screen.getByLabelText('Explain poem meaning')).toBeInTheDocument(), {
-          timeout: 5000,
-        });
+        await waitFor(
+          () => expect(screen.getByLabelText('Explain poem meaning')).toBeInTheDocument(),
+          {
+            timeout: 5000,
+          }
+        );
         await userEvent.click(screen.getByLabelText('Explain poem meaning'));
         await waitFor(
           () => {
@@ -1114,6 +1126,4 @@ describe('DiwanApp', () => {
       expect(screen.queryByLabelText(/Account menu/)).toBeNull();
     });
   });
-
 });
-


### PR DESCRIPTION
Fixes the single failing check that's been red on `main` and every PR: the **Unit Tests** job.

## Root cause

CI's Unit Tests output is precise — exactly one test fails:

```
FAIL src/test/App.test.jsx > DiwanApp > Poem Structure
  > renders the default poem with Arabic text longer than 10 characters
AssertionError: expected 0 to be greater than 0   (App.test.jsx:79)
Test Files  1 failed (36)
Tests  1 failed (41)
```

This is the **first `DiwanApp` mount in the file**. The poem's Arabic verses (`<p dir="rtl">`) can paint a tick after mount, but the test queried `querySelectorAll('p[dir="rtl"]')` **synchronously**, so on a cold first render it intermittently saw 0 elements. The sibling tests (`renders poem verses with dir="rtl"`, fonts, audio) pass in CI, so this was scoped to the first-render timing.

## Fix

Scoped to just that test: mock the mount-time auto-load fetch and `await` the verses via `waitFor` — the same pattern the other (passing) tests already use. No other tests touched.

## Verification

```
vitest run src/test/App.test.jsx -t "renders the default poem with Arabic text longer than 10 characters"
✓ renders the default poem with Arabic text longer than 10 characters
```

Note: I confirmed against the actual CI logs that this is the *only* test CI fails on (some tests fail in a local Node/deps environment but pass in CI; I deliberately left those untouched to avoid churning green tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_