### PR TITLE
test: repair unit suite so the CI gate passes without bail-masking

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,7 +29,20 @@ import WebSocket from 'ws';
 
 const { Pool } = pg;
 const app = express();
-const _labHtml = readFileSync(fileURLToPath(new URL('tts-lab.html', import.meta.url)), 'utf8');
+// TTS Lab HTML is a dev-only page. Load it lazily on first request and cache it, so a
+// missing/unreadable file — or a non-file import.meta.url (as under the test runner) —
+// never crashes server boot.
+let _labHtml = null;
+const loadLabHtml = () => {
+  if (_labHtml === null) {
+    try {
+      _labHtml = readFileSync(fileURLToPath(new URL('tts-lab.html', import.meta.url)), 'utf8');
+    } catch {
+      _labHtml = '';
+    }
+  }
+  return _labHtml;
+};
 const PORT = process.env.PORT || 3001;
 const LOG_ENABLED = process.env.LOG_ENABLED !== 'false'; // on by default
 const LOG_DEBUG = process.env.LOG_DEBUG === 'true'; // verbose DB debug, off by default
@@ -957,12 +970,14 @@ app.post('/api/ai/live-tts', async (req, res) => {
   const WS_MAX_STREAM = 180000;
   const WS_MAX_BUFFER = 90000;
 
-  if (!GEMINI_API_KEY) {
-    return res.status(503).json({ error: 'AI features unavailable: no API key configured' });
-  }
+  // Validate the request body before reporting backend availability so a malformed
+  // request always gets a 400 (not a 503 that hides the real problem).
   const { text, voiceName, systemInstruction, temperature } = req.body || {};
   if (!text || typeof text !== 'string' || !text.trim()) {
     return res.status(400).json({ error: 'Missing or empty "text" field' });
+  }
+  if (!GEMINI_API_KEY) {
+    return res.status(503).json({ error: 'AI features unavailable: no API key configured' });
   }
 
   const voice = voiceName || 'Fenrir';
@@ -1029,7 +1044,10 @@ app.post('/api/ai/live-tts', async (req, res) => {
     const resetIdle = () => {
       clearTimeout(idleTimer);
       idleTimer = setTimeout(() => {
-        log.error('Live TTS', `Idle ${WS_IDLE_TIMEOUT}ms, no new chunk (${ms()}) | ${chunkCount} chunks`);
+        log.error(
+          'Live TTS',
+          `Idle ${WS_IDLE_TIMEOUT}ms, no new chunk (${ms()}) | ${chunkCount} chunks`
+        );
         stop('idle', new Error('Live TTS stalled'));
       }, WS_IDLE_TIMEOUT);
     };
@@ -1131,8 +1149,14 @@ app.post('/api/ai/live-tts', async (req, res) => {
 
     ws.on('close', (code, reason) => {
       const reasonStr = reason?.toString() || '';
-      log.info('Live TTS', `WS closed (${ms()}) | code: ${code}${reasonStr ? ` | ${reasonStr}` : ''}`);
-      stop('ws-close', new Error(`WebSocket closed: code=${code}${reasonStr ? ` (${reasonStr})` : ''}`));
+      log.info(
+        'Live TTS',
+        `WS closed (${ms()}) | code: ${code}${reasonStr ? ` | ${reasonStr}` : ''}`
+      );
+      stop(
+        'ws-close',
+        new Error(`WebSocket closed: code=${code}${reasonStr ? ` (${reasonStr})` : ''}`)
+      );
     });
 
     return () => {
@@ -1164,7 +1188,10 @@ app.post('/api/ai/live-tts', async (req, res) => {
         sse({ meta: { sampleRate: 24000, mimeType: mime || 'audio/pcm;rate=24000' } }),
       onChunk: (b64) => sse({ chunk: b64 }),
       onDone: (reason, n) => {
-        log.info('Live TTS', `Stream done (${ms()}) | ${n} chunks | reason: ${reason} | voice: ${voice}`);
+        log.info(
+          'Live TTS',
+          `Stream done (${ms()}) | ${n} chunks | reason: ${reason} | voice: ${voice}`
+        );
         sse({ done: true, chunks: n, reason });
         try {
           res.end();
@@ -1191,7 +1218,8 @@ app.post('/api/ai/live-tts', async (req, res) => {
     onChunk: (b64) => chunks.push(b64),
     onDone: () => {
       if (!chunks.length) {
-        if (!res.headersSent) res.status(500).json({ error: 'No audio data received from Live API' });
+        if (!res.headersSent)
+          res.status(500).json({ error: 'No audio data received from Live API' });
         return;
       }
       // Decode each base64 chunk to binary, concat, re-encode. A plain string join
@@ -1232,7 +1260,7 @@ app.get('/tts-lab', (_req, res) => {
     'Content-Security-Policy',
     "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'; media-src blob:"
   );
-  res.type('html').send(_labHtml);
+  res.type('html').send(loadLabHtml());
 });
 
 app.get(

--- a/src/test/App.test.jsx
+++ b/src/test/App.test.jsx
@@ -99,17 +99,18 @@ describe('DiwanApp', () => {
       expect(document.body.textContent).toContain('Nizar Qabbani');
     });
 
-    it('renders tags for the default poem', () => {
-      render(<DiwanApp />);
-      expect(screen.getByText('Modern')).toBeInTheDocument();
-      expect(screen.getByText('Romantic')).toBeInTheDocument();
-      expect(screen.getByText('Ghazal')).toBeInTheDocument();
-    });
+    // NOTE: genre-tag chips ('Modern', 'Romantic', …) are no longer rendered in the
+    // main poem view. They lived in components/PoemCard.jsx, which app.jsx no longer
+    // mounts (verse rendering was inlined). The former "renders tags for the default
+    // poem" test asserted that removed UI and has been dropped accordingly.
 
-    it('renders poem verses with dir="rtl" attribute', () => {
+    it('renders poem verses with dir="rtl" attribute', async () => {
+      mockAutoLoadFetch();
       render(<DiwanApp />);
+      await waitFor(() =>
+        expect(document.querySelectorAll('p[dir="rtl"]').length).toBeGreaterThan(0)
+      );
       const rtlVerses = document.querySelectorAll('p[dir="rtl"]');
-      expect(rtlVerses.length).toBeGreaterThan(0);
       // Each verse line should have RTL direction
       rtlVerses.forEach((el) => {
         expect(el.getAttribute('dir')).toBe('rtl');
@@ -246,6 +247,10 @@ describe('DiwanApp', () => {
 
   describe('Audio Playback', () => {
     it('calls fetch when Play is clicked', async () => {
+      // Use the 'none' highlight mode so the control bar shows the single
+      // "Play recitation" button (the default 'pill' mode swaps in the
+      // PlayControlsStrip via AnimatePresence, whose label differs).
+      useUIStore.getState().setHighlightStyle('none');
       mockAutoLoadFetch();
       render(<DiwanApp />);
 
@@ -264,6 +269,7 @@ describe('DiwanApp', () => {
     });
 
     it('shows loading state when generating audio', async () => {
+      useUIStore.getState().setHighlightStyle('none');
       mockAutoLoadFetch();
       render(<DiwanApp />);
 
@@ -273,7 +279,6 @@ describe('DiwanApp', () => {
 
       // Replace fetch with a version that hangs for audio (TTS) calls
       // but resolves normally for everything else (auto-explain, streaming, etc.)
-      const originalMock = global.fetch;
       global.fetch = vi.fn((url) => {
         if (typeof url === 'string' && url.includes('/api/ai/gemini')) {
           // Gemini TTS / audio call — hang forever to keep loading state
@@ -283,19 +288,22 @@ describe('DiwanApp', () => {
         return Promise.resolve({ ok: true, body: null, json: async () => ({}) });
       });
 
-      const playBtn = screen.getByLabelText('Play recitation');
-      await userEvent.click(playBtn);
+      await userEvent.click(screen.getByLabelText('Play recitation'));
 
-      // The button should be disabled while generating
+      // While generating, the play button is replaced by the disabled
+      // "Preparing audio" loading control.
       await waitFor(() => {
-        expect(playBtn).toBeDisabled();
+        expect(screen.getByLabelText('Preparing audio')).toBeInTheDocument();
       });
+      expect(screen.getByLabelText('Preparing audio')).toBeDisabled();
     });
     it('iOS Safari audio unlock is handled by Tone.start() — no raw Audio mute/play/pause needed', async () => {
       // Tone.js now handles iOS Safari audio context unlock via Tone.start()
       // instead of the old mute/play/pause trick on a raw Audio element.
       // audioRef is useRef(null) — the Tone.Player lives in audioStore.
       // This test verifies the play button is clickable and doesn't crash.
+      useUIStore.getState().setHighlightStyle('none');
+      mockAutoLoadFetch();
       render(<DiwanApp />);
 
       await waitFor(() => {
@@ -1035,24 +1043,31 @@ describe('DiwanApp', () => {
   // ── Feature 8: Arabic RTL & fonts ─────────────────────────────────────
 
   describe('Arabic RTL & Fonts', () => {
-    it('renders Arabic verses with dir="rtl"', () => {
+    it('renders Arabic verses with dir="rtl"', async () => {
+      mockAutoLoadFetch();
       render(<DiwanApp />);
-      const rtlElements = document.querySelectorAll('p[dir="rtl"]');
-      expect(rtlElements.length).toBeGreaterThan(0);
+      await waitFor(() =>
+        expect(document.querySelectorAll('p[dir="rtl"]').length).toBeGreaterThan(0)
+      );
     });
 
-    it('applies font-amiri class by default', () => {
+    it('applies font-amiri class by default', async () => {
+      mockAutoLoadFetch();
       render(<DiwanApp />);
-      // The currentFontClass is applied to the verse container
-      const amiriElements = document.querySelectorAll('.font-amiri');
-      expect(amiriElements.length).toBeGreaterThan(0);
+      // The currentFontClass is applied to the verse container, which paints after mount
+      await waitFor(() =>
+        expect(document.querySelectorAll('.font-amiri').length).toBeGreaterThan(0)
+      );
     });
 
     it('changes font class when font is changed via store', async () => {
+      mockAutoLoadFetch();
       render(<DiwanApp />);
 
-      // Verify initial font is Amiri
-      expect(document.querySelectorAll('.font-amiri').length).toBeGreaterThan(0);
+      // Verify initial font is Amiri (verse container paints a tick after mount)
+      await waitFor(() =>
+        expect(document.querySelectorAll('.font-amiri').length).toBeGreaterThan(0)
+      );
 
       // Change font via store (Radix Select portal doesn't render reliably in jsdom)
       const { useUIStore } = await import('../stores/uiStore');

--- a/src/test/PlayControlsStrip.test.jsx
+++ b/src/test/PlayControlsStrip.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import PlayControlsStrip from '../components/PlayControlsStrip';
 import { useUIStore } from '../stores/uiStore';
+import { useAudioStore } from '../stores/audioStore';
 
 // Mock framer-motion AnimatePresence + motion so tests work without the full library
 vi.mock('framer-motion', () => ({
@@ -9,8 +10,8 @@ vi.mock('framer-motion', () => ({
   motion: new Proxy(
     {},
     {
-      get: (_, tag) =>
-        // eslint-disable-next-line react/display-name
+      get:
+        (_, tag) =>
         ({ children, ...rest }) => {
           const { initial, animate, exit, transition, ...domProps } = rest;
           return createElement(tag, domProps, children);
@@ -22,11 +23,17 @@ vi.mock('framer-motion', () => ({
 // Import createElement after the mock so it's available in the proxy factory
 import { createElement } from 'react';
 
-// Mock useTTSHighlight — only startPlayer and pauseOffset are used by the strip
+// Mock useTTSHighlight — the strip imports startPlayer, pauseOffset, playbackStartTime,
+// isSeeking and applyHighlightsOnce. The signal-like values must be objects with a
+// settable `.value` because seek() assigns to them (e.g. `pauseOffset.value = offset`).
 const mockStartPlayer = vi.fn();
+const mockApplyHighlightsOnce = vi.fn();
 vi.mock('../hooks/useTTSHighlight', () => ({
   startPlayer: (...args) => mockStartPlayer(...args),
-  pauseOffset: 0,
+  applyHighlightsOnce: (...args) => mockApplyHighlightsOnce(...args),
+  pauseOffset: { value: 0 },
+  playbackStartTime: { value: 0 },
+  isSeeking: { value: false },
 }));
 
 // Minimal mock player object
@@ -36,13 +43,17 @@ const VERSE_TIMES = [0, 12.5, 25.0, 40.0];
 
 beforeEach(() => {
   useUIStore.getState().reset();
+  useAudioStore.getState().reset();
   mockStartPlayer.mockClear();
+  mockApplyHighlightsOnce.mockClear();
   mockPlayer.start.mockClear();
   mockPlayer.stop.mockClear();
 });
 
 describe('PlayControlsStrip — visibility', () => {
-  it('is hidden when highlightStyle is "none"', () => {
+  it('renders its transport regardless of highlightStyle (parent gates visibility)', () => {
+    // The strip itself does not read highlightStyle — the parent (app.jsx) only mounts
+    // it when highlightStyle !== 'none'. So when rendered directly it always shows.
     useUIStore.getState().setHighlightStyle('none');
     const { container } = render(
       <PlayControlsStrip
@@ -53,8 +64,8 @@ describe('PlayControlsStrip — visibility', () => {
         onPlayPause={vi.fn()}
       />
     );
-    // AnimatePresence is mocked; when style is none the strip should not render
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByRole('button', { name: /play/i })).toBeInTheDocument();
   });
 
   it('renders when highlightStyle is active and player is loaded', () => {
@@ -135,6 +146,9 @@ describe('PlayControlsStrip — play/pause button', () => {
 describe('PlayControlsStrip — prev/next verse navigation', () => {
   it('calls startPlayer with previous verse time when Prev is clicked', () => {
     useUIStore.getState().setHighlightStyle('glow');
+    // seek() reads wasPlaying from the audio store (the isPlaying prop is stale by the
+    // time onstop fires), so the store must report playing for it to restart playback.
+    useAudioStore.getState().setPlaying(true);
     render(
       <PlayControlsStrip
         player={mockPlayer}
@@ -150,6 +164,7 @@ describe('PlayControlsStrip — prev/next verse navigation', () => {
 
   it('calls startPlayer with next verse time when Next is clicked', () => {
     useUIStore.getState().setHighlightStyle('glow');
+    useAudioStore.getState().setPlaying(true);
     render(
       <PlayControlsStrip
         player={mockPlayer}
@@ -163,18 +178,24 @@ describe('PlayControlsStrip — prev/next verse navigation', () => {
     expect(mockStartPlayer).toHaveBeenCalledWith(mockPlayer, VERSE_TIMES[2]);
   });
 
-  it('Prev is disabled at first verse', () => {
+  it('Prev stays enabled at first verse and restarts from the beginning', () => {
     useUIStore.getState().setHighlightStyle('glow');
+    // seek() restarts playback only when the store reports playing.
+    useAudioStore.getState().setPlaying(true);
     render(
       <PlayControlsStrip
         player={mockPlayer}
-        isPlaying={false}
+        isPlaying={true}
         verseStartTimes={VERSE_TIMES}
         currentVerseIndex={0}
         onPlayPause={vi.fn()}
       />
     );
-    expect(screen.getByRole('button', { name: /prev/i })).toBeDisabled();
+    // Prev is intentionally NOT disabled at verse 0 — it restarts from the start.
+    const prev = screen.getByRole('button', { name: /prev/i });
+    expect(prev).not.toBeDisabled();
+    fireEvent.click(prev);
+    expect(mockStartPlayer).toHaveBeenCalledWith(mockPlayer, 0);
   });
 
   it('Next is disabled at last verse', () => {

--- a/src/test/makeover-tone.test.js
+++ b/src/test/makeover-tone.test.js
@@ -110,11 +110,19 @@ describe('iOS silent switch bypass', () => {
     expect(content).toMatch(/isIOS\(\).*createHTMLAudioPlayer|createHTMLAudioPlayer.*isIOS\(\)/s);
   });
 
-  it('toneStart() is skipped on iOS in both playback paths', () => {
+  it('RESUME path skips toneStart() on iOS; GENERATE path unlocks the context on iOS too', () => {
     const content = fs.readFileSync(path.join(SRC, 'stores/actions/togglePlay.js'), 'utf-8');
-    // Both the RESUME and GENERATE paths should guard toneStart() with !isIOS()
-    const matches = content.match(/if\s*\(!isIOS\(\)\)\s*await\s*toneStart/g) || [];
-    expect(matches.length).toBeGreaterThanOrEqual(2);
+    // The RESUME path re-creates the player from the cached blob URL and, on iOS,
+    // uses an HTMLAudioElement (no AudioContext), so it guards toneStart with !isIOS().
+    const guarded = content.match(/if\s*\(!isIOS\(\)\)\s*await\s*toneStart/g) || [];
+    expect(guarded.length).toBeGreaterThanOrEqual(1);
+
+    // The GENERATE path intentionally unlocks the AudioContext on iOS too (set the
+    // audio session to 'playback' inside the gesture so Web Audio plays through the
+    // hardware silent switch — verified on a real iPhone). So there must also be an
+    // UNGUARDED `await toneStart()` reached on the generate path.
+    const allToneStart = content.match(/await\s*toneStart\s*\(/g) || [];
+    expect(allToneStart.length).toBeGreaterThan(guarded.length);
   });
 
   // Behavioural unit tests for createHTMLAudioPlayer.


### PR DESCRIPTION
## Why

The CI **Unit Tests** gate was red. Vitest's `bail: 1` in CI stops at the **first** failure, so only one failing test was ever visible. Running locally without bail surfaced the real picture: **13 assertion failures across three files, plus two test files that failed to even import** (silently red since April, masked by bail).

This unblocks the gate so it goes green on its own — no per-PR override needed (including for #598).

## Test fixes — tests had drifted from the current code (the source of truth)

**`src/test/App.test.jsx`**
- tags / RTL / font tests queried the poem card synchronously, but it paints a tick after mount (the file's own first test already documents this). Now mock the auto-load fetch and await via `waitFor`.
- Audio Playback tests used the stale aria-label `"Play recitation"`, which now only exists in the `highlightStyle === 'none'` control bar (the default is `'pill'`, which shows `"Start recitation"`). Set `'none'` mode and assert the real loading affordance (`"Preparing audio"`) instead of the old same-button-disabled model.
- Dropped the "renders tags for the default poem" test: genre-tag chips were removed from the main view (they live only in the now-unused `PoemCard.jsx` — see note below).

**`src/test/PlayControlsStrip.test.jsx`**
- Completed the `useTTSHighlight` mock (`isSeeking` / `playbackStartTime` / `applyHighlightsOnce`; `pauseOffset` must be an object with a settable `.value`).
- `seek()` reads `wasPlaying` from the audio store, not the `isPlaying` prop, so the store is set before asserting `startPlayer` is called.
- The component no longer self-gates on `highlightStyle` (the parent does) and no longer disables Prev at verse 0 (it restarts from the start). Both tests updated.

**`src/test/makeover-tone.test.js`**
- The iOS contract changed deliberately ("verified on a real iPhone"): the GENERATE path now unlocks the AudioContext on iOS too. Now asserts the real contract (RESUME guards `toneStart` with `!isIOS()`; GENERATE does not).

## Code fixes — genuine robustness wins that also unblocked the two import-crashing test files

**`server.js`**
- Load the dev-only `tts-lab.html` lazily on first `/tts-lab` request instead of eagerly at module load. The eager read crashed server boot (and every server / design-review test import) whenever `import.meta.url` is not a file URL.
- `/api/ai/live-tts` now validates the request body **before** the API-key check, so a malformed request returns `400` instead of a `503` that hid the real problem.

## Result

- **36 files / 647 tests green under `CI=1`** (bail on); coverage thresholds pass; `test:coverage` exits 0.
- No production behavior change beyond the two intentional `server.js` hardening fixes above.

## Follow-up to decide (not in this PR)

`PoemCard.jsx` is now dead code — it's the only place genre-tag chips render, and `app.jsx` no longer mounts it (verse rendering was inlined). So poems no longer show "Modern / Romantic / Ghazal"-style chips. Worth deciding whether to restore that feature or delete the dead component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_