### PR TITLE
feat(fonts): add Scheherazade New as a 9th Arabic typeface

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- Load fonts with display=swap for better performance -->
-    <link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Alexandria:wght@400;700&family=El+Messiri:wght@400;700&family=Lalezar&family=Rakkas&family=Fustat:wght@400;700&family=Kufam:wght@400;700&family=Katibeh&family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Forum&family=Reem+Kufi:wght@400;700&family=Bodoni+Moda:opsz,wght@6..96,400;6..96,500&family=IM+Fell+English:ital@0;1&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Alexandria:wght@400;700&family=El+Messiri:wght@400;700&family=Lalezar&family=Rakkas&family=Fustat:wght@400;700&family=Kufam:wght@400;700&family=Katibeh&family=Scheherazade+New:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Forum&family=Reem+Kufi:wght@400;700&family=Bodoni+Moda:opsz,wght@6..96,400;6..96,500&family=IM+Fell+English:ital@0;1&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/constants/fonts.js
+++ b/src/constants/fonts.js
@@ -7,5 +7,5 @@ export const FONTS = [
   { id: 'Fustat', label: 'Fustat', labelAr: 'فسطاط', family: 'font-fustat' },
   { id: 'Kufam', label: 'Kufam', labelAr: 'كوفام', family: 'font-kufam' },
   { id: 'Katibeh', label: 'Katibeh', labelAr: 'كاتبة', family: 'font-katibeh' },
-  { id: 'Scheherazade New', label: 'Scheherazade', labelAr: 'شهرزاد', family: 'font-scheherazade' },
+  { id: 'Scheherazade New', label: 'Scheherazade New', labelAr: 'شهرزاد', family: 'font-scheherazade' },
 ];

--- a/src/constants/fonts.js
+++ b/src/constants/fonts.js
@@ -7,4 +7,5 @@ export const FONTS = [
   { id: 'Fustat', label: 'Fustat', labelAr: 'فسطاط', family: 'font-fustat' },
   { id: 'Kufam', label: 'Kufam', labelAr: 'كوفام', family: 'font-kufam' },
   { id: 'Katibeh', label: 'Katibeh', labelAr: 'كاتبة', family: 'font-katibeh' },
+  { id: 'Scheherazade New', label: 'Scheherazade', labelAr: 'شهرزاد', family: 'font-scheherazade' },
 ];

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,8 +1,6 @@
 /* App-level utility styles extracted from inline <style> block in app.jsx */
 
-.arabic-shadow {
-  text-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-}
+.arabic-shadow { text-shadow: 0 4px 12px rgba(0,0,0,0.1); }
 
 .gold-foil-text {
   background: var(--gold-foil);
@@ -11,76 +9,35 @@
   background-clip: text;
   color: transparent;
 }
-.custom-scrollbar::-webkit-scrollbar {
-  width: 4px;
-}
-.custom-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--gold-structural);
-  border-radius: 10px;
-}
-.bg-radial-gradient {
-  background: radial-gradient(
-    circle,
-    var(--tw-gradient-from) 0%,
-    var(--tw-gradient-via) 50%,
-    var(--tw-gradient-to) 100%
-  );
-}
+.custom-scrollbar::-webkit-scrollbar { width: 4px; }
+.custom-scrollbar::-webkit-scrollbar-thumb { background: var(--gold-structural); border-radius: 10px; }
+.bg-radial-gradient { background: radial-gradient(circle, var(--tw-gradient-from) 0%, var(--tw-gradient-via) 50%, var(--tw-gradient-to) 100%); }
 
-.safe-bottom {
-  padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
-}
+.safe-bottom { padding-bottom: max(1.5rem, env(safe-area-inset-bottom)); }
 
-.font-amiri {
-  font-family: 'Amiri', serif;
-}
-.font-alexandria {
-  font-family: 'Alexandria', sans-serif;
-}
-.font-messiri {
-  font-family: 'El Messiri', sans-serif;
-}
-.font-lalezar {
-  font-family: 'Lalezar', cursive;
-}
-.font-rakkas {
-  font-family: 'Rakkas', cursive;
-}
-.font-fustat {
-  font-family: 'Fustat', serif;
-}
-.font-kufam {
-  font-family: 'Kufam', sans-serif;
-}
-.font-katibeh {
-  font-family: 'Katibeh', cursive;
-}
-.font-scheherazade {
-  font-family: 'Scheherazade New', serif;
-}
+.font-amiri { font-family: 'Amiri', serif; }
+.font-alexandria { font-family: 'Alexandria', sans-serif; }
+.font-messiri { font-family: 'El Messiri', sans-serif; }
+.font-lalezar { font-family: 'Lalezar', cursive; }
+.font-rakkas { font-family: 'Rakkas', cursive; }
+.font-fustat { font-family: 'Fustat', serif; }
+.font-kufam { font-family: 'Kufam', sans-serif; }
+.font-katibeh { font-family: 'Katibeh', cursive; }
+.font-scheherazade { font-family: 'Scheherazade New', serif; }
 
 .header-luminescence {
   text-shadow: 0 0 30px rgba(197, 160, 89, 0.3);
 }
 
+
 @keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 @keyframes fadeUp {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 .poem-meta-fade {
@@ -93,14 +50,8 @@
 
 /* English inline translation slides in left-to-right, one line at a time */
 @keyframes inlineFadeIn {
-  from {
-    opacity: 0;
-    transform: translateX(-12px);
-  }
-  to {
-    opacity: 0.6;
-    transform: translateX(0);
-  }
+  from { opacity: 0; transform: translateX(-12px); }
+  to   { opacity: 0.6; transform: translateX(0); }
 }
 
 .inline-fade-in {
@@ -140,185 +91,89 @@
 }
 
 @keyframes bounce {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-3px);
-  }
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
 }
 
 @keyframes discoverShuffle {
-  0% {
-    transform: rotate(0deg);
-  }
-  25% {
-    transform: rotate(-15deg);
-  }
-  75% {
-    transform: rotate(15deg);
-  }
-  100% {
-    transform: rotate(0deg);
-  }
+  0% { transform: rotate(0deg); }
+  25% { transform: rotate(-15deg); }
+  75% { transform: rotate(15deg); }
+  100% { transform: rotate(0deg); }
 }
 .discover-btn:hover .discover-icon {
   animation: discoverShuffle 0.5s ease-in-out;
 }
 
 @keyframes insightsDrawerIn {
-  from {
-    transform: translateY(100%);
-  }
-  to {
-    transform: translateY(0);
-  }
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
 }
 
 @keyframes poetPickerIn {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, 16px) scale(0.9);
-  }
-  60% {
-    opacity: 1;
-    transform: translate(-50%, -4px) scale(1.02);
-  }
-  100% {
-    opacity: 1;
-    transform: translate(-50%, 0) scale(1);
-  }
+  0%   { opacity: 0; transform: translate(-50%, 16px) scale(0.9); }
+  60%  { opacity: 1; transform: translate(-50%, -4px) scale(1.02); }
+  100% { opacity: 1; transform: translate(-50%, 0) scale(1); }
 }
 @keyframes poetPickerOut {
-  0% {
-    opacity: 1;
-    transform: translate(-50%, 0) scale(1);
-  }
-  40% {
-    opacity: 0.8;
-    transform: translate(-50%, -3px) scale(1.01);
-  }
-  100% {
-    opacity: 0;
-    transform: translate(-50%, 20px) scale(0.9);
-  }
+  0%   { opacity: 1; transform: translate(-50%, 0) scale(1); }
+  40%  { opacity: 0.8; transform: translate(-50%, -3px) scale(1.01); }
+  100% { opacity: 0; transform: translate(-50%, 20px) scale(0.9); }
 }
 
 @keyframes wave {
-  0%,
-  100% {
-    transform: scaleY(0.3);
-  }
-  50% {
-    transform: scaleY(1);
-  }
+  0%, 100% { transform: scaleY(0.3); }
+  50% { transform: scaleY(1); }
 }
 
 @keyframes shimmer {
-  0%,
-  100% {
-    opacity: 0.6;
-  }
-  50% {
-    opacity: 1;
-  }
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
 }
 
 @keyframes wave-organic-1 {
-  0% {
-    height: 10px;
-  }
-  25% {
-    height: 18px;
-  }
-  50% {
-    height: 24px;
-  }
-  75% {
-    height: 14px;
-  }
-  100% {
-    height: 10px;
-  }
+  0% { height: 10px; }
+  25% { height: 18px; }
+  50% { height: 24px; }
+  75% { height: 14px; }
+  100% { height: 10px; }
 }
 
 @keyframes wave-organic-2 {
-  0% {
-    height: 12px;
-  }
-  30% {
-    height: 20px;
-  }
-  60% {
-    height: 22px;
-  }
-  80% {
-    height: 16px;
-  }
-  100% {
-    height: 12px;
-  }
+  0% { height: 12px; }
+  30% { height: 20px; }
+  60% { height: 22px; }
+  80% { height: 16px; }
+  100% { height: 12px; }
 }
 
 @keyframes wave-organic-3 {
-  0% {
-    height: 14px;
-  }
-  20% {
-    height: 24px;
-  }
-  55% {
-    height: 18px;
-  }
-  85% {
-    height: 20px;
-  }
-  100% {
-    height: 14px;
-  }
+  0% { height: 14px; }
+  20% { height: 24px; }
+  55% { height: 18px; }
+  85% { height: 20px; }
+  100% { height: 14px; }
 }
 
 @keyframes wave-organic-4 {
-  0% {
-    height: 11px;
-  }
-  35% {
-    height: 19px;
-  }
-  65% {
-    height: 23px;
-  }
-  90% {
-    height: 15px;
-  }
-  100% {
-    height: 11px;
-  }
+  0% { height: 11px; }
+  35% { height: 19px; }
+  65% { height: 23px; }
+  90% { height: 15px; }
+  100% { height: 11px; }
 }
 
 @keyframes wave-organic-5 {
-  0% {
-    height: 10px;
-  }
-  28% {
-    height: 17px;
-  }
-  58% {
-    height: 21px;
-  }
-  88% {
-    height: 13px;
-  }
-  100% {
-    height: 10px;
-  }
+  0% { height: 10px; }
+  28% { height: 17px; }
+  58% { height: 21px; }
+  88% { height: 13px; }
+  100% { height: 10px; }
 }
 
 .volume-pulse-active .bar-with-glow {
-  box-shadow:
-    0 0 8px rgba(197, 160, 89, 0.6),
-    0 0 4px rgba(197, 160, 89, 0.4);
+  box-shadow: 0 0 8px rgba(197, 160, 89, 0.6),
+              0 0 4px rgba(197, 160, 89, 0.4);
 }
 
 .bar-with-glow {
@@ -326,44 +181,28 @@
 }
 
 @keyframes ratchetGlow {
-  0%,
-  100% {
-    box-shadow:
-      inset 0 0 80px rgba(249, 115, 22, 0.15),
-      inset 0 0 160px rgba(239, 68, 68, 0.08);
+  0%, 100% {
+    box-shadow: inset 0 0 80px rgba(249,115,22,0.15), inset 0 0 160px rgba(239,68,68,0.08);
   }
   50% {
-    box-shadow:
-      inset 0 0 120px rgba(249, 115, 22, 0.3),
-      inset 0 0 240px rgba(239, 68, 68, 0.18);
+    box-shadow: inset 0 0 120px rgba(249,115,22,0.3), inset 0 0 240px rgba(239,68,68,0.18);
   }
 }
 
 @keyframes fireTapFlash {
-  0% {
-    background: rgba(255, 140, 30, 0);
-    transform: scale(1);
-  }
-  20% {
-    background: rgba(255, 140, 30, 0.22);
-    transform: scale(1.1);
-  }
-  100% {
-    background: rgba(255, 140, 30, 0);
-    transform: scale(1);
-  }
+  0%   { background: rgba(255,140,30,0);    transform: scale(1); }
+  20%  { background: rgba(255,140,30,0.22); transform: scale(1.1); }
+  100% { background: rgba(255,140,30,0);    transform: scale(1); }
 }
-.fire-tap {
-  animation: fireTapFlash 0.42s ease-out forwards;
-}
+.fire-tap { animation: fireTapFlash 0.42s ease-out forwards; }
 
 /* ============================================
    Sonner toast overrides — gold glass design language
    ============================================ */
 
 [data-sonner-toaster] [data-sonner-toast] {
-  --normal-bg: rgba(12, 12, 14, 0.88);
-  --normal-border: rgba(197, 160, 89, 0.25);
+  --normal-bg: rgba(12,12,14,0.88);
+  --normal-border: rgba(197,160,89,0.25);
 }
 
 /* Default/success toast title in gold */
@@ -375,79 +214,50 @@
 
 /* Description text (poet name) in muted warm italic */
 [data-sonner-toast] [data-description] {
-  color: rgba(212, 200, 168, 0.88);
+  color: rgba(212,200,168,0.88);
   font-style: italic;
 }
 
 /* Error toast — subtle red accent, keep glass bg */
-[data-sonner-toast][data-type='error'] {
-  border-color: rgba(239, 68, 68, 0.3) !important;
+[data-sonner-toast][data-type="error"] {
+  border-color: rgba(239,68,68,0.3) !important;
 }
-[data-sonner-toast][data-type='error'] [data-title] {
+[data-sonner-toast][data-type="error"] [data-title] {
   color: #fca5a5;
 }
 
 /* Gold glow entrance animation */
-[data-sonner-toast][data-mounted='true'] {
+[data-sonner-toast][data-mounted="true"] {
   animation: toastGlow 0.6s ease-out;
 }
 
 @keyframes toastGlow {
-  0% {
-    box-shadow:
-      0 0 0 rgba(197, 160, 89, 0),
-      0 0 0 rgba(0, 0, 0, 0);
-  }
-  50% {
-    box-shadow:
-      0 0 20px rgba(197, 160, 89, 0.15),
-      0 4px 16px rgba(0, 0, 0, 0.4);
-  }
-  100% {
-    box-shadow:
-      0 0 40px rgba(197, 160, 89, 0.08),
-      0 8px 32px rgba(0, 0, 0, 0.6);
-  }
+  0%   { box-shadow: 0 0 0 rgba(197,160,89,0),    0 0  0 rgba(0,0,0,0); }
+  50%  { box-shadow: 0 0 20px rgba(197,160,89,0.15), 0 4px 16px rgba(0,0,0,0.4); }
+  100% { box-shadow: 0 0 40px rgba(197,160,89,0.08), 0 8px 32px rgba(0,0,0,0.6); }
 }
 
 /* Loading toast — subtle gold pulse on border */
-[data-sonner-toast][data-type='loading'] {
-  border-color: rgba(197, 160, 89, 0.35) !important;
-  animation:
-    toastGlow 0.6s ease-out,
-    loadingPulse 2s ease-in-out infinite 0.6s;
+[data-sonner-toast][data-type="loading"] {
+  border-color: rgba(197,160,89,0.35) !important;
+  animation: toastGlow 0.6s ease-out, loadingPulse 2s ease-in-out infinite 0.6s;
 }
 
 @keyframes loadingPulse {
-  0%,
-  100% {
-    border-color: rgba(197, 160, 89, 0.25);
-  }
-  50% {
-    border-color: rgba(197, 160, 89, 0.5);
-  }
+  0%, 100% { border-color: rgba(197,160,89,0.25); }
+  50% { border-color: rgba(197,160,89,0.5); }
 }
 
 /* Success toast — brief gold flash */
-[data-sonner-toast][data-type='success'] {
-  border-color: rgba(197, 160, 89, 0.5) !important;
+[data-sonner-toast][data-type="success"] {
+  border-color: rgba(197,160,89,0.5) !important;
 }
-[data-sonner-toast][data-type='success'] [data-title] {
+[data-sonner-toast][data-type="success"] [data-title] {
   color: var(--gold);
 }
 
-@keyframes breathe {
-  0%,
-  100% {
-    opacity: 0.35;
-  }
-  50% {
-    opacity: 0.8;
-  }
-}
-.font-fell {
-  font-family: 'IM Fell English', serif;
-}
+@keyframes breathe { 0%,100% { opacity: 0.35; } 50% { opacity: 0.8; } }
+.font-fell { font-family: 'IM Fell English', serif; }
 .gold-foil-text {
   background: var(--gold-foil);
   -webkit-background-clip: text;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,6 +1,8 @@
 /* App-level utility styles extracted from inline <style> block in app.jsx */
 
-.arabic-shadow { text-shadow: 0 4px 12px rgba(0,0,0,0.1); }
+.arabic-shadow {
+  text-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
 
 .gold-foil-text {
   background: var(--gold-foil);
@@ -9,34 +11,76 @@
   background-clip: text;
   color: transparent;
 }
-.custom-scrollbar::-webkit-scrollbar { width: 4px; }
-.custom-scrollbar::-webkit-scrollbar-thumb { background: var(--gold-structural); border-radius: 10px; }
-.bg-radial-gradient { background: radial-gradient(circle, var(--tw-gradient-from) 0%, var(--tw-gradient-via) 50%, var(--tw-gradient-to) 100%); }
+.custom-scrollbar::-webkit-scrollbar {
+  width: 4px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--gold-structural);
+  border-radius: 10px;
+}
+.bg-radial-gradient {
+  background: radial-gradient(
+    circle,
+    var(--tw-gradient-from) 0%,
+    var(--tw-gradient-via) 50%,
+    var(--tw-gradient-to) 100%
+  );
+}
 
-.safe-bottom { padding-bottom: max(1.5rem, env(safe-area-inset-bottom)); }
+.safe-bottom {
+  padding-bottom: max(1.5rem, env(safe-area-inset-bottom));
+}
 
-.font-amiri { font-family: 'Amiri', serif; }
-.font-alexandria { font-family: 'Alexandria', sans-serif; }
-.font-messiri { font-family: 'El Messiri', sans-serif; }
-.font-lalezar { font-family: 'Lalezar', cursive; }
-.font-rakkas { font-family: 'Rakkas', cursive; }
-.font-fustat { font-family: 'Fustat', serif; }
-.font-kufam { font-family: 'Kufam', sans-serif; }
-.font-katibeh { font-family: 'Katibeh', cursive; }
+.font-amiri {
+  font-family: 'Amiri', serif;
+}
+.font-alexandria {
+  font-family: 'Alexandria', sans-serif;
+}
+.font-messiri {
+  font-family: 'El Messiri', sans-serif;
+}
+.font-lalezar {
+  font-family: 'Lalezar', cursive;
+}
+.font-rakkas {
+  font-family: 'Rakkas', cursive;
+}
+.font-fustat {
+  font-family: 'Fustat', serif;
+}
+.font-kufam {
+  font-family: 'Kufam', sans-serif;
+}
+.font-katibeh {
+  font-family: 'Katibeh', cursive;
+}
+.font-scheherazade {
+  font-family: 'Scheherazade New', serif;
+}
 
 .header-luminescence {
   text-shadow: 0 0 30px rgba(197, 160, 89, 0.3);
 }
 
-
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .poem-meta-fade {
@@ -49,8 +93,14 @@
 
 /* English inline translation slides in left-to-right, one line at a time */
 @keyframes inlineFadeIn {
-  from { opacity: 0; transform: translateX(-12px); }
-  to   { opacity: 0.6; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+  to {
+    opacity: 0.6;
+    transform: translateX(0);
+  }
 }
 
 .inline-fade-in {
@@ -90,89 +140,185 @@
 }
 
 @keyframes bounce {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-3px); }
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-3px);
+  }
 }
 
 @keyframes discoverShuffle {
-  0% { transform: rotate(0deg); }
-  25% { transform: rotate(-15deg); }
-  75% { transform: rotate(15deg); }
-  100% { transform: rotate(0deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  25% {
+    transform: rotate(-15deg);
+  }
+  75% {
+    transform: rotate(15deg);
+  }
+  100% {
+    transform: rotate(0deg);
+  }
 }
 .discover-btn:hover .discover-icon {
   animation: discoverShuffle 0.5s ease-in-out;
 }
 
 @keyframes insightsDrawerIn {
-  from { transform: translateY(100%); }
-  to   { transform: translateY(0); }
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
 }
 
 @keyframes poetPickerIn {
-  0%   { opacity: 0; transform: translate(-50%, 16px) scale(0.9); }
-  60%  { opacity: 1; transform: translate(-50%, -4px) scale(1.02); }
-  100% { opacity: 1; transform: translate(-50%, 0) scale(1); }
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 16px) scale(0.9);
+  }
+  60% {
+    opacity: 1;
+    transform: translate(-50%, -4px) scale(1.02);
+  }
+  100% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
 }
 @keyframes poetPickerOut {
-  0%   { opacity: 1; transform: translate(-50%, 0) scale(1); }
-  40%  { opacity: 0.8; transform: translate(-50%, -3px) scale(1.01); }
-  100% { opacity: 0; transform: translate(-50%, 20px) scale(0.9); }
+  0% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+  40% {
+    opacity: 0.8;
+    transform: translate(-50%, -3px) scale(1.01);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, 20px) scale(0.9);
+  }
 }
 
 @keyframes wave {
-  0%, 100% { transform: scaleY(0.3); }
-  50% { transform: scaleY(1); }
+  0%,
+  100% {
+    transform: scaleY(0.3);
+  }
+  50% {
+    transform: scaleY(1);
+  }
 }
 
 @keyframes shimmer {
-  0%, 100% { opacity: 0.6; }
-  50% { opacity: 1; }
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 @keyframes wave-organic-1 {
-  0% { height: 10px; }
-  25% { height: 18px; }
-  50% { height: 24px; }
-  75% { height: 14px; }
-  100% { height: 10px; }
+  0% {
+    height: 10px;
+  }
+  25% {
+    height: 18px;
+  }
+  50% {
+    height: 24px;
+  }
+  75% {
+    height: 14px;
+  }
+  100% {
+    height: 10px;
+  }
 }
 
 @keyframes wave-organic-2 {
-  0% { height: 12px; }
-  30% { height: 20px; }
-  60% { height: 22px; }
-  80% { height: 16px; }
-  100% { height: 12px; }
+  0% {
+    height: 12px;
+  }
+  30% {
+    height: 20px;
+  }
+  60% {
+    height: 22px;
+  }
+  80% {
+    height: 16px;
+  }
+  100% {
+    height: 12px;
+  }
 }
 
 @keyframes wave-organic-3 {
-  0% { height: 14px; }
-  20% { height: 24px; }
-  55% { height: 18px; }
-  85% { height: 20px; }
-  100% { height: 14px; }
+  0% {
+    height: 14px;
+  }
+  20% {
+    height: 24px;
+  }
+  55% {
+    height: 18px;
+  }
+  85% {
+    height: 20px;
+  }
+  100% {
+    height: 14px;
+  }
 }
 
 @keyframes wave-organic-4 {
-  0% { height: 11px; }
-  35% { height: 19px; }
-  65% { height: 23px; }
-  90% { height: 15px; }
-  100% { height: 11px; }
+  0% {
+    height: 11px;
+  }
+  35% {
+    height: 19px;
+  }
+  65% {
+    height: 23px;
+  }
+  90% {
+    height: 15px;
+  }
+  100% {
+    height: 11px;
+  }
 }
 
 @keyframes wave-organic-5 {
-  0% { height: 10px; }
-  28% { height: 17px; }
-  58% { height: 21px; }
-  88% { height: 13px; }
-  100% { height: 10px; }
+  0% {
+    height: 10px;
+  }
+  28% {
+    height: 17px;
+  }
+  58% {
+    height: 21px;
+  }
+  88% {
+    height: 13px;
+  }
+  100% {
+    height: 10px;
+  }
 }
 
 .volume-pulse-active .bar-with-glow {
-  box-shadow: 0 0 8px rgba(197, 160, 89, 0.6),
-              0 0 4px rgba(197, 160, 89, 0.4);
+  box-shadow:
+    0 0 8px rgba(197, 160, 89, 0.6),
+    0 0 4px rgba(197, 160, 89, 0.4);
 }
 
 .bar-with-glow {
@@ -180,28 +326,44 @@
 }
 
 @keyframes ratchetGlow {
-  0%, 100% {
-    box-shadow: inset 0 0 80px rgba(249,115,22,0.15), inset 0 0 160px rgba(239,68,68,0.08);
+  0%,
+  100% {
+    box-shadow:
+      inset 0 0 80px rgba(249, 115, 22, 0.15),
+      inset 0 0 160px rgba(239, 68, 68, 0.08);
   }
   50% {
-    box-shadow: inset 0 0 120px rgba(249,115,22,0.3), inset 0 0 240px rgba(239,68,68,0.18);
+    box-shadow:
+      inset 0 0 120px rgba(249, 115, 22, 0.3),
+      inset 0 0 240px rgba(239, 68, 68, 0.18);
   }
 }
 
 @keyframes fireTapFlash {
-  0%   { background: rgba(255,140,30,0);    transform: scale(1); }
-  20%  { background: rgba(255,140,30,0.22); transform: scale(1.1); }
-  100% { background: rgba(255,140,30,0);    transform: scale(1); }
+  0% {
+    background: rgba(255, 140, 30, 0);
+    transform: scale(1);
+  }
+  20% {
+    background: rgba(255, 140, 30, 0.22);
+    transform: scale(1.1);
+  }
+  100% {
+    background: rgba(255, 140, 30, 0);
+    transform: scale(1);
+  }
 }
-.fire-tap { animation: fireTapFlash 0.42s ease-out forwards; }
+.fire-tap {
+  animation: fireTapFlash 0.42s ease-out forwards;
+}
 
 /* ============================================
    Sonner toast overrides — gold glass design language
    ============================================ */
 
 [data-sonner-toaster] [data-sonner-toast] {
-  --normal-bg: rgba(12,12,14,0.88);
-  --normal-border: rgba(197,160,89,0.25);
+  --normal-bg: rgba(12, 12, 14, 0.88);
+  --normal-border: rgba(197, 160, 89, 0.25);
 }
 
 /* Default/success toast title in gold */
@@ -213,50 +375,79 @@
 
 /* Description text (poet name) in muted warm italic */
 [data-sonner-toast] [data-description] {
-  color: rgba(212,200,168,0.88);
+  color: rgba(212, 200, 168, 0.88);
   font-style: italic;
 }
 
 /* Error toast — subtle red accent, keep glass bg */
-[data-sonner-toast][data-type="error"] {
-  border-color: rgba(239,68,68,0.3) !important;
+[data-sonner-toast][data-type='error'] {
+  border-color: rgba(239, 68, 68, 0.3) !important;
 }
-[data-sonner-toast][data-type="error"] [data-title] {
+[data-sonner-toast][data-type='error'] [data-title] {
   color: #fca5a5;
 }
 
 /* Gold glow entrance animation */
-[data-sonner-toast][data-mounted="true"] {
+[data-sonner-toast][data-mounted='true'] {
   animation: toastGlow 0.6s ease-out;
 }
 
 @keyframes toastGlow {
-  0%   { box-shadow: 0 0 0 rgba(197,160,89,0),    0 0  0 rgba(0,0,0,0); }
-  50%  { box-shadow: 0 0 20px rgba(197,160,89,0.15), 0 4px 16px rgba(0,0,0,0.4); }
-  100% { box-shadow: 0 0 40px rgba(197,160,89,0.08), 0 8px 32px rgba(0,0,0,0.6); }
+  0% {
+    box-shadow:
+      0 0 0 rgba(197, 160, 89, 0),
+      0 0 0 rgba(0, 0, 0, 0);
+  }
+  50% {
+    box-shadow:
+      0 0 20px rgba(197, 160, 89, 0.15),
+      0 4px 16px rgba(0, 0, 0, 0.4);
+  }
+  100% {
+    box-shadow:
+      0 0 40px rgba(197, 160, 89, 0.08),
+      0 8px 32px rgba(0, 0, 0, 0.6);
+  }
 }
 
 /* Loading toast — subtle gold pulse on border */
-[data-sonner-toast][data-type="loading"] {
-  border-color: rgba(197,160,89,0.35) !important;
-  animation: toastGlow 0.6s ease-out, loadingPulse 2s ease-in-out infinite 0.6s;
+[data-sonner-toast][data-type='loading'] {
+  border-color: rgba(197, 160, 89, 0.35) !important;
+  animation:
+    toastGlow 0.6s ease-out,
+    loadingPulse 2s ease-in-out infinite 0.6s;
 }
 
 @keyframes loadingPulse {
-  0%, 100% { border-color: rgba(197,160,89,0.25); }
-  50% { border-color: rgba(197,160,89,0.5); }
+  0%,
+  100% {
+    border-color: rgba(197, 160, 89, 0.25);
+  }
+  50% {
+    border-color: rgba(197, 160, 89, 0.5);
+  }
 }
 
 /* Success toast — brief gold flash */
-[data-sonner-toast][data-type="success"] {
-  border-color: rgba(197,160,89,0.5) !important;
+[data-sonner-toast][data-type='success'] {
+  border-color: rgba(197, 160, 89, 0.5) !important;
 }
-[data-sonner-toast][data-type="success"] [data-title] {
+[data-sonner-toast][data-type='success'] [data-title] {
   color: var(--gold);
 }
 
-@keyframes breathe { 0%,100% { opacity: 0.35; } 50% { opacity: 0.8; } }
-.font-fell { font-family: 'IM Fell English', serif; }
+@keyframes breathe {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+.font-fell {
+  font-family: 'IM Fell English', serif;
+}
 .gold-foil-text {
   background: var(--gold-foil);
   -webkit-background-clip: text;


### PR DESCRIPTION
Adds **Scheherazade New** to the Arabic font switcher, bringing the typeface count from 8 to 9.

## Why this font

Scheherazade New is designed by SIL specifically for **fully diacritized Arabic text** — it renders tashkeel (harakat) cleanly without clipping or collision. That makes it a natural fit for this app, whose poems are diacritized end to end.

## Changes

- **`src/constants/fonts.js`** — new entry: `{ id: 'Scheherazade New', label: 'Scheherazade', labelAr: 'شهرزاد', family: 'font-scheherazade' }`.
- **`src/styles/app.css`** — `.font-scheherazade { font-family: 'Scheherazade New', serif; }`.
- **`index.html`** — load `Scheherazade New` (weights 400;700) via the existing Google Fonts link.

It flows automatically into the font picker (which maps over `FONTS`), so no component changes are needed. Production build passes.

## Note

This is also the live test for the **README Auto-Update** workflow: it changes a documented feature (the README states "Eight Arabic typefaces (Amiri, … Katibeh)"), so merging it should trigger the workflow to open a `chore/readme-autoupdate` PR updating that line to nine and adding Scheherazade — with the rationale recorded in `readme_ci_changelog.md`.

Closes nothing — net-new enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_