### PR TITLE
design(sprint): share-modal & login-modal design directions

### DIFF
--- a/design-review/login-modal/index.html
+++ b/design-review/login-modal/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+<title>Login Modal — Design Directions</title>
+<style>
+  :root {
+    --gold: #c5a059;
+    --gold-bright: #d4b463;
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+  html, body { height: 100%; width: 100%; background: #04040a; overflow: hidden; font-family: system-ui, -apple-system, sans-serif; }
+
+  /* Each option fills the whole screen */
+  .frame {
+    position: fixed; inset: 0; width: 100%; height: 100%;
+    border: none; opacity: 0; pointer-events: none;
+    transition: opacity 0.3s var(--ease);
+  }
+  .frame.active { opacity: 1; pointer-events: auto; }
+
+  /* Floating side-nav arrows */
+  .nav-btn {
+    position: fixed; top: 50%; transform: translateY(-50%);
+    z-index: 50; width: 48px; height: 48px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    border: 1px solid rgba(197,160,89,0.45);
+    background: rgba(7,7,12,0.6); backdrop-filter: blur(10px);
+    color: var(--gold); font-size: 22px; line-height: 1; cursor: pointer;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+    transition: background 0.18s var(--ease), color 0.18s var(--ease), transform 0.18s var(--ease), opacity 0.18s;
+  }
+  .nav-btn:hover { background: rgba(197,160,89,0.18); color: var(--gold-bright); transform: translateY(-50%) scale(1.08); }
+  .nav-btn:active { transform: translateY(-50%) scale(0.92); }
+  .nav-btn:disabled { opacity: 0.18; pointer-events: none; }
+  .nav-btn:focus-visible { outline: 2px solid var(--gold); outline-offset: 3px; }
+  .nav-prev { left: calc(8px + env(safe-area-inset-left, 0px)); }
+  .nav-next { right: calc(8px + env(safe-area-inset-right, 0px)); }
+
+  /* Compact label pill (top-center) */
+  .label {
+    position: fixed; top: calc(10px + env(safe-area-inset-top, 0px)); left: 50%;
+    transform: translateX(-50%); z-index: 50;
+    display: flex; align-items: center; gap: 8px; max-width: 80vw;
+    padding: 6px 14px; border-radius: 999px;
+    background: rgba(7,7,12,0.72); backdrop-filter: blur(10px);
+    border: 1px solid rgba(197,160,89,0.28);
+    font-size: 12px; color: var(--gold); white-space: nowrap; overflow: hidden;
+  }
+  .label .num { opacity: 0.55; font-weight: 700; letter-spacing: 0.04em; }
+  .label .name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; }
+  .label .flag {
+    font-size: 8.5px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; color: #1a1200;
+    background: linear-gradient(135deg, #a8853d, #c5a059 30%, #e0c97a 50%, #c5a059 70%, #a8853d);
+    border-radius: 4px; padding: 2px 6px; display: none;
+  }
+  .label.is-flag .flag { display: inline-block; }
+
+  /* Dots */
+  .dots {
+    position: fixed; bottom: calc(12px + env(safe-area-inset-bottom, 0px)); left: 50%;
+    transform: translateX(-50%); z-index: 50;
+    display: flex; gap: 8px; padding: 8px 12px; border-radius: 999px;
+    background: rgba(7,7,12,0.6); backdrop-filter: blur(8px); border: 1px solid rgba(197,160,89,0.18);
+  }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: rgba(197,160,89,0.25); cursor: pointer; transition: all 0.25s var(--ease); }
+  .dot.active { background: var(--gold); width: 22px; border-radius: 4px; box-shadow: 0 0 6px rgba(197,160,89,0.4); }
+  .dot:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+</style>
+</head>
+<body>
+  <iframe class="frame active" src="l1.html" title="L1 — Wax Seal Invitation Card" loading="eager"></iframe>
+  <iframe class="frame" src="l2.html" title="L2 — Tessellated Bottom Sheet" loading="lazy"></iframe>
+  <iframe class="frame" src="l3.html" title="L3 — Threshold / Doorway (Flagship)" loading="lazy"></iframe>
+
+  <button class="nav-btn nav-prev" id="prev" aria-label="Previous design" disabled>‹</button>
+  <button class="nav-btn nav-next" id="next" aria-label="Next design">›</button>
+
+  <div class="label" id="label">
+    <span class="num" id="num">L1</span>
+    <span class="name" id="name">Wax Seal Invitation Card</span>
+    <span class="flag">Flagship</span>
+  </div>
+
+  <div class="dots" id="dots" role="tablist" aria-label="Design directions"></div>
+
+<script>
+  const dirs = [
+    { num: 'L1', name: 'Wax Seal Invitation Card', flagship: false },
+    { num: 'L2', name: 'Tessellated Bottom Sheet', flagship: false },
+    { num: 'L3', name: 'Threshold / Doorway', flagship: true },
+  ];
+  const frames = Array.from(document.querySelectorAll('.frame'));
+  const prev = document.getElementById('prev');
+  const next = document.getElementById('next');
+  const label = document.getElementById('label');
+  const num = document.getElementById('num');
+  const name = document.getElementById('name');
+  const dotsWrap = document.getElementById('dots');
+  let cur = 0;
+
+  dirs.forEach((d, i) => {
+    const dot = document.createElement('button');
+    dot.className = 'dot' + (i === 0 ? ' active' : '');
+    dot.setAttribute('role', 'tab');
+    dot.setAttribute('aria-label', `${d.num}: ${d.name}`);
+    dot.addEventListener('click', () => go(i));
+    dotsWrap.appendChild(dot);
+  });
+  const dots = Array.from(dotsWrap.children);
+
+  function go(i) {
+    if (i < 0 || i >= dirs.length) return;
+    frames[cur].classList.remove('active');
+    dots[cur].classList.remove('active');
+    cur = i;
+    frames[cur].classList.add('active');
+    dots[cur].classList.add('active');
+    const d = dirs[cur];
+    num.textContent = d.num;
+    name.textContent = d.name;
+    label.classList.toggle('is-flag', d.flagship);
+    prev.disabled = cur === 0;
+    next.disabled = cur === dirs.length - 1;
+  }
+
+  prev.addEventListener('click', () => go(cur - 1));
+  next.addEventListener('click', () => go(cur + 1));
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowLeft') go(cur - 1);
+    if (e.key === 'ArrowRight') go(cur + 1);
+  });
+</script>
+</body>
+</html>

--- a/design-review/login-modal/l1.html
+++ b/design-review/login-modal/l1.html
@@ -1,0 +1,748 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+<title>L1 — Wax Seal Invitation Card</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Reem+Kufi:wght@400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet" />
+<style>
+/* ===========================
+   DESIGN TOKENS
+   =========================== */
+:root {
+  --gold: #c5a059;
+  --gold-bright: #d4b463;
+  --gold-foil: linear-gradient(135deg, #b8922e, #c5a059 30%, #e2c67a 55%, #c5a059 75%, #a07d38);
+  --gold-molten: linear-gradient(135deg, #a8853d, #c5a059 22%, #e0c97a 38%, #d4b463 48%, #b8924a 62%, #d8bc6e 78%, #c5a059);
+  --gold-hairline: linear-gradient(90deg, transparent, rgba(160,128,64,0.4) 20%, #c5a059 50%, rgba(160,128,64,0.4) 80%, transparent);
+  --gold-border: rgba(197,160,89,0.25);
+  --gold-label: #1a1200;
+  --lapis-deep: #1e3a6e;
+  --lapis-medium: #2e5090;
+  --lapis-light: #4a7cc9;
+  --bg-app: #0c0c0e;
+  --bg-panel: linear-gradient(145deg, rgba(20,18,15,0.97), rgba(12,12,14,0.98));
+  --text-primary: rgba(236,232,224,0.94);
+  --text-muted: rgba(236,232,224,0.45);
+  --text-dim: rgba(236,232,224,0.28);
+  --surface: rgba(255,255,255,0.04);
+  --surface-hover: rgba(255,255,255,0.07);
+  --radius-card: 20px;
+  --radius-btn: 12px;
+  --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --dur-entrance: 0.7s;
+  --dur-content: 0.5s;
+  --dur-hover: 0.18s;
+}
+
+/* ===========================
+   RESET & GLOBAL
+   =========================== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+html, body {
+  height: 100%;
+  background: #080810;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ===========================
+   DIRECTION LABEL
+   =========================== */
+.direction-label {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 100;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(197,160,89,0.9);
+  background: rgba(12,12,14,0.85);
+  border: 1px solid rgba(197,160,89,0.2);
+  border-radius: 6px;
+  padding: 6px 10px;
+  backdrop-filter: blur(8px);
+  line-height: 1.4;
+}
+.direction-label span {
+  display: block;
+  color: rgba(236,232,224,0.55);
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+/* ===========================
+   APP BACKDROP (dimmed poetry reader)
+   =========================== */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(ellipse at 50% 40%, rgba(197,160,89,0.05) 0%, rgba(0,0,0,0.82) 100%);
+}
+
+/* subtle Islamic geometry in backdrop */
+.backdrop::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(60deg, rgba(197,160,89,0.03) 0px, rgba(197,160,89,0.03) 1px, transparent 1px, transparent 28px),
+    repeating-linear-gradient(-60deg, rgba(197,160,89,0.03) 0px, rgba(197,160,89,0.03) 1px, transparent 1px, transparent 28px),
+    repeating-linear-gradient(0deg, rgba(197,160,89,0.02) 0px, rgba(197,160,89,0.02) 1px, transparent 1px, transparent 28px);
+  pointer-events: none;
+}
+
+/* Faint "poem text" behind the modal — gives context */
+.backdrop-poem {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  pointer-events: none;
+  padding: 40px;
+  opacity: 0.12;
+}
+.backdrop-poem .line {
+  font-family: 'Amiri', serif;
+  font-size: clamp(1.2rem, 3vw, 2rem);
+  color: #c5a059;
+  direction: rtl;
+  text-align: center;
+  filter: blur(1.5px);
+}
+
+/* ===========================
+   PHONE FRAME
+   =========================== */
+.phone-frame {
+  position: relative;
+  width: 412px;
+  height: 700px;
+  background: #0c0c0e;
+  border-radius: 36px;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,0.06),
+    0 32px 64px rgba(0,0,0,0.7),
+    0 8px 24px rgba(0,0,0,0.5);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* phone notch */
+.phone-frame::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 120px;
+  height: 28px;
+  background: #0c0c0e;
+  border-radius: 0 0 18px 18px;
+  z-index: 10;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.04);
+}
+
+.phone-screen {
+  position: absolute;
+  inset: 0;
+  background: #0a0a0c;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+/* faint reading content behind modal */
+.phone-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 60px 32px;
+}
+.phone-content .poem-line {
+  font-family: 'Amiri', serif;
+  font-size: 1.05rem;
+  color: rgba(197,160,89,0.22);
+  direction: rtl;
+  text-align: center;
+}
+
+/* dim overlay within phone */
+.phone-dim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.72);
+  backdrop-filter: blur(3px);
+  z-index: 1;
+}
+
+/* ===========================
+   MODAL — INVITATION CARD
+   =========================== */
+.modal {
+  position: relative;
+  z-index: 2;
+  width: 340px;
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+  border: 1px solid var(--gold-border);
+  box-shadow:
+    0 0 0 0.5px rgba(197,160,89,0.12),
+    0 24px 48px rgba(0,0,0,0.6),
+    0 4px 12px rgba(197,160,89,0.06),
+    inset 0 1px 0 rgba(197,160,89,0.08);
+  overflow: hidden;
+  /* entrance animation */
+  opacity: 0;
+  transform: scale(0.88) translateY(16px);
+  animation: modalEntrance var(--dur-entrance) var(--ease-spring) 0.15s forwards;
+}
+
+@keyframes modalEntrance {
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* gold hairline top */
+.modal-hairline-top {
+  height: 2px;
+  background: var(--gold-hairline);
+  position: relative;
+  overflow: visible;
+}
+
+/* animated gold sheen sweep — loops slowly */
+.modal-hairline-top::after {
+  content: '';
+  position: absolute;
+  top: -2px;
+  left: -60%;
+  width: 60%;
+  height: 6px;
+  background: linear-gradient(90deg, transparent, rgba(255,240,180,0.7), transparent);
+  animation: sheenSweep 4s var(--ease-out) 0.8s infinite;
+}
+
+@keyframes sheenSweep {
+  0%   { left: -60%; opacity: 0; }
+  8%   { opacity: 1; }
+  92%  { opacity: 1; }
+  100% { left: 110%; opacity: 0; }
+}
+
+/* close button */
+.btn-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid rgba(197,160,89,0.2);
+  background: rgba(197,160,89,0.05);
+  color: rgba(197,160,89,0.55);
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background var(--dur-hover) var(--ease-out),
+              color var(--dur-hover) var(--ease-out),
+              border-color var(--dur-hover) var(--ease-out),
+              transform var(--dur-hover) var(--ease-out);
+  z-index: 5;
+  /* no negative margin; pseudo-element expands touch target */
+  padding: 4px;
+}
+/* touch target expansion */
+.btn-close::before {
+  content: '';
+  position: absolute;
+  inset: -4px;
+}
+.btn-close:hover {
+  background: rgba(197,160,89,0.12);
+  color: var(--gold);
+  border-color: rgba(197,160,89,0.4);
+  transform: scale(1.06);
+}
+.btn-close:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: 2px;
+}
+.btn-close:active { transform: scale(0.9); transition-duration: 0.08s; }
+
+/* modal body */
+.modal-body {
+  padding: 32px 28px 28px;
+}
+
+/* ===========================
+   WAX SEAL MOTIF
+   =========================== */
+.seal-wrap {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 22px;
+  opacity: 0;
+  animation: fadeUp 0.5s var(--ease-spring) 0.45s forwards;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(10px) scale(0.92); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.seal {
+  position: relative;
+  width: 64px;
+  height: 64px;
+}
+
+/* the wax disc */
+.seal-disc {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: radial-gradient(circle at 36% 32%, #e0c97a, #c5a059 38%, #9a7a30 72%, #7a5e20);
+  box-shadow:
+    0 3px 8px rgba(0,0,0,0.5),
+    0 1px 2px rgba(0,0,0,0.3),
+    inset 0 1px 2px rgba(255,240,180,0.3);
+}
+
+/* star/rosette impression */
+.seal-disc::before {
+  content: '';
+  position: absolute;
+  inset: 8px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(26,18,0,0.35);
+  background: transparent;
+}
+.seal-disc::after {
+  content: '✦';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: rgba(26,18,0,0.5);
+  line-height: 1;
+}
+
+/* the pressed indentation — qalam/feather */
+.seal-mark {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  color: rgba(26,18,0,0.6);
+  z-index: 1;
+}
+
+/* ===========================
+   HEADLINE AREA
+   =========================== */
+.headline {
+  text-align: center;
+  margin-bottom: 20px;
+  opacity: 0;
+  animation: fadeUp 0.5s var(--ease-spring) 0.55s forwards;
+}
+
+.headline-ar {
+  font-family: 'Reem Kufi', sans-serif;
+  font-size: 1.85rem;
+  font-weight: 600;
+  color: var(--gold);
+  direction: rtl;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+  margin-bottom: 4px;
+}
+
+.headline-en {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-style: italic;
+  font-size: 1rem;
+  color: rgba(197,160,89,0.65);
+  letter-spacing: 0.06em;
+  font-weight: 400;
+}
+
+/* ===========================
+   DIVIDER — feather/qalam
+   =========================== */
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 20px;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 0.65s forwards;
+}
+@keyframes fadeIn { to { opacity: 1; } }
+
+.divider-line {
+  flex: 1;
+  height: 1px;
+  background: var(--gold-hairline);
+}
+.divider-feather {
+  font-size: 14px;
+  opacity: 0.5;
+  color: var(--gold);
+}
+
+/* ===========================
+   VALUE PROP
+   =========================== */
+.value-prop {
+  text-align: center;
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+  margin-bottom: 22px;
+  padding: 0 4px;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 0.7s forwards;
+}
+
+/* ===========================
+   GOOGLE BUTTON — molten gold fill
+   =========================== */
+.btn-google {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 100%;
+  min-height: 52px;
+  padding: 0 20px;
+  border-radius: var(--radius-btn);
+  border: none;
+  cursor: pointer;
+  background: var(--gold-molten);
+  color: var(--gold-label);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--dur-hover) var(--ease-out),
+              box-shadow var(--dur-hover) var(--ease-out);
+  /* convex lighting: inset specular edges + outer glow */
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.45) inset,
+    0 -1px 0 rgba(0,0,0,0.25) inset,
+    0 4px 14px rgba(197,160,89,0.32),
+    0 1px 4px rgba(197,160,89,0.18);
+  opacity: 0;
+  animation: fadeUp 0.45s var(--ease-spring) 0.8s forwards;
+}
+
+/* convex top-dome highlight — always visible */
+.btn-google::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 50%;
+  border-radius: var(--radius-btn) var(--radius-btn) 60% 60% / var(--radius-btn) var(--radius-btn) 50% 50%;
+  background: linear-gradient(to bottom,
+    rgba(255,255,255,0.28) 0%,
+    rgba(255,255,255,0.07) 60%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+/* slow continuous gold sheen sweep */
+.btn-google::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 25%,
+    rgba(255,255,255,0.22) 45%,
+    rgba(255,255,255,0.28) 50%,
+    rgba(255,255,255,0.22) 55%,
+    transparent 75%
+  );
+  transform: translateX(-140%);
+  animation: goldSheen 3.8s var(--ease-out) 1.0s infinite;
+}
+
+@keyframes goldSheen {
+  0%   { transform: translateX(-140%); opacity: 0; }
+  8%   { opacity: 1; }
+  92%  { opacity: 1; }
+  100% { transform: translateX(140%); opacity: 0; }
+}
+
+.btn-google:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.45) inset,
+    0 -1px 0 rgba(0,0,0,0.25) inset,
+    0 8px 24px rgba(197,160,89,0.44),
+    0 3px 8px rgba(197,160,89,0.24);
+}
+.btn-google:active {
+  transform: scale(0.967) translateY(1px);
+  transition-duration: 0.08s;
+  box-shadow:
+    0 0.5px 0 rgba(255,255,255,0.28) inset,
+    0 -2px 0 rgba(0,0,0,0.32) inset,
+    0 2px 8px rgba(197,160,89,0.2);
+}
+.btn-google:focus-visible {
+  outline: 2px solid var(--gold-bright);
+  outline-offset: 2px;
+}
+
+.google-g {
+  flex-shrink: 0;
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.18));
+}
+
+/* ===========================
+   DISMISS LINK
+   =========================== */
+.btn-dismiss {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 8px;
+  margin-top: 12px;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color var(--dur-hover) var(--ease-out),
+              background var(--dur-hover) var(--ease-out);
+  letter-spacing: 0.03em;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 0.95s forwards;
+}
+.btn-dismiss:hover {
+  color: rgba(197,160,89,0.5);
+  background: rgba(255,255,255,0.03);
+}
+.btn-dismiss:focus-visible {
+  outline: 2px solid rgba(197,160,89,0.4);
+  outline-offset: 2px;
+}
+
+/* ===========================
+   TRUST LINE
+   =========================== */
+.trust-line {
+  text-align: center;
+  font-family: system-ui, sans-serif;
+  font-size: 0.625rem;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(197,160,89,0.08);
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 1.05s forwards;
+}
+
+/* gold hairline bottom */
+.modal-hairline-bottom {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(197,160,89,0.2), transparent);
+}
+
+/* ===========================
+   ISLAMIC GEOMETRY CORNER ACCENTS
+   =========================== */
+.corner {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  pointer-events: none;
+  opacity: 0.35;
+}
+.corner-tl { top: 6px; left: 6px; }
+.corner-br { bottom: 6px; right: 6px; transform: rotate(180deg); }
+
+.corner::before, .corner::after {
+  content: '';
+  position: absolute;
+  background: var(--gold);
+}
+.corner::before {
+  top: 0; left: 0;
+  width: 100%; height: 1.5px;
+}
+.corner::after {
+  top: 0; left: 0;
+  width: 1.5px; height: 100%;
+}
+
+/* responsive: shrink phone on small viewports */
+@media (max-width: 440px) {
+  .phone-frame { width: 100vw; height: 100dvh; border-radius: 0; }
+}
+
+/* ===========================
+   REDUCED MOTION
+   =========================== */
+@media (prefers-reduced-motion: reduce) {
+  .modal { animation: none; opacity: 1; transform: none; }
+  .seal-wrap { animation: none; opacity: 1; }
+  .headline { animation: none; opacity: 1; }
+  .divider { animation: none; opacity: 1; }
+  .value-prop { animation: none; opacity: 1; }
+  .btn-google { animation: none; opacity: 1; }
+  .btn-google::before { animation: none; }
+  .btn-dismiss { animation: none; opacity: 1; }
+  .trust-line { animation: none; opacity: 1; }
+  .modal-hairline-top::after { animation: none; }
+}
+</style>
+</head>
+<body>
+
+<div class="direction-label">
+  L1 — Wax Seal Invitation Card
+  <span>A formal envelope metaphor; the wax seal reveals a qalam mark; CTA fills in molten gold</span>
+</div>
+
+<div class="backdrop">
+  <div class="backdrop-poem">
+    <div class="line">قِفَا نَبْكِ مِنْ ذِكْرَى حَبِيبٍ وَمَنْزِلِ</div>
+    <div class="line">بِسِقْطِ اللِّوَى بَيْنَ الدَّخُولِ فَحَوْمَلِ</div>
+  </div>
+
+  <div class="phone-frame">
+    <div class="phone-screen">
+      <!-- faint poem content behind modal -->
+      <div class="phone-content">
+        <div class="poem-line">أَلَا لَيْتَ الشَّبَابَ يَعُودُ يَوْمًا</div>
+        <div class="poem-line">فَأُخْبِرَهُ بِمَا فَعَلَ الْمَشِيبُ</div>
+        <div class="poem-line" style="opacity:0.6">— أبو تمام</div>
+      </div>
+
+      <!-- dim overlay -->
+      <div class="phone-dim"></div>
+
+      <!-- ===== MODAL ===== -->
+      <div class="modal" role="dialog" aria-modal="true" aria-label="Sign in to Dīwān">
+
+        <div class="modal-hairline-top"></div>
+
+        <!-- corner decorations -->
+        <div class="corner corner-tl"></div>
+        <div class="corner corner-br"></div>
+
+        <!-- close -->
+        <button class="btn-close" aria-label="Close, continue reading" onclick="this.closest('.phone-screen').querySelector('.phone-dim').style.opacity='0'; this.closest('[role=dialog]').style.animation='modalExit 0.3s cubic-bezier(0.7,0,1,1) forwards';">
+          ✕
+        </button>
+
+        <div class="modal-body">
+
+          <!-- wax seal -->
+          <div class="seal-wrap" aria-hidden="true">
+            <div class="seal">
+              <div class="seal-disc"></div>
+              <div class="seal-mark">🪶</div>
+            </div>
+          </div>
+
+          <!-- headline -->
+          <div class="headline">
+            <div class="headline-ar" lang="ar" dir="rtl">ادخل الديوان</div>
+            <div class="headline-en">Enter the Dīwān</div>
+          </div>
+
+          <!-- decorative divider -->
+          <div class="divider" aria-hidden="true">
+            <div class="divider-line"></div>
+            <div class="divider-feather">✦</div>
+            <div class="divider-line"></div>
+          </div>
+
+          <!-- value proposition -->
+          <p class="value-prop">
+            Save beloved verses &amp; keep your settings in harmony across all your devices.
+          </p>
+
+          <!-- Google CTA -->
+          <button class="btn-google" type="button">
+            <svg class="google-g" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            Continue with Google
+          </button>
+
+          <!-- dismiss -->
+          <button class="btn-dismiss" type="button">
+            Maybe later — continue reading
+          </button>
+
+          <!-- trust -->
+          <p class="trust-line">We never post on your behalf &nbsp;·&nbsp; No spam, ever</p>
+
+        </div><!-- /.modal-body -->
+
+        <div class="modal-hairline-bottom"></div>
+      </div><!-- /.modal -->
+
+    </div><!-- /.phone-screen -->
+  </div><!-- /.phone-frame -->
+</div><!-- /.backdrop -->
+
+<style>
+@keyframes modalExit {
+  to { opacity: 0; transform: scale(0.9) translateY(12px); }
+}
+</style>
+
+</body>
+</html>

--- a/design-review/login-modal/l2.html
+++ b/design-review/login-modal/l2.html
@@ -1,0 +1,662 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+<title>L2 — Tessellated Bottom Sheet</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Reem+Kufi:wght@400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet" />
+<style>
+/* ===========================
+   DESIGN TOKENS
+   =========================== */
+:root {
+  --gold: #c5a059;
+  --gold-bright: #d4b463;
+  --gold-foil: linear-gradient(135deg, #b8922e, #c5a059 30%, #e2c67a 55%, #c5a059 75%, #a07d38);
+  --gold-molten: linear-gradient(135deg, #a8853d, #c5a059 22%, #e0c97a 38%, #d4b463 48%, #b8924a 62%, #d8bc6e 78%, #c5a059);
+  --gold-hairline: linear-gradient(90deg, transparent, rgba(160,128,64,0.4) 20%, #c5a059 50%, rgba(160,128,64,0.4) 80%, transparent);
+  --gold-border: rgba(197,160,89,0.25);
+  --gold-label: #1a1200;
+  --lapis-deep: #1e3a6e;
+  --lapis-medium: #2e5090;
+  --lapis-light: #4a7cc9;
+  --bg-app: #0c0c0e;
+  --text-primary: rgba(236,232,224,0.94);
+  --text-muted: rgba(236,232,224,0.50);
+  --text-dim: rgba(236,232,224,0.28);
+  --radius-btn: 14px;
+  --ease-spring: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-in: cubic-bezier(0.7, 0, 1, 1);
+  --dur-sheet: 0.65s;
+  --dur-hover: 0.18s;
+}
+
+/* ===========================
+   RESET
+   =========================== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0; padding: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+html, body {
+  height: 100%;
+  background: #05050a;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ===========================
+   DIRECTION LABEL
+   =========================== */
+.direction-label {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  z-index: 100;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(197,160,89,0.9);
+  background: rgba(5,5,10,0.9);
+  border: 1px solid rgba(197,160,89,0.2);
+  border-radius: 6px;
+  padding: 6px 10px;
+  backdrop-filter: blur(8px);
+  line-height: 1.4;
+}
+.direction-label span {
+  display: block;
+  color: rgba(236,232,224,0.5);
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+/* ===========================
+   BACKDROP
+   =========================== */
+.backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #08080e;
+}
+
+/* ===========================
+   PHONE FRAME
+   =========================== */
+.phone-frame {
+  position: relative;
+  width: 412px;
+  height: 700px;
+  background: #0c0c0e;
+  border-radius: 36px;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,0.06),
+    0 32px 64px rgba(0,0,0,0.75),
+    0 8px 24px rgba(0,0,0,0.5);
+  overflow: hidden;
+}
+
+/* phone notch */
+.phone-frame::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 120px;
+  height: 28px;
+  background: #0c0c0e;
+  border-radius: 0 0 18px 18px;
+  z-index: 20;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.04);
+}
+
+/* ===========================
+   PHONE SCREEN — reading view
+   =========================== */
+.phone-screen {
+  position: absolute;
+  inset: 0;
+  background: #090910;
+  overflow: hidden;
+}
+
+/* ambient glow */
+.phone-screen::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 30%, rgba(197,160,89,0.06) 0%, transparent 60%),
+    radial-gradient(ellipse at 50% 100%, rgba(30,58,110,0.12) 0%, transparent 55%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* reading text — visible behind the sheet */
+.reading-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  padding: 60px 32px 280px;
+  z-index: 1;
+}
+.reading-content .r-poet {
+  font-family: 'Reem Kufi', sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  color: rgba(197,160,89,0.4);
+  text-transform: uppercase;
+}
+.reading-content .r-line {
+  font-family: 'Amiri', serif;
+  font-size: 1.15rem;
+  color: rgba(236,232,224,0.35);
+  direction: rtl;
+  text-align: center;
+  line-height: 2;
+}
+
+/* dim overlay */
+.phone-dim {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.65);
+  backdrop-filter: blur(2px);
+  z-index: 2;
+}
+
+/* ===========================
+   BOTTOM SHEET
+   =========================== */
+.bottom-sheet {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 3;
+  border-radius: 24px 24px 0 0;
+  overflow: hidden;
+  animation: sheetRise var(--dur-sheet) var(--ease-spring) 0.1s both;
+}
+
+@keyframes sheetRise {
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+}
+
+/* ===========================
+   TESSELLATED HEADER BAND
+   =========================== */
+.sheet-header {
+  position: relative;
+  height: 96px;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(20,16,10,0.98), rgba(14,12,10,0.97));
+}
+
+/* Islamic star tessellation — richer 8-point star lattice */
+.sheet-header::before {
+  content: '';
+  position: absolute;
+  inset: -10px;
+  background-image:
+    /* primary diagonal lattice — creates star intersections */
+    repeating-linear-gradient(45deg,  rgba(197,160,89,0.18) 0px, rgba(197,160,89,0.18) 1px, transparent 1px, transparent 22px),
+    repeating-linear-gradient(-45deg, rgba(197,160,89,0.18) 0px, rgba(197,160,89,0.18) 1px, transparent 1px, transparent 22px),
+    /* orthogonal grid — cross-connects the diagonals */
+    repeating-linear-gradient(0deg,   rgba(197,160,89,0.09) 0px, rgba(197,160,89,0.09) 1px, transparent 1px, transparent 22px),
+    repeating-linear-gradient(90deg,  rgba(197,160,89,0.09) 0px, rgba(197,160,89,0.09) 1px, transparent 1px, transparent 22px),
+    /* finer 22.5° lines — approximates 8-point star spokes */
+    repeating-linear-gradient(22.5deg, rgba(197,160,89,0.07) 0px, rgba(197,160,89,0.07) 1px, transparent 1px, transparent 44px),
+    repeating-linear-gradient(-22.5deg, rgba(197,160,89,0.07) 0px, rgba(197,160,89,0.07) 1px, transparent 1px, transparent 44px);
+  opacity: 1;
+  animation: tessBreath 6s ease-in-out infinite;
+}
+
+@keyframes tessBreath {
+  0%, 100% { opacity: 0.85; }
+  50% { opacity: 1; }
+}
+
+/* gold vignette fade at bottom of header */
+.sheet-header::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 40px;
+  background: linear-gradient(to bottom, transparent, rgba(14,12,10,0.97));
+}
+
+/* gold hairline across top of sheet */
+.header-hairline {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 2px;
+  background: var(--gold-hairline);
+  z-index: 2;
+}
+/* animated sheen */
+.header-hairline::after {
+  content: '';
+  position: absolute;
+  top: -3px; left: -60%;
+  width: 60%;
+  height: 8px;
+  background: linear-gradient(90deg, transparent, rgba(255,240,180,0.55), transparent);
+  animation: sheenSweep 2.8s cubic-bezier(0.4,0,0.2,1) 0.7s forwards;
+}
+@keyframes sheenSweep { to { left: 110%; } }
+
+/* header title centered over pattern */
+.header-content {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  padding-bottom: 4px;
+}
+
+.header-ar {
+  font-family: 'Reem Kufi', sans-serif;
+  font-size: 1.65rem;
+  font-weight: 600;
+  color: var(--gold);
+  direction: rtl;
+  letter-spacing: 0.02em;
+  text-shadow: 0 2px 12px rgba(197,160,89,0.4);
+  opacity: 0;
+  animation: fadeIn 0.5s var(--ease-spring) 0.4s forwards;
+}
+.header-en {
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 0.82rem;
+  color: rgba(197,160,89,0.6);
+  letter-spacing: 0.08em;
+  margin-top: 2px;
+  opacity: 0;
+  animation: fadeIn 0.5s var(--ease-out) 0.5s forwards;
+}
+
+@keyframes fadeIn { to { opacity: 1; } }
+
+/* pill handle */
+.sheet-handle {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(197,160,89,0.35);
+  z-index: 3;
+}
+
+/* close button */
+.btn-close {
+  position: absolute;
+  top: 12px;
+  right: 14px;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid rgba(197,160,89,0.18);
+  background: rgba(197,160,89,0.06);
+  color: rgba(197,160,89,0.5);
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 4;
+  /* 44px touch target via padding expansion, no margin overflow */
+  padding: 4px;
+  min-width: 36px;
+  min-height: 36px;
+  /* Expand hit area without overflow */
+  -webkit-appearance: none;
+  transition: background 0.18s, color 0.18s, border-color 0.18s, transform 0.18s;
+}
+/* Expanded touch area for accessibility */
+.btn-close::before {
+  content: '';
+  position: absolute;
+  inset: -4px;
+}
+.btn-close:hover {
+  background: rgba(197,160,89,0.14);
+  color: var(--gold);
+  border-color: rgba(197,160,89,0.4);
+  transform: scale(1.06);
+}
+.btn-close:active {
+  transform: scale(0.9);
+  transition-duration: 0.08s;
+}
+.btn-close:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: 2px;
+}
+
+/* ===========================
+   SHEET BODY
+   =========================== */
+.sheet-body {
+  background: linear-gradient(180deg, rgba(14,12,10,0.97), rgba(10,10,14,0.98));
+  padding: 20px 24px 28px;
+  /* safe area bottom */
+  padding-bottom: calc(24px + env(safe-area-inset-bottom, 0px));
+}
+
+/* ===========================
+   FEATURE ITEMS
+   =========================== */
+.features {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  opacity: 0;
+  animation: slideUp 0.45s var(--ease-spring) 0.55s forwards;
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.feature-item {
+  flex: 1;
+  background: rgba(197,160,89,0.05);
+  border: 1px solid rgba(197,160,89,0.12);
+  border-radius: 12px;
+  padding: 12px 10px;
+  text-align: center;
+}
+.feature-icon {
+  font-size: 18px;
+  margin-bottom: 6px;
+  display: block;
+  filter: sepia(1) saturate(2) hue-rotate(10deg);
+}
+.feature-label {
+  font-family: system-ui, sans-serif;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+  line-height: 1.35;
+  letter-spacing: 0.02em;
+}
+
+/* ===========================
+   GOOGLE BUTTON
+   =========================== */
+.btn-google {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 11px;
+  width: 100%;
+  min-height: 54px;
+  padding: 0 20px;
+  border-radius: var(--radius-btn);
+  border: none;
+  cursor: pointer;
+  background: var(--gold-molten);
+  color: var(--gold-label);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.92rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.18s var(--ease-out), box-shadow 0.18s var(--ease-out);
+  /* convex edge highlights + outer glow */
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.42) inset,
+    0 -1px 0 rgba(0,0,0,0.24) inset,
+    0 4px 16px rgba(197,160,89,0.32),
+    0 1px 4px rgba(197,160,89,0.18);
+  opacity: 0;
+  animation: slideUp 0.45s var(--ease-spring) 0.68s forwards;
+}
+
+/* convex top-dome highlight */
+.btn-google::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 50%;
+  border-radius: var(--radius-btn) var(--radius-btn) 60% 60% / var(--radius-btn) var(--radius-btn) 50% 50%;
+  background: linear-gradient(to bottom,
+    rgba(255,255,255,0.26) 0%,
+    rgba(255,255,255,0.06) 60%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+/* slow looping gold sheen sweep */
+.btn-google::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 25%,
+    rgba(255,255,255,0.22) 45%,
+    rgba(255,255,255,0.28) 50%,
+    rgba(255,255,255,0.22) 55%,
+    transparent 75%
+  );
+  transform: translateX(-140%);
+  animation: goldSheen 3.6s var(--ease-out) 1.1s infinite;
+}
+
+@keyframes goldSheen {
+  0%   { transform: translateX(-140%); opacity: 0; }
+  8%   { opacity: 1; }
+  92%  { opacity: 1; }
+  100% { transform: translateX(140%); opacity: 0; }
+}
+
+.btn-google:hover {
+  transform: translateY(-1px) scale(1.01);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.42) inset,
+    0 -1px 0 rgba(0,0,0,0.24) inset,
+    0 8px 24px rgba(197,160,89,0.44),
+    0 3px 8px rgba(197,160,89,0.24);
+}
+.btn-google:active {
+  transform: scale(0.967) translateY(1px);
+  transition-duration: 0.08s;
+  box-shadow:
+    0 0.5px 0 rgba(255,255,255,0.28) inset,
+    0 -2px 0 rgba(0,0,0,0.3) inset,
+    0 2px 8px rgba(197,160,89,0.2);
+}
+.btn-google:focus-visible { outline: 2px solid var(--gold-bright); outline-offset: 2px; }
+
+/* ===========================
+   DISMISS
+   =========================== */
+.btn-dismiss {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 8px;
+  margin-top: 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 0.83rem;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color 0.18s, background 0.18s;
+  letter-spacing: 0.03em;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 0.82s forwards;
+}
+.btn-dismiss:hover { color: rgba(197,160,89,0.5); background: rgba(255,255,255,0.03); }
+.btn-dismiss:focus-visible { outline: 2px solid rgba(197,160,89,0.4); outline-offset: 2px; }
+
+/* ===========================
+   TRUST + DIVIDER
+   =========================== */
+.sheet-footer {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(197,160,89,0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 0.9s forwards;
+}
+.footer-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: rgba(197,160,89,0.3);
+}
+.footer-text {
+  font-family: system-ui, sans-serif;
+  font-size: 0.6rem;
+  color: var(--text-dim);
+  letter-spacing: 0.04em;
+}
+
+/* responsive */
+@media (max-width: 440px) {
+  .phone-frame { width: 100vw; height: 100dvh; border-radius: 0; }
+}
+
+/* ===========================
+   REDUCED MOTION
+   =========================== */
+@media (prefers-reduced-motion: reduce) {
+  .bottom-sheet { animation: none; }
+  .header-ar { animation: none; opacity: 1; }
+  .header-en { animation: none; opacity: 1; }
+  .features { animation: none; opacity: 1; }
+  .btn-google { animation: none; opacity: 1; }
+  .btn-google::before { animation: none; }
+  .btn-dismiss { animation: none; opacity: 1; }
+  .sheet-footer { animation: none; opacity: 1; }
+  .header-hairline::after { animation: none; }
+  .sheet-header::before { animation: none; }
+}
+</style>
+</head>
+<body>
+
+<div class="direction-label">
+  L2 — Tessellated Bottom Sheet
+  <span>Sheet rises from below; Islamic star pattern crowns the header; features grid anchors value prop</span>
+</div>
+
+<div class="backdrop">
+  <div class="phone-frame">
+    <div class="phone-screen">
+
+      <!-- reading content visible behind -->
+      <div class="reading-content" aria-hidden="true">
+        <div class="r-poet">المتنبي</div>
+        <div class="r-line">عَلَى قَدْرِ أَهْلِ الْعَزْمِ تَأْتِي الْعَزَائِمُ</div>
+        <div class="r-line">وَتَأْتِي عَلَى قَدْرِ الْكِرَامِ الْمَكَارِمُ</div>
+      </div>
+
+      <!-- dim overlay -->
+      <div class="phone-dim"></div>
+
+      <!-- ===== BOTTOM SHEET ===== -->
+      <div class="bottom-sheet" role="dialog" aria-modal="true" aria-label="Sign in to Dīwān">
+
+        <!-- tessellated header -->
+        <div class="sheet-header">
+          <div class="header-hairline"></div>
+          <div class="sheet-handle" aria-hidden="true"></div>
+
+          <button class="btn-close" aria-label="Close, continue reading">✕</button>
+
+          <div class="header-content">
+            <div class="header-ar" lang="ar" dir="rtl">ادخل الديوان</div>
+            <div class="header-en">Enter the Dīwān</div>
+          </div>
+        </div>
+
+        <!-- sheet body -->
+        <div class="sheet-body">
+
+          <!-- feature trio -->
+          <div class="features" aria-label="What you unlock">
+            <div class="feature-item">
+              <span class="feature-icon" aria-hidden="true">🔖</span>
+              <div class="feature-label">Save favourite verses</div>
+            </div>
+            <div class="feature-item">
+              <span class="feature-icon" aria-hidden="true">⚙️</span>
+              <div class="feature-label">Sync settings across devices</div>
+            </div>
+            <div class="feature-item">
+              <span class="feature-icon" aria-hidden="true">📖</span>
+              <div class="feature-label">Reading history &amp; progress</div>
+            </div>
+          </div>
+
+          <!-- Google CTA -->
+          <button class="btn-google" type="button">
+            <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+            </svg>
+            Continue with Google
+          </button>
+
+          <!-- dismiss -->
+          <button class="btn-dismiss" type="button">
+            Continue reading without an account
+          </button>
+
+          <!-- trust footer -->
+          <div class="sheet-footer">
+            <span class="footer-text">We never post on your behalf</span>
+            <div class="footer-dot" aria-hidden="true"></div>
+            <span class="footer-text">No spam, ever</span>
+          </div>
+
+        </div><!-- /.sheet-body -->
+      </div><!-- /.bottom-sheet -->
+
+    </div><!-- /.phone-screen -->
+  </div><!-- /.phone-frame -->
+</div><!-- /.backdrop -->
+
+</body>
+</html>

--- a/design-review/login-modal/l3.html
+++ b/design-review/login-modal/l3.html
@@ -1,0 +1,794 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+<title>L3 — Threshold / Doorway (Flagship)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Reem+Kufi:wght@400;500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet" />
+<style>
+/* ===========================
+   DESIGN TOKENS — FLAGSHIP
+   =========================== */
+:root {
+  --gold:          #c5a059;
+  --gold-bright:   #d4b463;
+  --gold-label:    #1a1200;
+  --gold-molten:   linear-gradient(135deg, #a8853d, #c5a059 22%, #e0c97a 38%, #d4b463 48%, #b8924a 62%, #d8bc6e 78%, #c5a059);
+  --gold-foil:     linear-gradient(135deg, #b8922e, #c5a059 30%, #e2c67a 55%, #c5a059 75%, #a07d38);
+  --gold-hairline: linear-gradient(90deg, transparent, rgba(160,128,64,0.4) 20%, #c5a059 50%, rgba(160,128,64,0.4) 80%, transparent);
+  --gold-border:   rgba(197,160,89,0.28);
+  --lapis-deep:    #1e3a6e;
+  --lapis-medium:  #2e5090;
+  --lapis-light:   #4a7cc9;
+  --bg-app:        #0c0c0e;
+  --bg-modal:      linear-gradient(160deg, rgba(22,18,12,0.98) 0%, rgba(10,10,14,0.99) 100%);
+  --text-primary:  rgba(236,232,224,0.94);
+  --text-muted:    rgba(236,232,224,0.52);
+  --text-dim:      rgba(236,232,224,0.3);
+  --radius-modal:  22px;
+  --radius-btn:    999px;        /* pill — maximises "liquid" quality */
+  --ease-spring:   cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out:      cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-in:       cubic-bezier(0.7, 0, 1, 1);
+}
+
+/* ===========================
+   RESET
+   =========================== */
+*, *::before, *::after {
+  box-sizing: border-box; margin: 0; padding: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+html, body {
+  height: 100%;
+  background: #040408;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* ===========================
+   DIRECTION LABEL
+   =========================== */
+.direction-label {
+  position: fixed;
+  top: 16px; left: 16px;
+  z-index: 100;
+  font-family: system-ui, sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(197,160,89,0.95);
+  background: rgba(4,4,8,0.92);
+  border: 1px solid rgba(197,160,89,0.22);
+  border-radius: 6px;
+  padding: 6px 10px;
+  backdrop-filter: blur(10px);
+  line-height: 1.4;
+}
+.direction-label span {
+  display: block;
+  color: rgba(236,232,224,0.5);
+  font-size: 9px;
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+/* ===========================
+   OUTER SCENE — amber ambient
+   =========================== */
+.scene {
+  position: fixed; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  background: radial-gradient(ellipse at 50% 40%, rgba(197,160,89,0.06), transparent 65%);
+}
+
+/* ===========================
+   PHONE FRAME
+   =========================== */
+.phone-frame {
+  position: relative;
+  width: 412px; height: 700px;
+  background: #0c0c0e;
+  border-radius: 36px;
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,0.05),
+    0 40px 80px rgba(0,0,0,0.8),
+    0 8px 24px rgba(0,0,0,0.5);
+  overflow: hidden;
+}
+.phone-frame::before {
+  content: '';
+  position: absolute; top: 0; left: 50%; transform: translateX(-50%);
+  width: 120px; height: 28px;
+  background: #0c0c0e;
+  border-radius: 0 0 18px 18px;
+  z-index: 20;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.04);
+}
+
+/* ===========================
+   PHONE SCREEN
+   =========================== */
+.phone-screen {
+  position: absolute; inset: 0;
+  background: #08080e;
+  display: flex; align-items: center; justify-content: center;
+  overflow: hidden;
+}
+
+/* faint poem text in bg */
+.bg-poem {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 22px;
+  padding: 60px 36px;
+  pointer-events: none;
+  z-index: 0;
+}
+.bg-line {
+  font-family: 'Amiri', serif;
+  font-size: 1.1rem;
+  color: rgba(197,160,89,0.18);
+  direction: rtl; text-align: center;
+  line-height: 2;
+  filter: blur(0.8px);
+}
+
+/* full-screen dim + blur  */
+.phone-dim {
+  position: absolute; inset: 0;
+  background: rgba(0,0,0,0.78);
+  backdrop-filter: blur(4px);
+  z-index: 1;
+}
+
+/* ===========================
+   MODAL — THRESHOLD ARCHWAY
+   =========================== */
+.modal {
+  position: relative;
+  z-index: 2;
+  width: 356px;
+  border-radius: var(--radius-modal);
+  background: var(--bg-modal);
+  border: 1px solid var(--gold-border);
+  box-shadow:
+    0 0 0 0.5px rgba(197,160,89,0.1),
+    0 32px 64px rgba(0,0,0,0.7),
+    0 8px 24px rgba(0,0,0,0.5),
+    0 0 40px rgba(197,160,89,0.06),
+    inset 0 1px 0 rgba(197,160,89,0.12),
+    inset 0 -1px 0 rgba(197,160,89,0.06);
+  overflow: hidden;
+  opacity: 0;
+  transform: scale(0.86) translateY(18px);
+  animation: modalSpring 0.75s var(--ease-spring) 0.1s forwards;
+}
+
+@keyframes modalSpring {
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+/* ===========================
+   TOP HAIRLINE — animated sheen
+   =========================== */
+.hairline-top {
+  height: 2px;
+  background: var(--gold-hairline);
+  position: relative; overflow: hidden;
+}
+.hairline-top::after {
+  content: '';
+  position: absolute; top: -3px; left: -70%;
+  width: 70%; height: 8px;
+  background: linear-gradient(90deg, transparent, rgba(255,248,200,0.7), transparent);
+  animation: sheen 3s var(--ease-out) 0.9s infinite;
+}
+@keyframes sheen {
+  0%   { left: -70%; opacity: 0; }
+  10%  { opacity: 1; }
+  90%  { opacity: 1; }
+  100% { left: 110%; opacity: 0; }
+}
+
+/* ===========================
+   LIVE GEOMETRIC CANVAS — tessellation zone
+   =========================== */
+.geo-zone {
+  position: relative;
+  height: 128px;
+  overflow: hidden;
+  background: linear-gradient(180deg,
+    rgba(18,14,8,0.97) 0%,
+    rgba(14,11,7,0.97) 60%,
+    rgba(10,10,14,0.97) 100%
+  );
+}
+
+.geo-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+}
+
+/* vignette over canvas — fades tessellation into body */
+.geo-vignette {
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 45%, transparent 20%, rgba(10,10,14,0.4) 100%),
+    linear-gradient(to bottom, rgba(18,14,8,0.2) 0%, transparent 30%, rgba(10,10,14,0.88) 80%, rgba(10,10,14,0.99) 96%, rgba(10,10,14,1) 100%);
+  pointer-events: none;
+}
+
+/* ===========================
+   DOORWAY / ARCH TYPOGRAPHY — overlaid on canvas
+   =========================== */
+.arch-headline {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  z-index: 2;
+  padding-bottom: 4px;
+}
+
+.arch-ar {
+  font-family: 'Reem Kufi', sans-serif;
+  font-size: 2rem;
+  font-weight: 700;          /* maximum weight — strong presence */
+  color: var(--gold-bright);
+  direction: rtl;
+  letter-spacing: 0.015em;
+  text-shadow:
+    0 2px 16px rgba(197,160,89,0.55),
+    0 0 40px rgba(197,160,89,0.2);
+  opacity: 0;
+  animation: titleReveal 0.65s var(--ease-spring) 0.5s forwards;
+}
+
+@keyframes titleReveal {
+  from { opacity: 0; transform: scale(0.94) translateY(6px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.arch-en {
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-weight: 400;
+  font-size: 0.88rem;
+  color: rgba(197,160,89,0.6);
+  letter-spacing: 0.1em;
+  margin-top: 3px;
+  opacity: 0;
+  animation: fadeIn 0.5s var(--ease-out) 0.68s forwards;
+}
+
+/* close button — sits at top-right of geo zone */
+.btn-close {
+  position: absolute;
+  top: 12px; right: 14px;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  border: 1px solid rgba(197,160,89,0.2);
+  background: rgba(0,0,0,0.45);
+  color: rgba(197,160,89,0.5);
+  font-size: 13px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  z-index: 5;
+  /* no negative margin overflow; expanded via pseudo */
+  padding: 4px;
+  transition: background 0.16s, color 0.16s, border-color 0.16s, transform 0.16s;
+  backdrop-filter: blur(6px);
+}
+/* touch-area expansion without layout overflow */
+.btn-close::before {
+  content: '';
+  position: absolute;
+  inset: -4px;
+}
+.btn-close:hover {
+  background: rgba(197,160,89,0.15);
+  color: var(--gold);
+  border-color: rgba(197,160,89,0.5);
+  transform: scale(1.08);
+}
+.btn-close:active {
+  transform: scale(0.9);
+  transition-duration: 0.08s;
+}
+.btn-close:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+
+/* ===========================
+   MODAL BODY
+   =========================== */
+.modal-body {
+  padding: 20px 26px 22px;
+}
+
+/* ===========================
+   VERSE — Amiri, lighter role
+   =========================== */
+.verse-block {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+  background: rgba(197,160,89,0.04);
+  border: 1px solid rgba(197,160,89,0.1);
+  border-radius: 12px;
+  position: relative;
+  opacity: 0;
+  animation: slideUp 0.5s var(--ease-spring) 0.65s forwards;
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* left gold rule */
+.verse-block::before {
+  content: '';
+  position: absolute; top: 10px; bottom: 10px; right: 0;
+  width: 2px;
+  background: linear-gradient(to bottom, transparent, var(--gold) 30%, var(--gold) 70%, transparent);
+  border-radius: 1px;
+  opacity: 0.4;
+}
+
+.verse-ar {
+  font-family: 'Amiri', serif;
+  font-size: 0.96rem;
+  font-weight: 400;
+  color: var(--text-primary);
+  direction: rtl; text-align: right;
+  line-height: 2;
+  letter-spacing: 0.01em;
+}
+
+/* editorial Italian sub-label */
+.verse-attribution {
+  margin-top: 4px;
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 0.73rem;
+  color: rgba(197,160,89,0.45);
+  text-align: right;
+  direction: rtl;
+  letter-spacing: 0.04em;
+}
+
+/* ===========================
+   VALUE PROP
+   =========================== */
+.value-prop {
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 0.87rem;
+  font-weight: 400;         /* fine editorial weight — contrast with Reem Kufi bold */
+  color: var(--text-muted);
+  line-height: 1.7;
+  text-align: center;
+  margin-bottom: 20px;
+  padding: 0 4px;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 0.78s forwards;
+}
+
+@keyframes fadeIn { to { opacity: 1; } }
+
+/* ===========================
+   LIQUID MOLTEN GOLD CTA — flagship hero button
+   =========================== */
+.btn-google-wrap {
+  opacity: 0;
+  animation: slideUp 0.5s var(--ease-spring) 0.88s forwards;
+}
+
+.btn-google {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 11px;
+  width: 100%;
+  min-height: 56px;
+  padding: 0 22px;
+  border-radius: var(--radius-btn);   /* full pill */
+  border: none;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  /* molten gold fill */
+  background: var(--gold-molten);
+  color: var(--gold-label);
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.94rem;
+  font-weight: 700;
+  letter-spacing: 0.025em;
+  /* convex lighting: top highlight simulates dome */
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.5) inset,     /* specular top edge */
+    0 -1px 0 rgba(0,0,0,0.28) inset,          /* shadow bottom edge */
+    0 6px 20px rgba(197,160,89,0.38),
+    0 2px 6px  rgba(197,160,89,0.22);
+  transition:
+    transform 0.16s var(--ease-out),
+    box-shadow 0.16s var(--ease-out);
+}
+
+/* convex top highlight dome — ::after on full pill */
+.btn-google::after {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  /* top half of the pill only, convex */
+  height: 50%;
+  border-radius: var(--radius-btn) var(--radius-btn) 60% 60% / var(--radius-btn) var(--radius-btn) 50% 50%;
+  background: linear-gradient(to bottom,
+    rgba(255,255,255,0.26) 0%,
+    rgba(255,255,255,0.06) 60%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+
+/* slow continuous gold sheen sweep — auto-animates */
+.btn-google::before {
+  content: '';
+  position: absolute; inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 25%,
+    rgba(255,255,255,0.22) 45%,
+    rgba(255,255,255,0.28) 50%,
+    rgba(255,255,255,0.22) 55%,
+    transparent 75%
+  );
+  transform: translateX(-140%);
+  animation: goldSheen 3.5s var(--ease-out) 1.2s infinite;
+}
+
+@keyframes goldSheen {
+  0%   { transform: translateX(-140%); opacity: 0; }
+  8%   { opacity: 1; }
+  92%  { opacity: 1; }
+  100% { transform: translateX(140%); opacity: 0; }
+}
+
+/* hover lift */
+.btn-google:hover {
+  transform: translateY(-2px) scale(1.015);
+  box-shadow:
+    0 1px 0 rgba(255,255,255,0.5) inset,
+    0 -1px 0 rgba(0,0,0,0.28) inset,
+    0 10px 28px rgba(197,160,89,0.48),
+    0 4px 10px rgba(197,160,89,0.28);
+}
+
+/* press — "soft press" inward */
+.btn-google:active {
+  transform: scale(0.965) translateY(1px);
+  box-shadow:
+    0 0.5px 0 rgba(255,255,255,0.3) inset,
+    0 -2px 0 rgba(0,0,0,0.35) inset,
+    0 2px 8px rgba(197,160,89,0.2);
+  transition-duration: 0.08s;
+}
+
+.btn-google:focus-visible {
+  outline: 2px solid var(--gold-bright);
+  outline-offset: 3px;
+}
+
+/* Google G glyph */
+.g-logo {
+  flex-shrink: 0;
+  /* slight depth ring around the G in dark context */
+  filter: drop-shadow(0 1px 2px rgba(0,0,0,0.18));
+}
+
+.btn-label {
+  position: relative; z-index: 1;
+  color: var(--gold-label);
+  font-weight: 700;
+}
+
+/* ===========================
+   DISMISS
+   =========================== */
+.btn-dismiss {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 8px;
+  margin-top: 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-dim);
+  font-family: 'Cormorant Garamond', serif;
+  font-style: italic;
+  font-size: 0.83rem;
+  text-align: center;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color 0.18s, background 0.18s;
+  letter-spacing: 0.03em;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 1.05s forwards;
+}
+.btn-dismiss:hover { color: rgba(197,160,89,0.5); background: rgba(255,255,255,0.03); }
+.btn-dismiss:focus-visible { outline: 2px solid rgba(197,160,89,0.4); outline-offset: 2px; }
+
+/* ===========================
+   TRUST + DIVIDER
+   =========================== */
+.trust-row {
+  margin-top: 14px;
+  padding-top: 13px;
+  border-top: 1px solid rgba(197,160,89,0.09);
+  text-align: center;
+  font-family: system-ui, sans-serif;
+  font-size: 0.6rem;
+  color: var(--text-dim);
+  letter-spacing: 0.05em;
+  opacity: 0;
+  animation: fadeIn 0.4s var(--ease-out) 1.15s forwards;
+}
+
+/* ===========================
+   BOTTOM HAIRLINE
+   =========================== */
+.hairline-bottom {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(197,160,89,0.22), transparent);
+}
+
+/* ===========================
+   responsive
+   =========================== */
+@media (max-width: 440px) {
+  .phone-frame { width: 100vw; height: 100dvh; border-radius: 0; }
+  .modal { width: 94vw; }
+}
+
+/* ===========================
+   REDUCED MOTION
+   =========================== */
+@media (prefers-reduced-motion: reduce) {
+  .modal { animation: none; opacity: 1; transform: none; }
+  .arch-ar { animation: none; opacity: 1; transform: none; }
+  .arch-en { animation: none; opacity: 1; }
+  .verse-block { animation: none; opacity: 1; transform: none; }
+  .value-prop { animation: none; opacity: 1; }
+  .btn-google-wrap { animation: none; opacity: 1; }
+  .btn-google::before { animation: none; }
+  .btn-dismiss { animation: none; opacity: 1; }
+  .trust-row { animation: none; opacity: 1; }
+  .hairline-top::after { animation: none; }
+}
+</style>
+</head>
+<body>
+
+<div class="direction-label">
+  L3 — Threshold / Doorway (Flagship)
+  <span>Live tessellated star canvas; liquid pill CTA; Reem Kufi 700 / Amiri / Cormorant weight hierarchy</span>
+</div>
+
+<div class="scene">
+  <div class="phone-frame">
+    <div class="phone-screen">
+
+      <!-- background poem text -->
+      <div class="bg-poem" aria-hidden="true">
+        <div class="bg-line">وَمَا نَيْلُ الْمَطَالِبِ بِالتَّمَنِّي</div>
+        <div class="bg-line">وَلَكِنْ تُؤْخَذُ الدُّنْيَا غِلَابَا</div>
+        <div class="bg-line" style="font-size:0.82rem; opacity:0.7">— الطُّغْرَائِيّ</div>
+      </div>
+
+      <div class="phone-dim"></div>
+
+      <!-- ===== MODAL ===== -->
+      <div class="modal" role="dialog" aria-modal="true" aria-label="Sign in to Dīwān">
+
+        <!-- top hairline with sheen -->
+        <div class="hairline-top"></div>
+
+        <!-- live tessellation zone -->
+        <div class="geo-zone">
+          <canvas class="geo-canvas" id="tessCanvas" aria-hidden="true"></canvas>
+          <div class="geo-vignette"></div>
+
+          <!-- arch headline -->
+          <div class="arch-headline">
+            <div class="arch-ar" lang="ar" dir="rtl">ادخل الديوان</div>
+            <div class="arch-en">Enter the Dīwān</div>
+          </div>
+
+          <!-- close -->
+          <button class="btn-close" aria-label="Close, continue reading">✕</button>
+        </div>
+
+        <!-- body -->
+        <div class="modal-body">
+
+          <!-- couplet verse excerpt -->
+          <div class="verse-block">
+            <div class="verse-ar" lang="ar" dir="rtl">
+              أَلَا لَيْتَ الشَّبَابَ يَعُودُ يَوْمًا
+            </div>
+            <div class="verse-attribution" lang="ar" dir="rtl">— أبو تمام</div>
+          </div>
+
+          <!-- value prop — Cormorant italic, restrained weight -->
+          <p class="value-prop">
+            Save beloved verses &amp; keep your settings in harmony<br>across all your devices.
+          </p>
+
+          <!-- LIQUID MOLTEN GOLD CTA -->
+          <div class="btn-google-wrap">
+            <button class="btn-google" type="button">
+              <svg class="g-logo" width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+              </svg>
+              <span class="btn-label">Continue with Google</span>
+            </button>
+          </div>
+
+          <!-- dismiss -->
+          <button class="btn-dismiss" type="button">
+            Continue reading without an account
+          </button>
+
+          <!-- trust -->
+          <div class="trust-row">
+            We never post on your behalf &nbsp;·&nbsp; No spam, ever
+          </div>
+
+        </div><!-- /.modal-body -->
+
+        <div class="hairline-bottom"></div>
+      </div><!-- /.modal -->
+
+    </div><!-- /.phone-screen -->
+  </div><!-- /.phone-frame -->
+</div><!-- /.scene -->
+
+<!-- ===========================
+     LIVE ISLAMIC TESSELLATION
+     8-point star field — animates slowly
+     =========================== -->
+<script>
+(function() {
+  const canvas = document.getElementById('tessCanvas');
+  if (!canvas) return;
+
+  // Respect prefers-reduced-motion: draw once, no animation
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const ctx = canvas.getContext('2d');
+  let W, H, raf;
+
+  // ---- sizing ----
+  function resize() {
+    const pr = Math.min(devicePixelRatio, 2); // cap at 2x for perf
+    W = canvas.offsetWidth;
+    H = canvas.offsetHeight;
+    canvas.width  = W * pr;
+    canvas.height = H * pr;
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(pr, pr);
+  }
+  resize();
+  window.addEventListener('resize', () => { resize(); if (prefersReduced) draw(0); });
+
+  // ---- draw one 8-point star ----
+  function star8(cx, cy, r, phi) {
+    const pts = 8;
+    const inner = r * 0.38; // slightly tighter inner for crisper stars
+    ctx.beginPath();
+    for (let i = 0; i < pts * 2; i++) {
+      const angle = (Math.PI / pts) * i + phi;
+      const radius = i % 2 === 0 ? r : inner;
+      const x = cx + Math.cos(angle) * radius;
+      const y = cy + Math.sin(angle) * radius;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+  }
+
+  // ---- draw connecting octagon fill between stars ----
+  function octagon(cx, cy, r, phi) {
+    ctx.beginPath();
+    for (let i = 0; i < 8; i++) {
+      const angle = (Math.PI / 4) * i + phi;
+      const x = cx + Math.cos(angle) * r;
+      const y = cy + Math.sin(angle) * r;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+  }
+
+  // ---- render ----
+  let startTime = null;
+
+  function draw(ts) {
+    if (!startTime) startTime = ts;
+    const t = prefersReduced ? 0 : (ts - startTime) / 1000;
+
+    ctx.clearRect(0, 0, W, H);
+
+    // tile parameters — slightly smaller tiles = denser, more ornate
+    const tileSize = 38;
+    const cols = Math.ceil(W / tileSize) + 3;
+    const rows = Math.ceil(H / tileSize) + 3;
+
+    // slow drift
+    const driftX = prefersReduced ? 0 : Math.sin(t * 0.11) * 7;
+    const driftY = prefersReduced ? 0 : Math.cos(t * 0.085) * 5;
+    // gentle rotation breathe
+    const phi = prefersReduced ? Math.PI / 8 : (Math.PI / 8 + Math.sin(t * 0.065) * 0.07);
+
+    for (let row = -1; row < rows; row++) {
+      for (let col = -1; col < cols; col++) {
+        const offsetX = (row % 2 === 0) ? 0 : tileSize * 0.5;
+        const cx = col * tileSize + offsetX + driftX;
+        const cy = row * tileSize + driftY;
+        const r = tileSize * 0.40;
+
+        const phase = col * 1.27 + row * 0.91;
+        const pulse = prefersReduced ? 1 : (0.88 + 0.12 * Math.sin(t * 0.45 + phase * 0.38));
+
+        const baseAlpha = 0.28 * pulse;
+
+        ctx.save();
+
+        // octagon connector (drawn first, behind star)
+        ctx.globalAlpha = baseAlpha * 0.22;
+        ctx.strokeStyle = '#c5a059';
+        ctx.lineWidth = 0.6;
+        octagon(cx, cy, r * 0.62 * pulse, phi + Math.PI / 8);
+        ctx.stroke();
+
+        // 8-point star — subtle inner fill gives body
+        ctx.globalAlpha = baseAlpha * 0.18;
+        ctx.fillStyle = 'rgba(197,160,89,1)';
+        star8(cx, cy, r * pulse, phi);
+        ctx.fill();
+
+        ctx.globalAlpha = baseAlpha;
+        ctx.strokeStyle = '#c5a059';
+        ctx.lineWidth = 0.85;
+        star8(cx, cy, r * pulse, phi);
+        ctx.stroke();
+
+        ctx.restore();
+      }
+    }
+
+    // radial edge fade — vignette to keep edges from looking abrupt
+    const grd = ctx.createRadialGradient(W/2, H/2, W * 0.2, W/2, H/2, Math.max(W, H) * 0.65);
+    grd.addColorStop(0, 'rgba(10,10,14,0)');
+    grd.addColorStop(0.75, 'rgba(10,10,14,0)');
+    grd.addColorStop(1, 'rgba(10,10,14,0.7)');
+    ctx.fillStyle = grd;
+    ctx.globalAlpha = 1;
+    ctx.fillRect(0, 0, W, H);
+
+    if (!prefersReduced) {
+      raf = requestAnimationFrame(draw);
+    }
+  }
+
+  raf = requestAnimationFrame(draw);
+})();
+</script>
+
+</body>
+</html>

--- a/design-review/share-modal/index.html
+++ b/design-review/share-modal/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+<title>Share Modal — Design Directions</title>
+<style>
+  :root {
+    --gold: #c5a059;
+    --gold-bright: #d4b463;
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
+  }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
+  html, body { height: 100%; width: 100%; background: #04040a; overflow: hidden; font-family: system-ui, -apple-system, sans-serif; }
+
+  /* Each option fills the whole screen */
+  .frame {
+    position: fixed; inset: 0; width: 100%; height: 100%;
+    border: none; opacity: 0; pointer-events: none;
+    transition: opacity 0.3s var(--ease);
+  }
+  .frame.active { opacity: 1; pointer-events: auto; }
+
+  /* Floating side-nav arrows */
+  .nav-btn {
+    position: fixed; top: 50%; transform: translateY(-50%);
+    z-index: 50; width: 48px; height: 48px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    border: 1px solid rgba(197,160,89,0.45);
+    background: rgba(7,7,12,0.6); backdrop-filter: blur(10px);
+    color: var(--gold); font-size: 22px; line-height: 1; cursor: pointer;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+    transition: background 0.18s var(--ease), color 0.18s var(--ease), transform 0.18s var(--ease), opacity 0.18s;
+  }
+  .nav-btn:hover { background: rgba(197,160,89,0.18); color: var(--gold-bright); transform: translateY(-50%) scale(1.08); }
+  .nav-btn:active { transform: translateY(-50%) scale(0.92); }
+  .nav-btn:disabled { opacity: 0.18; pointer-events: none; }
+  .nav-btn:focus-visible { outline: 2px solid var(--gold); outline-offset: 3px; }
+  .nav-prev { left: calc(8px + env(safe-area-inset-left, 0px)); }
+  .nav-next { right: calc(8px + env(safe-area-inset-right, 0px)); }
+
+  /* Compact label pill (top-center) */
+  .label {
+    position: fixed; top: calc(10px + env(safe-area-inset-top, 0px)); left: 50%;
+    transform: translateX(-50%); z-index: 50;
+    display: flex; align-items: center; gap: 8px; max-width: 80vw;
+    padding: 6px 14px; border-radius: 999px;
+    background: rgba(7,7,12,0.72); backdrop-filter: blur(10px);
+    border: 1px solid rgba(197,160,89,0.28);
+    font-size: 12px; color: var(--gold); white-space: nowrap; overflow: hidden;
+  }
+  .label .num { opacity: 0.55; font-weight: 700; letter-spacing: 0.04em; }
+  .label .name { font-weight: 600; overflow: hidden; text-overflow: ellipsis; }
+  .label .flag {
+    font-size: 8.5px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; color: #1a1200;
+    background: linear-gradient(135deg, #a8853d, #c5a059 30%, #e0c97a 50%, #c5a059 70%, #a8853d);
+    border-radius: 4px; padding: 2px 6px; display: none;
+  }
+  .label.is-flag .flag { display: inline-block; }
+
+  /* Dots */
+  .dots {
+    position: fixed; bottom: calc(12px + env(safe-area-inset-bottom, 0px)); left: 50%;
+    transform: translateX(-50%); z-index: 50;
+    display: flex; gap: 8px; padding: 8px 12px; border-radius: 999px;
+    background: rgba(7,7,12,0.6); backdrop-filter: blur(8px); border: 1px solid rgba(197,160,89,0.18);
+  }
+  .dot { width: 8px; height: 8px; border-radius: 50%; background: rgba(197,160,89,0.25); cursor: pointer; transition: all 0.25s var(--ease); }
+  .dot.active { background: var(--gold); width: 22px; border-radius: 4px; box-shadow: 0 0 6px rgba(197,160,89,0.4); }
+  .dot:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+</style>
+</head>
+<body>
+  <iframe class="frame active" src="s1.html" title="S1 — Folio (Flagship)" loading="eager"></iframe>
+  <iframe class="frame" src="s2.html" title="S2 — Majlis" loading="lazy"></iframe>
+  <iframe class="frame" src="s3.html" title="S3 — Maktuba" loading="lazy"></iframe>
+
+  <button class="nav-btn nav-prev" id="prev" aria-label="Previous design" disabled>‹</button>
+  <button class="nav-btn nav-next" id="next" aria-label="Next design">›</button>
+
+  <div class="label is-flag" id="label">
+    <span class="num" id="num">S1</span>
+    <span class="name" id="name">Folio</span>
+    <span class="flag">Flagship</span>
+  </div>
+
+  <div class="dots" id="dots" role="tablist" aria-label="Design directions"></div>
+
+<script>
+  const dirs = [
+    { num: 'S1', name: 'Folio', flagship: true },
+    { num: 'S2', name: 'Majlis', flagship: false },
+    { num: 'S3', name: 'Maktuba', flagship: false },
+  ];
+  const frames = Array.from(document.querySelectorAll('.frame'));
+  const prev = document.getElementById('prev');
+  const next = document.getElementById('next');
+  const label = document.getElementById('label');
+  const num = document.getElementById('num');
+  const name = document.getElementById('name');
+  const dotsWrap = document.getElementById('dots');
+  let cur = 0;
+
+  dirs.forEach((d, i) => {
+    const dot = document.createElement('button');
+    dot.className = 'dot' + (i === 0 ? ' active' : '');
+    dot.setAttribute('role', 'tab');
+    dot.setAttribute('aria-label', `${d.num}: ${d.name}`);
+    dot.addEventListener('click', () => go(i));
+    dotsWrap.appendChild(dot);
+  });
+  const dots = Array.from(dotsWrap.children);
+
+  function go(i) {
+    if (i < 0 || i >= dirs.length) return;
+    frames[cur].classList.remove('active');
+    dots[cur].classList.remove('active');
+    cur = i;
+    frames[cur].classList.add('active');
+    dots[cur].classList.add('active');
+    const d = dirs[cur];
+    num.textContent = d.num;
+    name.textContent = d.name;
+    label.classList.toggle('is-flag', d.flagship);
+    prev.disabled = cur === 0;
+    next.disabled = cur === dirs.length - 1;
+  }
+
+  prev.addEventListener('click', () => go(cur - 1));
+  next.addEventListener('click', () => go(cur + 1));
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowLeft') go(cur - 1);
+    if (e.key === 'ArrowRight') go(cur + 1);
+  });
+</script>
+</body>
+</html>

--- a/design-review/share-modal/s1.html
+++ b/design-review/share-modal/s1.html
@@ -1,0 +1,1462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Folio — Share Modal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500;1,600&family=Reem+Kufi:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   DESIGN TOKENS
+   ============================================================ */
+:root {
+  --gold: #c5a059;
+  --gold-bright: #d4b463;
+  --gold-foil: linear-gradient(135deg, #b8922e, #c5a059 30%, #e2c67a 55%, #c5a059 75%, #a07d38);
+  --molten-gold: linear-gradient(135deg, #a8853d, #c5a059 22%, #e0c97a 38%, #d4b463 48%, #b8924a 62%, #d8bc6e 78%, #c5a059);
+  --lapis-deep: #1e3a6e;
+  --lapis-medium: #2e5090;
+  --lapis-light: #4a7cc9;
+  --bg-app: #0c0c0e;
+  --panel-bg: linear-gradient(145deg, rgba(20,18,15,0.97), rgba(12,12,14,0.98));
+  --gold-border: rgba(197,160,89,0.25);
+  --gold-rule: linear-gradient(90deg, transparent, rgba(160,128,64,0.4) 20%, #C5A059 50%, rgba(160,128,64,0.4) 80%, transparent);
+
+  --font-arabic-display: 'Reem Kufi', serif;
+  --font-arabic-body: 'Amiri', serif;
+  --font-english-editorial: 'Cormorant Garamond', Georgia, serif;
+  --font-ui: system-ui, -apple-system, sans-serif;
+
+  /* Premium easing */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out-quart: cubic-bezier(.4, 0, .2, 1);
+  --ease-in-quart: cubic-bezier(.7, 0, 1, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  --duration-entrance: 0.7s;
+  --duration-shelf: 0.5s;
+  --duration-transition: 0.3s;
+  --duration-hover: 0.18s;
+  --duration-micro: 0.1s;
+
+  --radius-phone: 48px;
+  --radius-chip: 50%;
+  --radius-btn: 10px;
+}
+
+/* ============================================================
+   RESET & BASE
+   ============================================================ */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  height: 100%;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  background: var(--bg-app);
+  height: 100vh;
+  height: 100dvh;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  font-family: var(--font-ui);
+  overflow: hidden;
+  position: relative;
+}
+
+/* Ambient radial glow behind the phone */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image:
+    radial-gradient(ellipse 70% 50% at 50% 60%, rgba(197,160,89,0.05) 0%, transparent 70%),
+    radial-gradient(ellipse 50% 40% at 20% 100%, rgba(30,58,110,0.08) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ============================================================
+   STAGE LABEL
+   ============================================================ */
+.stage-label {
+  display: none;
+}
+
+.stage-label__title {
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--gold);
+  letter-spacing: 0.02em;
+  line-height: 1;
+  text-shadow: 0 1px 8px rgba(0,0,0,0.8);
+}
+
+.stage-label__sub {
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 0.65rem;
+  font-weight: 400;
+  color: rgba(197,160,89,0.45);
+  letter-spacing: 0.04em;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.7);
+}
+
+/* ============================================================
+   PHONE FRAME
+   ============================================================ */
+.phone-frame {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  border-radius: 0;
+  background: #111113;
+  box-shadow: none;
+  overflow: hidden;
+
+  /* Spring entrance */
+  opacity: 0;
+  transform: scale(0.98);
+  animation: phoneEntrance var(--duration-entrance) var(--ease-spring) 0.08s forwards;
+}
+
+@keyframes phoneEntrance {
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+/* Phone volume/side buttons (decorative) — hidden in full-bleed mobile view */
+.phone-frame::before {
+  display: none;
+}
+
+/* Dynamic Island — hidden; real device chrome already provides this */
+.phone-dynamic-island {
+  display: none;
+}
+
+/* Phone screen area */
+.phone-screen {
+  position: absolute;
+  inset: 0;
+  border-radius: 0;
+  overflow: hidden;
+  background: var(--bg-app);
+}
+
+/* Status bar — hidden; real device chrome already provides this */
+.phone-statusbar {
+  display: none;
+}
+
+/* ============================================================
+   SHARE MODAL — FOLIO
+   The card IS the modal. No background container visible.
+   ============================================================ */
+.share-modal {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 0;
+  overflow: hidden;
+}
+
+/* Full-bleed card wrapper */
+.card-preview-wrapper {
+  position: absolute;
+  inset: 0;
+  border-radius: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* ============================================================
+   ISLAMIC GEOMETRY CANVAS BAND — removed; full-canvas handles tessellation
+   ============================================================ */
+.geometry-canvas-band {
+  display: none;
+}
+
+/* ============================================================
+   CARD PREVIEW
+   ============================================================ */
+.card-preview {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 32px 175px;
+  transition:
+    opacity var(--duration-transition) var(--ease-out-quart),
+    background-color var(--duration-transition) var(--ease-out-quart);
+}
+
+/* Islamic geometry texture — static CSS layer (very subtle) */
+.card-preview::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.035;
+  background-image:
+    repeating-linear-gradient(0deg, transparent, transparent 34px, rgba(197,160,89,0.9) 34px, rgba(197,160,89,0.9) 35px),
+    repeating-linear-gradient(90deg, transparent, transparent 34px, rgba(197,160,89,0.9) 34px, rgba(197,160,89,0.9) 35px),
+    repeating-linear-gradient(45deg, transparent, transparent 23px, rgba(197,160,89,0.5) 23px, rgba(197,160,89,0.5) 24px),
+    repeating-linear-gradient(-45deg, transparent, transparent 23px, rgba(197,160,89,0.5) 23px, rgba(197,160,89,0.5) 24px);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.card-preview > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* Cross-dissolve when style changes */
+.card-preview.transitioning {
+  opacity: 0;
+}
+
+/* ---- CARD BORDER — gold foil shimmer pulse ---- */
+.card-foil-border {
+  position: absolute;
+  inset: 14px;
+  border-radius: 6px;
+  pointer-events: none;
+  z-index: 1;
+  animation: foilBorderPulse 2s ease-in-out infinite alternate;
+}
+
+@keyframes foilBorderPulse {
+  0%   { box-shadow: 0 0 0 1px rgba(197,160,89,0.18), 0 0 12px rgba(197,160,89,0.06); }
+  100% { box-shadow: 0 0 0 1px rgba(226,198,122,0.32), 0 0 24px rgba(197,160,89,0.14); }
+}
+
+/* ---- STYLE: Dīwān (default) ---- */
+.card-preview[data-style="diwan"] {
+  background-color: #0c0c0e;
+}
+
+.card-preview[data-style="diwan"] .card-accent-bar {
+  background: var(--lapis-deep);
+  opacity: 1;
+}
+
+.card-preview[data-style="diwan"] .card-ornament {
+  border-color: var(--gold-border);
+  opacity: 1;
+}
+
+.card-preview[data-style="diwan"] .arabic-poetry {
+  color: #ece8e0;
+}
+
+.card-preview[data-style="diwan"] .english-translation {
+  color: rgba(236,232,224,0.55);
+}
+
+.card-preview[data-style="diwan"] .poet-name {
+  color: var(--gold);
+}
+
+/* ---- STYLE: Ibn Muqla ---- */
+.card-preview[data-style="ibn-muqla"] {
+  background-color: #1a1208;
+}
+
+.card-preview[data-style="ibn-muqla"]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 70% 50% at 30% 20%, rgba(80,50,10,0.45) 0%, transparent 70%),
+    radial-gradient(ellipse 50% 70% at 80% 80%, rgba(40,20,5,0.55) 0%, transparent 70%),
+    radial-gradient(ellipse 100% 100% at 50% 50%, transparent 40%, rgba(0,0,0,0.6) 100%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.card-preview[data-style="ibn-muqla"] .card-accent-bar {
+  opacity: 0;
+}
+
+.card-preview[data-style="ibn-muqla"] .card-ornament {
+  border-color: rgba(180,130,60,0.2);
+  opacity: 0.5;
+}
+
+.card-preview[data-style="ibn-muqla"] .arabic-poetry {
+  color: #f0e8d8;
+}
+
+.card-preview[data-style="ibn-muqla"] .english-translation {
+  color: rgba(220,200,160,0.5);
+}
+
+.card-preview[data-style="ibn-muqla"] .poet-name {
+  color: rgba(197,160,89,0.8);
+}
+
+/* ---- STYLE: Sinan ---- */
+.card-preview[data-style="sinan"] {
+  background-color: #f8f6f0;
+}
+
+.card-preview[data-style="sinan"]::before {
+  background-image:
+    repeating-linear-gradient(0deg, transparent, transparent 34px, rgba(197,160,89,0.18) 34px, rgba(197,160,89,0.18) 35px),
+    repeating-linear-gradient(90deg, transparent, transparent 34px, rgba(197,160,89,0.18) 34px, rgba(197,160,89,0.18) 35px);
+  opacity: 0.9;
+}
+
+.card-preview[data-style="sinan"] .card-accent-bar {
+  background: var(--gold);
+  height: 2px;
+  opacity: 1;
+}
+
+.card-preview[data-style="sinan"] .card-ornament {
+  border-color: rgba(197,160,89,0.4);
+  opacity: 1;
+}
+
+.card-preview[data-style="sinan"] .arabic-poetry {
+  color: #111115;
+}
+
+.card-preview[data-style="sinan"] .english-translation {
+  color: rgba(17,17,21,0.45);
+}
+
+.card-preview[data-style="sinan"] .poet-name {
+  color: var(--gold);
+}
+
+.card-preview[data-style="sinan"] .card-rule {
+  background: linear-gradient(90deg, transparent, rgba(197,160,89,0.6) 20%, var(--gold) 50%, rgba(197,160,89,0.6) 80%, transparent);
+}
+
+/* ---- STYLE: Zaha Hadid ---- */
+.card-preview[data-style="zaha"] {
+  background-color: #111115;
+}
+
+.card-preview[data-style="zaha"]::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, transparent 60%, rgba(80,80,110,0.15) 100%),
+    linear-gradient(-45deg, transparent 70%, rgba(60,60,90,0.12) 100%);
+  clip-path: polygon(0 0, 100% 0, 100% 70%, 85% 100%, 0 100%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.card-preview[data-style="zaha"] .card-accent-bar {
+  background: linear-gradient(90deg, rgba(150,150,180,0.3), rgba(200,200,220,0.6));
+  opacity: 1;
+}
+
+.card-preview[data-style="zaha"] .card-ornament {
+  border-color: rgba(180,180,210,0.15);
+  transform: skewX(-2deg);
+  opacity: 1;
+}
+
+.card-preview[data-style="zaha"] .arabic-poetry {
+  color: #d8d8e8;
+}
+
+.card-preview[data-style="zaha"] .english-translation {
+  color: rgba(200,200,218,0.42);
+}
+
+.card-preview[data-style="zaha"] .poet-name {
+  color: rgba(180,180,210,0.7);
+}
+
+.card-preview[data-style="zaha"] .card-rule {
+  background: linear-gradient(90deg, transparent, rgba(180,180,210,0.3) 20%, rgba(200,200,220,0.5) 50%, rgba(180,180,210,0.3) 80%, transparent);
+  transform: skewX(-2deg);
+}
+
+/* ---- STYLE: Hassan Fathy ---- */
+.card-preview[data-style="fathy"] {
+  background-color: #2d1b0e;
+}
+
+.card-preview[data-style="fathy"]::before {
+  background-image:
+    repeating-linear-gradient(0deg, transparent, transparent 28px, rgba(180,120,60,0.22) 28px, rgba(180,120,60,0.22) 29px),
+    repeating-linear-gradient(90deg, transparent, transparent 28px, rgba(180,120,60,0.22) 28px, rgba(180,120,60,0.22) 29px);
+  opacity: 0.5;
+}
+
+.card-preview[data-style="fathy"]::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 200px;
+  background: linear-gradient(0deg, rgba(45,27,14,0.9) 0%, transparent 100%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.card-preview[data-style="fathy"] .card-accent-bar {
+  background: linear-gradient(90deg, #8b4513, #c5872a, #8b4513);
+  opacity: 0.8;
+}
+
+.card-preview[data-style="fathy"] .card-ornament {
+  border-color: rgba(180,120,50,0.35);
+  border-radius: 12px;
+  opacity: 1;
+}
+
+.card-preview[data-style="fathy"] .arabic-poetry {
+  color: #f0d8b0;
+}
+
+.card-preview[data-style="fathy"] .english-translation {
+  color: rgba(220,190,140,0.5);
+}
+
+.card-preview[data-style="fathy"] .poet-name {
+  color: #c5872a;
+}
+
+.card-preview[data-style="fathy"] .card-rule {
+  background: linear-gradient(90deg, transparent, rgba(180,120,50,0.4) 20%, rgba(197,135,42,0.7) 50%, rgba(180,120,50,0.4) 80%, transparent);
+}
+
+/* ============================================================
+   CARD INNER ELEMENTS
+   ============================================================ */
+.card-accent-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: var(--lapis-deep);
+  transition:
+    background var(--duration-transition) var(--ease-out-quart),
+    opacity var(--duration-transition) var(--ease-out-quart),
+    height var(--duration-transition) var(--ease-out-quart);
+  z-index: 3;
+}
+
+.card-ornament {
+  position: absolute;
+  inset: 20px;
+  border: 1px solid var(--gold-border);
+  pointer-events: none;
+  z-index: 1;
+  transition:
+    border-color var(--duration-transition) var(--ease-out-quart),
+    border-radius var(--duration-transition) var(--ease-out-quart),
+    opacity var(--duration-transition) var(--ease-out-quart),
+    transform var(--duration-transition) var(--ease-out-quart);
+}
+
+.card-ornament::before,
+.card-ornament::after {
+  content: '';
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  border-color: inherit;
+  border-style: solid;
+}
+
+.card-ornament::before {
+  top: -1px;
+  left: -1px;
+  border-width: 2px 0 0 2px;
+}
+
+.card-ornament::after {
+  bottom: -1px;
+  right: -1px;
+  border-width: 0 2px 2px 0;
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  width: 100%;
+  max-width: 300px;
+}
+
+.card-bismillah {
+  font-family: var(--font-arabic-display);
+  font-weight: 700;
+  font-size: clamp(1.4rem, 4vw, 1.8rem);
+  color: var(--gold);
+  letter-spacing: 0.06em;
+  opacity: 0.75;
+  text-align: center;
+  direction: rtl;
+  lang: ar;
+}
+
+.card-rule {
+  width: 100%;
+  height: 1px;
+  background: var(--gold-rule);
+  border: none;
+  transition:
+    background var(--duration-transition) var(--ease-out-quart),
+    transform var(--duration-transition) var(--ease-out-quart);
+}
+
+/* Arabic verse — Amiri 400, generous line-height */
+.arabic-poetry {
+  font-family: var(--font-arabic-body);
+  font-size: 1.375rem;
+  font-weight: 400;
+  line-height: 2;
+  color: #ece8e0;
+  text-align: center;
+  direction: rtl;
+  transition: color var(--duration-transition) var(--ease-out-quart);
+}
+
+.arabic-poetry .verse {
+  display: block;
+}
+
+.card-divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.card-divider::before,
+.card-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--gold-rule);
+}
+
+.card-divider-ornament {
+  color: var(--gold);
+  font-size: 0.6875rem;
+  opacity: 0.55;
+}
+
+/* English translation — Cormorant Garamond italic, noticeably smaller */
+.english-translation {
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.75;
+  color: rgba(236,232,224,0.55);
+  text-align: center;
+  transition: color var(--duration-transition) var(--ease-out-quart);
+}
+
+.english-translation .verse {
+  display: block;
+}
+
+.poet-attribution {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-block-start: 6px;
+}
+
+.poet-rule {
+  width: 36px;
+  height: 1px;
+  background: var(--gold-rule);
+  margin-block-end: 6px;
+}
+
+/* Poet name — Reem Kufi 700, display weight */
+.poet-name {
+  font-family: var(--font-arabic-display);
+  font-weight: 700;
+  font-size: clamp(1.4rem, 4vw, 1.8rem);
+  color: var(--gold);
+  letter-spacing: 0.03em;
+  direction: rtl;
+  transition: color var(--duration-transition) var(--ease-out-quart);
+}
+
+/* Latin name — Cormorant italic, deliberately subordinate */
+.poet-name-latin {
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: rgba(197,160,89,0.45);
+  letter-spacing: 0.07em;
+  transition: color var(--duration-transition) var(--ease-out-quart);
+}
+
+/* ============================================================
+   CLOSE BUTTON — FLOATING ON CARD
+   ============================================================ */
+.btn-close {
+  position: absolute;
+  top: calc(16px + env(safe-area-inset-top, 0px));
+  right: 16px;
+  z-index: 50;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(12,12,14,0.60);
+  border: 1px solid rgba(197,160,89,0.22);
+  color: rgba(236,232,224,0.80);
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  transition:
+    background var(--duration-hover) var(--ease-out-quart),
+    border-color var(--duration-hover) var(--ease-out-quart),
+    transform var(--duration-micro) var(--ease-out-quart);
+  min-width: 44px;
+  min-height: 44px;
+  line-height: 1;
+}
+
+.btn-close:hover {
+  background: rgba(197,160,89,0.14);
+  border-color: rgba(197,160,89,0.38);
+}
+
+.btn-close:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+.btn-close:active {
+  transform: scale(0.93);
+}
+
+/* ============================================================
+   FROSTED CHROME SHELF — MELTS INTO CARD
+   ============================================================ */
+.chrome-shelf {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  /* Folio: dissolve — no hard edge at top */
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    rgba(12,12,14,0.35) 12%,
+    rgba(12,12,14,0.72) 36%,
+    rgba(12,12,14,0.88) 60%,
+    rgba(12,12,14,0.96) 100%
+  );
+  backdrop-filter: blur(22px) saturate(140%);
+  -webkit-backdrop-filter: blur(22px) saturate(140%);
+  padding: 28px 18px calc(22px + env(safe-area-inset-bottom, 0px));
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  /* Slides up on entrance */
+  transform: translateY(100%);
+  animation: shelfRise var(--duration-shelf) var(--ease-out-expo) 0.55s forwards;
+}
+
+@keyframes shelfRise {
+  to { transform: translateY(0); }
+}
+
+/* Soft gradient bridge from card to shelf */
+.chrome-shelf::before {
+  content: '';
+  position: absolute;
+  top: -56px;
+  left: 0;
+  right: 0;
+  height: 56px;
+  background: linear-gradient(180deg, transparent 0%, rgba(12,12,14,0.12) 100%);
+  pointer-events: none;
+}
+
+/* ============================================================
+   STYLE PICKER CHIPS
+   ============================================================ */
+.style-picker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.style-chip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  min-width: 44px;
+  min-height: 44px;
+  justify-content: center;
+}
+
+.style-chip:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+.chip-swatch {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  position: relative;
+  transition:
+    transform var(--duration-hover) var(--ease-out-expo),
+    box-shadow var(--duration-hover) var(--ease-out-quart);
+  border: 2px solid transparent;
+  flex-shrink: 0;
+}
+
+/* Active gold ring */
+.style-chip[aria-pressed="true"] .chip-swatch {
+  border-color: var(--gold);
+  box-shadow:
+    0 0 0 2px rgba(12,12,14,0.85),
+    0 0 0 4px var(--gold),
+    0 0 14px rgba(197,160,89,0.45);
+}
+
+.style-chip:hover:not([aria-pressed="true"]) .chip-swatch {
+  transform: scale(1.1) translateY(-1px);
+  box-shadow: 0 4px 14px rgba(197,160,89,0.25), 0 0 0 1.5px rgba(197,160,89,0.25);
+}
+
+.style-chip:active .chip-swatch {
+  transform: scale(0.94);
+}
+
+/* Swatch color palettes */
+.chip-swatch--diwan    { background: radial-gradient(circle at 35% 30%, #1e3a6e 0%, #0c0c0e 100%); }
+.chip-swatch--ibn-muqla { background: radial-gradient(circle at 35% 30%, #3a2a10 0%, #1a1208 100%); }
+.chip-swatch--sinan    { background: radial-gradient(circle at 35% 30%, #f0ece4 0%, #d4cfc5 100%); }
+.chip-swatch--zaha     { background: radial-gradient(circle at 35% 30%, #252535 0%, #111115 100%); }
+.chip-swatch--fathy    { background: radial-gradient(circle at 35% 30%, #5c3018 0%, #2d1b0e 100%); }
+
+/* Gold accent dot on each swatch */
+.chip-swatch::after {
+  content: '';
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--gold);
+  opacity: 0.65;
+}
+
+/* Style chip labels — system-ui, deliberately subordinate */
+.chip-label {
+  font-family: var(--font-ui);
+  font-size: 0.5rem;
+  color: rgba(197,160,89,0.55);
+  letter-spacing: 0.05em;
+  text-align: center;
+  white-space: nowrap;
+  text-transform: uppercase;
+  line-height: 1;
+  max-width: 52px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.style-chip[aria-pressed="true"] .chip-label {
+  color: var(--gold-bright);
+}
+
+/* ============================================================
+   ACTION BUTTONS
+   ============================================================ */
+.action-buttons {
+  display: flex;
+  gap: 10px;
+  align-items: stretch;
+}
+
+/* ---- HERO CTA: Molten Gold Share Button ---- */
+.btn-share {
+  flex: 2;
+  height: 50px;
+  min-height: 44px;
+  border-radius: var(--radius-btn);
+  background: var(--molten-gold);
+  border: none;
+  border-top: 1px solid rgba(255,255,255,0.22);
+  border-bottom: 1px solid rgba(0,0,0,0.35);
+  color: #1a1200;
+  font-family: var(--font-ui);
+  font-size: 0.9375rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+  /* Convex metallic surface — strong inset lights + warm glow */
+  box-shadow:
+    inset 0 2px 3px rgba(255,255,255,0.32),
+    inset 0 -2px 4px rgba(0,0,0,0.45),
+    inset 2px 0 3px rgba(255,255,255,0.08),
+    inset -2px 0 3px rgba(0,0,0,0.15),
+    0 5px 24px rgba(197,160,89,0.45),
+    0 2px 6px rgba(0,0,0,0.5);
+  transition:
+    transform var(--duration-micro) var(--ease-out-quart),
+    filter var(--duration-hover) var(--ease-out-quart),
+    box-shadow var(--duration-hover) var(--ease-out-quart);
+}
+
+/* Convex top highlight — stronger dome sheen */
+.btn-share::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 52%;
+  background:
+    radial-gradient(ellipse 70% 100% at 50% -10%, rgba(255,255,255,0.38) 0%, rgba(255,255,255,0.12) 50%, transparent 100%);
+  border-radius: 10px 10px 50% 50%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Gold sheen sweep — loops every 3.5s, slower and more elegant */
+.btn-share::after {
+  content: '';
+  position: absolute;
+  top: -10%;
+  left: 0;
+  width: 45%;
+  height: 120%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(255,255,255,0.12) 30%,
+    rgba(255,255,255,0.38) 50%,
+    rgba(255,255,255,0.12) 70%,
+    transparent 100%
+  );
+  transform: skewX(-18deg) translateX(-180%);
+  animation: goldSheen 3.5s var(--ease-out-quart) 1.0s infinite;
+  pointer-events: none;
+  z-index: 3;
+}
+
+@keyframes goldSheen {
+  0%   { transform: skewX(-18deg) translateX(-180%); }
+  40%  { transform: skewX(-18deg) translateX(380%); }
+  100% { transform: skewX(-18deg) translateX(380%); }
+}
+
+.btn-share:hover {
+  filter: brightness(1.08) saturate(1.06);
+  box-shadow:
+    inset 0 2px 3px rgba(255,255,255,0.35),
+    inset 0 -2px 4px rgba(0,0,0,0.42),
+    0 7px 32px rgba(197,160,89,0.58),
+    0 3px 8px rgba(0,0,0,0.5);
+}
+
+.btn-share:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+.btn-share:active {
+  transform: scale(0.97) translateY(1px);
+  filter: brightness(0.96);
+  box-shadow:
+    inset 0 2px 6px rgba(0,0,0,0.35),
+    inset 0 1px 2px rgba(255,255,255,0.1),
+    0 2px 10px rgba(197,160,89,0.25);
+}
+
+/* ---- Ghost gold secondary buttons ---- */
+.btn-ghost {
+  flex: 1;
+  height: 50px;
+  min-height: 44px;
+  border-radius: var(--radius-btn);
+  background: rgba(197,160,89,0.07);
+  border: 1px solid var(--gold-border);
+  color: var(--gold);
+  font-family: var(--font-ui);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    background var(--duration-hover) var(--ease-out-quart),
+    border-color var(--duration-hover) var(--ease-out-quart),
+    transform var(--duration-micro) var(--ease-out-quart);
+  white-space: nowrap;
+  padding-inline: 8px;
+  min-width: 44px;
+}
+
+.btn-ghost:hover {
+  background: rgba(197,160,89,0.13);
+  border-color: rgba(197,160,89,0.42);
+}
+
+.btn-ghost:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+.btn-ghost:active {
+  transform: scale(0.97);
+}
+
+/* ============================================================
+   REDUCED MOTION
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .phone-frame {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .chrome-shelf {
+    animation: none;
+    transform: translateY(0);
+  }
+
+  .btn-share::after {
+    animation: none;
+  }
+
+  .card-foil-border {
+    animation: none;
+  }
+
+  .card-preview {
+    transition: none;
+  }
+
+  .style-chip:hover .chip-swatch {
+    transform: none;
+  }
+
+  #geo-canvas,
+  #geometryCanvas {
+    display: none;
+  }
+
+  .card-foil-border {
+    animation: none;
+    box-shadow: 0 0 0 1px rgba(197,160,89,0.22);
+  }
+}
+
+/* ── Live Islamic geometry canvas ── */
+#geo-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  /* sits above card bg-color but behind card content */
+  mix-blend-mode: screen;
+}
+</style>
+</head>
+
+<body>
+
+  <!-- Stage label — outside phone -->
+  <div class="stage-label" aria-hidden="true">
+    <span class="stage-label__title">Folio</span>
+    <span class="stage-label__sub">Full-bleed card — chrome dissolves into art</span>
+  </div>
+
+  <!-- Phone Frame -->
+  <div class="phone-frame" role="presentation">
+
+    <!-- Dynamic Island -->
+    <div class="phone-dynamic-island" role="presentation" aria-hidden="true"></div>
+
+    <!-- Phone Screen -->
+    <div class="phone-screen">
+
+      <!-- Status Bar -->
+      <div class="phone-statusbar" aria-hidden="true">
+        <span class="phone-statusbar__time">9:41</span>
+        <div class="phone-statusbar__icons">
+          <svg width="18" height="12" viewBox="0 0 18 12" fill="none" aria-hidden="true">
+            <rect x="0" y="8" width="3" height="4" rx="0.5" fill="currentColor"/>
+            <rect x="4.5" y="5.5" width="3" height="6.5" rx="0.5" fill="currentColor"/>
+            <rect x="9" y="3" width="3" height="9" rx="0.5" fill="currentColor"/>
+            <rect x="13.5" y="0" width="3" height="12" rx="0.5" fill="currentColor" opacity="0.3"/>
+          </svg>
+          <svg width="16" height="12" viewBox="0 0 16 12" fill="none" aria-hidden="true">
+            <path d="M8 10C8.55228 10 9 10.4477 9 11C9 11.5523 8.55228 12 8 12C7.44772 12 7 11.5523 7 11C7 10.4477 7.44772 10 8 10Z" fill="currentColor"/>
+            <path d="M5.17 7.83C5.95 7.05 7.03 6.6 8 6.6C8.97 6.6 10.05 7.05 10.83 7.83L12 6.5C10.9 5.56 9.49 5 8 5C6.51 5 5.1 5.56 4 6.5L5.17 7.83Z" fill="currentColor"/>
+            <path d="M2.34 5.16C3.83 3.79 5.87 3 8 3C10.13 3 12.17 3.79 13.66 5.16L15 3.66C13.19 1.96 10.72 1 8 1C5.28 1 2.81 1.96 1 3.66L2.34 5.16Z" fill="currentColor"/>
+          </svg>
+          <svg width="25" height="12" viewBox="0 0 25 12" fill="none" aria-hidden="true">
+            <rect x="0.5" y="0.5" width="21" height="11" rx="2.5" stroke="currentColor" stroke-opacity="0.35"/>
+            <rect x="1.5" y="1.5" width="18" height="9" rx="1.5" fill="currentColor"/>
+            <path d="M23 4V8C23.8047 7.66122 24.328 6.87313 24.328 6C24.328 5.12687 23.8047 4.33878 23 4Z" fill="currentColor" opacity="0.4"/>
+          </svg>
+        </div>
+      </div>
+
+      <!-- Share Modal — Folio: card IS the modal -->
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Share poem"
+        class="share-modal"
+      >
+
+        <!-- Card Preview — full bleed -->
+        <div class="card-preview-wrapper">
+
+          <!-- Live animated Islamic geometry tessellation (z-index 0, behind all card content) -->
+          <canvas id="geo-canvas" aria-hidden="true"></canvas>
+
+          <div class="card-preview" data-style="diwan" id="cardPreview">
+
+            <!-- Accent bar -->
+            <div class="card-accent-bar" aria-hidden="true"></div>
+
+            <!-- Animated Islamic geometry canvas band -->
+            <div class="geometry-canvas-band" aria-hidden="true">
+              <canvas id="geometryCanvas"></canvas>
+            </div>
+
+            <!-- Gold foil border shimmer -->
+            <div class="card-foil-border" aria-hidden="true"></div>
+
+            <!-- Ornamental corner frame -->
+            <div class="card-ornament" aria-hidden="true"></div>
+
+            <!-- Poetry Content -->
+            <div class="card-content">
+              <div class="card-bismillah" dir="rtl" lang="ar" aria-hidden="true">بِسۡمِ ٱللَّهِ</div>
+              <hr class="card-rule" aria-hidden="true">
+
+              <!-- Arabic couplet — Amiri 400, generous line-height -->
+              <p class="arabic-poetry" dir="rtl" lang="ar">
+                <span class="verse">أَنا لا أُريدُكِ كامِلَةً، أُريدُكِ حَقيقيَّة</span>
+                <span class="verse">أُريدُكِ كَما أَنتِ، في كُلِّ فَوضاكِ الجَميلة</span>
+              </p>
+
+              <!-- Ornamental divider -->
+              <div class="card-divider" aria-hidden="true">
+                <span class="card-divider-ornament">✦</span>
+              </div>
+
+              <!-- English translation — Cormorant italic, noticeably smaller -->
+              <p class="english-translation" lang="en">
+                <span class="verse">I do not want you perfect, I want you real</span>
+                <span class="verse">I want you as you are, in all your beautiful chaos</span>
+              </p>
+
+              <!-- Poet attribution -->
+              <div class="poet-attribution">
+                <div class="poet-rule" aria-hidden="true"></div>
+                <!-- Reem Kufi 700 — the editorial crown -->
+                <span class="poet-name" dir="rtl" lang="ar">نزار قباني</span>
+                <!-- Cormorant italic — deliberately subordinate -->
+                <span class="poet-name-latin" lang="en">Nizar Qabbani</span>
+              </div>
+            </div>
+
+          </div><!-- /card-preview -->
+        </div><!-- /card-preview-wrapper -->
+
+        <!-- Close button — floats over card -->
+        <button class="btn-close" aria-label="Close share dialog" id="btnClose">✕</button>
+
+        <!-- Frosted Chrome Shelf — dissolves upward into card -->
+        <div class="chrome-shelf" role="group" aria-label="Share options">
+
+          <!-- Style Picker -->
+          <div class="style-picker" role="radiogroup" aria-label="Card style">
+
+            <button
+              class="style-chip"
+              role="radio"
+              aria-pressed="true"
+              aria-label="Dīwān style"
+              data-style="diwan"
+            >
+              <div class="chip-swatch chip-swatch--diwan" aria-hidden="true"></div>
+              <span class="chip-label">Dīwān</span>
+            </button>
+
+            <button
+              class="style-chip"
+              role="radio"
+              aria-pressed="false"
+              aria-label="Ibn Muqla style"
+              data-style="ibn-muqla"
+            >
+              <div class="chip-swatch chip-swatch--ibn-muqla" aria-hidden="true"></div>
+              <span class="chip-label">Ibn Muqla</span>
+            </button>
+
+            <button
+              class="style-chip"
+              role="radio"
+              aria-pressed="false"
+              aria-label="Sinan style"
+              data-style="sinan"
+            >
+              <div class="chip-swatch chip-swatch--sinan" aria-hidden="true"></div>
+              <span class="chip-label">Sinan</span>
+            </button>
+
+            <button
+              class="style-chip"
+              role="radio"
+              aria-pressed="false"
+              aria-label="Zaha Hadid style"
+              data-style="zaha"
+            >
+              <div class="chip-swatch chip-swatch--zaha" aria-hidden="true"></div>
+              <span class="chip-label">Zaha</span>
+            </button>
+
+            <button
+              class="style-chip"
+              role="radio"
+              aria-pressed="false"
+              aria-label="Hassan Fathy style"
+              data-style="fathy"
+            >
+              <div class="chip-swatch chip-swatch--fathy" aria-hidden="true"></div>
+              <span class="chip-label">H. Fathy</span>
+            </button>
+
+          </div><!-- /style-picker -->
+
+          <!-- Action Buttons -->
+          <div class="action-buttons" role="group" aria-label="Share actions">
+            <button class="btn-share" aria-label="Share poem">
+              Share
+            </button>
+            <button class="btn-ghost" aria-label="Download as PNG" id="btnDownload">
+              Download
+            </button>
+            <button class="btn-ghost" aria-label="Copy link" id="btnCopyLink">
+              Copy Link
+            </button>
+          </div>
+
+        </div><!-- /chrome-shelf -->
+
+      </div><!-- /share-modal -->
+
+    </div><!-- /phone-screen -->
+  </div><!-- /phone-frame -->
+
+<script>
+(function () {
+  'use strict';
+
+  /* ============================================================
+     ANIMATED ISLAMIC GEOMETRY CANVAS
+     8-pointed star tessellation, drifts sinusoidally
+     ============================================================ */
+  (function initGeometryCanvas() {
+    var canvas = document.getElementById('geometryCanvas');
+    if (!canvas) return;
+
+    var prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    var ctx = canvas.getContext('2d');
+    var raf;
+    var startTime = performance.now();
+
+    function resize() {
+      var band = canvas.parentElement;
+      var dpr = window.devicePixelRatio || 1;
+      canvas.width  = band.offsetWidth  * dpr;
+      canvas.height = band.offsetHeight * dpr;
+      ctx.scale(dpr, dpr);
+    }
+
+    // Draw a single 8-pointed star centered at (cx, cy) with outer radius r
+    function draw8Star(cx, cy, r) {
+      var innerR = r * 0.414; // ratio for a regular 8-star
+      var points = 8;
+      ctx.beginPath();
+      for (var i = 0; i < points * 2; i++) {
+        var angle = (Math.PI / points) * i - Math.PI / 2;
+        var radius = (i % 2 === 0) ? r : innerR;
+        var x = cx + Math.cos(angle) * radius;
+        var y = cy + Math.sin(angle) * radius;
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.closePath();
+    }
+
+    function drawGrid(offsetX, offsetY) {
+      var w = canvas.width  / (window.devicePixelRatio || 1);
+      var h = canvas.height / (window.devicePixelRatio || 1);
+      var cellSize = 40;
+      var starR    = 14;
+
+      ctx.clearRect(0, 0, w, h);
+      ctx.strokeStyle = 'rgba(197,160,89,0.18)';
+      ctx.lineWidth   = 0.8;
+
+      // Tessellate across the band, offset by animated values
+      var cols = Math.ceil(w / cellSize) + 2;
+      var rows = Math.ceil(h / cellSize) + 2;
+
+      var startCol = -1;
+      var startRow = -1;
+
+      for (var row = startRow; row < rows; row++) {
+        for (var col = startCol; col < cols; col++) {
+          var cx = col * cellSize + (offsetX % cellSize);
+          var cy = row * cellSize + (offsetY % cellSize);
+
+          // Alternating row offset for a denser hex-like feel
+          if (row % 2 !== 0) cx += cellSize * 0.5;
+
+          draw8Star(cx, cy, starR);
+          ctx.stroke();
+
+          // Small connecting square between stars
+          ctx.beginPath();
+          ctx.rect(cx - 4, cy - 4, 8, 8);
+          ctx.stroke();
+        }
+      }
+    }
+
+    function animate(now) {
+      if (prefersReduced) {
+        drawGrid(0, 0);
+        return;
+      }
+
+      var elapsed = (now - startTime) / 1000; // seconds
+
+      // Slow sinusoidal drift
+      var ox = Math.sin(elapsed * 0.18) * 12;
+      var oy = Math.cos(elapsed * 0.12) * 6;
+
+      drawGrid(ox, oy);
+      raf = requestAnimationFrame(animate);
+    }
+
+    resize();
+    raf = requestAnimationFrame(animate);
+
+    window.addEventListener('resize', function () {
+      resize();
+    });
+  }());
+
+  /* ============================================================
+     STYLE CHIP INTERACTION — cross-dissolve card style
+     ============================================================ */
+  var card   = document.getElementById('cardPreview');
+  var chips  = document.querySelectorAll('.style-chip');
+
+  chips.forEach(function (chip) {
+    chip.addEventListener('click', function () {
+      var newStyle = chip.getAttribute('data-style');
+      if (card.getAttribute('data-style') === newStyle) return;
+
+      chips.forEach(function (c) { c.setAttribute('aria-pressed', 'false'); });
+      chip.setAttribute('aria-pressed', 'true');
+
+      var prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      if (prefersReduced) {
+        card.setAttribute('data-style', newStyle);
+        return;
+      }
+
+      card.classList.add('transitioning');
+      setTimeout(function () {
+        card.setAttribute('data-style', newStyle);
+        card.classList.remove('transitioning');
+      }, 150);
+    });
+  });
+
+  /* ============================================================
+     CLOSE BUTTON — demo loop
+     ============================================================ */
+  var btnClose   = document.getElementById('btnClose');
+  var phoneFrame = document.querySelector('.phone-frame');
+
+  btnClose.addEventListener('click', function () {
+    phoneFrame.style.transition = 'opacity 0.3s cubic-bezier(.4,0,.2,1), transform 0.3s cubic-bezier(.4,0,.2,1)';
+    phoneFrame.style.opacity    = '0';
+    phoneFrame.style.transform  = 'scale(0.93) translateY(10px)';
+
+    setTimeout(function () {
+      phoneFrame.style.transition = '';
+      phoneFrame.style.opacity    = '';
+      phoneFrame.style.transform  = '';
+      phoneFrame.style.animation  = 'none';
+      void phoneFrame.offsetWidth; // reflow
+      phoneFrame.style.animation  = '';
+    }, 1100);
+  });
+
+  /* ============================================================
+     ACTION BUTTON FEEDBACK (demo)
+     ============================================================ */
+  var btnShare    = document.querySelector('.btn-share');
+  var btnDownload = document.getElementById('btnDownload');
+  var btnCopyLink = document.getElementById('btnCopyLink');
+
+  btnShare.addEventListener('click', function () {
+    var orig = btnShare.textContent;
+    btnShare.textContent = 'Shared!';
+    setTimeout(function () { btnShare.textContent = orig; }, 1600);
+  });
+
+  btnDownload.addEventListener('click', function () {
+    var orig = btnDownload.textContent;
+    btnDownload.textContent = 'Saved!';
+    setTimeout(function () { btnDownload.textContent = orig; }, 1600);
+  });
+
+  btnCopyLink.addEventListener('click', function () {
+    var orig = btnCopyLink.textContent;
+    btnCopyLink.textContent = 'Copied!';
+    setTimeout(function () { btnCopyLink.textContent = orig; }, 1600);
+  });
+
+}());
+
+/* ── Live Islamic 8-pointed star tessellation ─────────────────────────── */
+(function () {
+  'use strict';
+  const canvas = document.getElementById('geo-canvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+
+  function resize() {
+    const w = canvas.offsetWidth;
+    const h = canvas.offsetHeight;
+    canvas.width  = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  // Draw an 8-pointed star centered at cx,cy with outer radius r
+  function drawStar8(cx, cy, r, rotation) {
+    const innerR = r * 0.414; // tan(22.5°) ratio for proper 8-star
+    ctx.beginPath();
+    for (let i = 0; i < 16; i++) {
+      const angle = (Math.PI / 8) * i + rotation;
+      const radius = i % 2 === 0 ? r : innerR;
+      const x = cx + Math.cos(angle) * radius;
+      const y = cy + Math.sin(angle) * radius;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+  }
+
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  let startTime = null;
+
+  function draw(ts) {
+    if (!startTime) startTime = ts;
+    const elapsed = (ts - startTime) / 1000;
+
+    const w = canvas.offsetWidth;
+    const h = canvas.offsetHeight;
+    ctx.clearRect(0, 0, w, h);
+
+    // Gentle drift
+    const driftX = Math.sin(elapsed * 0.18) * 5;
+    const driftY = Math.cos(elapsed * 0.12) * 4;
+    const breathe = Math.sin(elapsed * 0.4) * 0.8; // radius oscillation in px
+    const rot     = elapsed * 0.06; // slow spin
+
+    const sz   = 36; // grid spacing
+    const cols = Math.ceil(w / sz) + 3;
+    const rows = Math.ceil(h / sz) + 3;
+
+    ctx.strokeStyle = 'rgba(197,160,89,0.15)';
+    ctx.lineWidth   = 0.75;
+
+    for (let row = -2; row < rows; row++) {
+      for (let col = -2; col < cols; col++) {
+        const cx = col * sz + (row % 2 === 0 ? 0 : sz / 2) + driftX;
+        const cy = row * sz * 0.866 + driftY;
+        const r  = sz * 0.35 + breathe;
+        drawStar8(cx, cy, r, rot);
+        ctx.stroke();
+      }
+    }
+
+    if (!prefersReducedMotion) {
+      requestAnimationFrame(draw);
+    }
+  }
+
+  resize();
+  requestAnimationFrame(draw);
+  window.addEventListener('resize', resize);
+}());
+</script>
+
+</body>
+</html>

--- a/design-review/share-modal/s2.html
+++ b/design-review/share-modal/s2.html
@@ -1,0 +1,1584 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Majlis — Share Modal S2</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Reem+Kufi:wght@400;500;600;700&family=Amiri:ital,wght@0,400;0,700;1,400&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500;1,600&display=swap" rel="stylesheet">
+<style>
+/* ============================================
+   DESIGN TOKENS
+   ============================================ */
+:root {
+  --gold: #c5a059;
+  --gold-bright: #d4b463;
+  --gold-foil: linear-gradient(135deg, #b8922e, #c5a059 30%, #e2c67a 55%, #c5a059 75%, #a07d38);
+  --molten-gold: linear-gradient(135deg, #a8853d, #c5a059 22%, #e0c97a 38%, #d4b463 48%, #b8924a 62%, #d8bc6e 78%, #c5a059);
+  --lapis-deep: #1e3a6e;
+  --lapis-medium: #2e5090;
+  --lapis-light: #4a7cc9;
+  --bg-app: #0c0c0e;
+  --panel-bg: linear-gradient(145deg, rgba(20,18,15,0.97), rgba(12,12,14,0.98));
+  --gold-border: rgba(197,160,89,0.25);
+  --gold-rule: linear-gradient(90deg, transparent, rgba(160,128,64,0.4) 20%, #C5A059 50%, rgba(160,128,64,0.4) 80%, transparent);
+
+  --font-arabic-display: 'Reem Kufi', sans-serif;
+  --font-arabic-body: 'Amiri', serif;
+  --font-english-editorial: 'Cormorant Garamond', serif;
+  --font-ui: system-ui, -apple-system, sans-serif;
+
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-out-quart: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  --radius-modal: 24px;
+  --duration-entrance: 0.65s;
+  --duration-transition: 0.3s;
+  --duration-hover: 0.15s;
+}
+
+/* ============================================
+   RESET & BASE
+   ============================================ */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  height: 100%;
+  height: 100dvh;
+  overflow: hidden;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  background: #080808;
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  font-family: var(--font-ui);
+  height: 100vh;
+  height: 100dvh;
+  padding: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* ============================================
+   PHONE FRAME
+   ============================================ */
+.phone-frame {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  background: var(--bg-app);
+  border-radius: 0;
+  box-shadow: none;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+}
+
+/* Notch — hidden; real device chrome already provides this */
+.phone-frame::before {
+  display: none;
+}
+
+/* Subtle ambient glow on phone */
+.phone-frame::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 0;
+  background: radial-gradient(ellipse at 30% 20%, rgba(197,160,89,0.04) 0%, transparent 60%);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* ============================================
+   APP BACKDROP (inside phone)
+   ============================================ */
+.app-backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 20% 10%, rgba(30,58,110,0.3) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 80%, rgba(197,160,89,0.08) 0%, transparent 50%),
+    linear-gradient(180deg, #0d0d10 0%, #0a0a0c 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 52px 20px 20px;
+}
+
+/* Caption label — hidden; the real viewer already shows a label for this mockup */
+.caption-label {
+  display: none;
+}
+
+.caption-title {
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-weight: 500;
+  font-size: 15px;
+  color: var(--gold);
+  letter-spacing: 0.02em;
+  display: block;
+  margin-top: 8px;
+}
+
+.caption-subtitle {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  color: rgba(197,160,89,0.5);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: block;
+  margin-top: 3px;
+}
+
+/* ============================================
+   MODAL OVERLAY
+   ============================================ */
+.modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.65);
+  display: flex;
+  align-items: flex-start;
+  z-index: 50;
+  border-radius: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* ============================================
+   MODAL PANEL
+   ============================================ */
+.modal-panel {
+  width: 100%;
+  min-height: 100%;
+  max-height: none;
+  background: var(--panel-bg);
+  border: none;
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: relative;
+
+  animation: modalEnter var(--duration-entrance) var(--ease-out-expo) forwards;
+}
+
+@keyframes modalEnter {
+  from {
+    transform: translateY(100%) scale(0.95);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+  }
+}
+
+/* Architectural arch ornament on modal top */
+.modal-panel::before {
+  content: '';
+  position: absolute;
+  top: -1px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 140px;
+  height: 28px;
+  border: 1px solid rgba(197,160,89,0.35);
+  border-bottom: none;
+  border-radius: 70px 70px 0 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Inner arch accent line */
+.modal-panel::after {
+  content: '';
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100px;
+  height: 20px;
+  border: 1px solid rgba(197,160,89,0.18);
+  border-bottom: none;
+  border-radius: 50px 50px 0 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Left pillar */
+.pillar-left,
+.pillar-right {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: linear-gradient(180deg, rgba(197,160,89,0.3) 0%, rgba(197,160,89,0.08) 40%, transparent 100%);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.pillar-left { left: 20px; }
+.pillar-right { right: 20px; }
+
+/* ============================================
+   MODAL HEADER
+   ============================================ */
+.modal-header {
+  padding: calc(12px + env(safe-area-inset-top, 0px)) 20px 10px;
+  position: relative;
+  z-index: 3;
+  animation: fadeSlideUp 0.5s var(--ease-out-expo) 0.3s both;
+}
+
+@keyframes fadeSlideUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.header-arch-ornament {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.arch-icon {
+  width: 36px;
+  height: 24px;
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.arch-icon svg {
+  width: 36px;
+  height: 24px;
+}
+
+.header-content {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.header-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.modal-title-arabic {
+  font-family: var(--font-arabic-display);
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--gold-bright);
+  display: block;
+  direction: rtl;
+  text-align: right;
+  letter-spacing: 0.01em;
+  line-height: 1.3;
+}
+
+.modal-title-english {
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 13px;
+  font-weight: 400;
+  color: rgba(197,160,89,0.75);
+  display: block;
+  margin-top: 2px;
+  letter-spacing: 0.03em;
+}
+
+.modal-subtitle {
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 11px;
+  color: rgba(197,160,89,0.45);
+  display: block;
+  margin-top: 4px;
+  letter-spacing: 0.04em;
+}
+
+.close-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--gold-border);
+  background: rgba(197,160,89,0.06);
+  color: rgba(197,160,89,0.7);
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--duration-hover) var(--ease-out-quart),
+              color var(--duration-hover) var(--ease-out-quart),
+              border-color var(--duration-hover) var(--ease-out-quart);
+  flex-shrink: 0;
+  outline: none;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.close-btn:hover {
+  background: rgba(197,160,89,0.14);
+  color: var(--gold-bright);
+  border-color: rgba(197,160,89,0.5);
+}
+
+.close-btn:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+/* Gold rule */
+.gold-rule {
+  height: 1px;
+  background: var(--gold-rule);
+  border: none;
+  margin: 0 0 0 0;
+  flex-shrink: 0;
+}
+
+/* ============================================
+   THUMBNAIL CAROUSEL
+   ============================================ */
+.carousel-section {
+  padding: 8px 20px 6px;
+  position: relative;
+  animation: fadeSlideUp 0.5s var(--ease-out-expo) 0.4s both;
+}
+
+.carousel-label {
+  font-family: var(--font-ui);
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(197,160,89,0.4);
+  margin-bottom: 10px;
+  display: block;
+}
+
+.carousel-track-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.carousel-nav {
+  width: 28px;
+  height: 44px;
+  background: rgba(197,160,89,0.06);
+  border: 1px solid var(--gold-border);
+  border-radius: 6px;
+  color: rgba(197,160,89,0.6);
+  font-size: 11px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background var(--duration-hover) var(--ease-out-quart),
+              color var(--duration-hover) var(--ease-out-quart);
+  outline: none;
+}
+
+.carousel-nav:hover {
+  background: rgba(197,160,89,0.12);
+  color: var(--gold-bright);
+}
+
+.carousel-nav:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+.carousel-track {
+  display: flex;
+  gap: 8px;
+  overflow: hidden;
+  flex: 1;
+  padding: 4px 2px;
+}
+
+/* ============================================
+   THUMBNAIL CARDS
+   ============================================ */
+.thumb {
+  width: 72px;
+  height: 90px;
+  border-radius: 8px;
+  border: 1.5px solid var(--gold-border);
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  overflow: hidden;
+  transition: transform var(--duration-transition) var(--ease-out-quart),
+              opacity var(--duration-transition) var(--ease-out-quart),
+              border-color var(--duration-transition) var(--ease-out-quart),
+              box-shadow var(--duration-transition) var(--ease-out-quart);
+  opacity: 0.55;
+  outline: none;
+
+  animation: thumbEnter 0.35s var(--ease-out-expo) both;
+}
+
+.thumb:nth-child(1) { animation-delay: 0.55s; }
+.thumb:nth-child(2) { animation-delay: 0.60s; }
+.thumb:nth-child(3) { animation-delay: 0.65s; }
+.thumb:nth-child(4) { animation-delay: 0.70s; }
+.thumb:nth-child(5) { animation-delay: 0.75s; }
+
+@keyframes thumbEnter {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 0.55; transform: translateY(0); }
+}
+
+.thumb:hover {
+  opacity: 0.8;
+  transform: scale(1.03);
+}
+
+.thumb.active {
+  opacity: 1;
+  transform: scale(1.05);
+  border-color: var(--gold);
+  box-shadow: 0 0 0 1px var(--gold), 0 4px 16px rgba(197,160,89,0.3);
+}
+
+.thumb:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+/* Thumb style backgrounds */
+.thumb-diwan { background: #0c0c0e; }
+.thumb-ibn-muqla { background: #1a1208; }
+.thumb-sinan { background: #f0ebe0; }
+.thumb-zaha { background: #1a1a20; }
+.thumb-hassan { background: #2d1b0e; }
+
+/* Thumb content miniature */
+.thumb-inner {
+  position: absolute;
+  inset: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+}
+
+.thumb-border-deco {
+  position: absolute;
+  inset: 3px;
+  border-radius: 4px;
+}
+
+.thumb-diwan .thumb-border-deco {
+  border: 1px solid rgba(197,160,89,0.4);
+}
+
+.thumb-sinan .thumb-border-deco {
+  border: 1px solid rgba(197,160,89,0.5);
+  background: repeating-linear-gradient(
+    45deg,
+    transparent,
+    transparent 6px,
+    rgba(197,160,89,0.06) 6px,
+    rgba(197,160,89,0.06) 7px
+  );
+}
+
+.thumb-zaha .thumb-border-deco {
+  border: 1px solid rgba(180,180,200,0.3);
+  clip-path: polygon(0 8%, 8% 0, 100% 0, 100% 92%, 92% 100%, 0 100%);
+}
+
+.thumb-hassan .thumb-border-deco {
+  border: 1px solid rgba(210,140,80,0.4);
+  border-radius: 2px 2px 20px 20px / 2px 2px 10px 10px;
+}
+
+.thumb-line {
+  height: 2px;
+  border-radius: 1px;
+  margin: 1px 6px;
+}
+
+.thumb-diwan .thumb-line { background: rgba(197,160,89,0.5); }
+.thumb-ibn-muqla .thumb-line { background: rgba(210,180,120,0.5); }
+.thumb-sinan .thumb-line { background: rgba(197,160,89,0.6); }
+.thumb-zaha .thumb-line { background: rgba(180,180,200,0.5); }
+.thumb-hassan .thumb-line { background: rgba(210,140,80,0.5); }
+
+.thumb-line-long { width: 80%; }
+.thumb-line-short { width: 55%; }
+.thumb-line-med { width: 68%; }
+
+.thumb-name {
+  position: absolute;
+  bottom: 4px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 7px;
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  letter-spacing: 0.04em;
+}
+
+.thumb-diwan .thumb-name { color: rgba(197,160,89,0.7); }
+.thumb-ibn-muqla .thumb-name { color: rgba(210,180,120,0.7); }
+.thumb-sinan .thumb-name { color: rgba(140,110,60,0.8); }
+.thumb-zaha .thumb-name { color: rgba(180,180,210,0.7); }
+.thumb-hassan .thumb-name { color: rgba(210,140,80,0.7); }
+
+/* ============================================
+   GOLD RULE BETWEEN SECTIONS
+   ============================================ */
+.section-rule {
+  height: 1px;
+  background: var(--gold-rule);
+  border: none;
+  margin: 4px 20px;
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+/* ============================================
+   LARGE CARD PREVIEW
+   ============================================ */
+.preview-section {
+  flex: 1;
+  padding: 4px 20px;
+  min-height: 140px;
+  max-height: 240px;
+  display: flex;
+  align-items: center;
+  animation: fadeSlideUp 0.5s var(--ease-out-expo) 0.7s both;
+  overflow: hidden;
+}
+
+.preview-card-wrapper {
+  width: 100%;
+  height: 180px;
+  min-height: 140px;
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.6), 0 0 0 1px var(--gold-border);
+  isolation: isolate;
+}
+
+.preview-card {
+  width: 100%;
+  min-height: 140px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 20px 34px;
+  position: absolute;
+  inset: 0;
+  transition: opacity var(--duration-transition) var(--ease-out-quart);
+}
+
+.preview-card.hidden-card {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.preview-card.visible-card {
+  opacity: 1;
+}
+
+/* Card style: Dīwān */
+.card-diwan {
+  background: #0c0c0e;
+}
+
+.card-diwan .card-border-frame {
+  position: absolute;
+  inset: 10px;
+  border: 1px solid rgba(197,160,89,0.35);
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.card-diwan .card-border-frame::before {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border: 1px solid rgba(197,160,89,0.15);
+  border-radius: 2px;
+}
+
+/* Corner ornaments */
+.card-diwan .card-border-frame::after {
+  content: '';
+  position: absolute;
+  top: -1px; left: -1px;
+  width: 14px; height: 14px;
+  border-top: 2px solid var(--gold);
+  border-left: 2px solid var(--gold);
+}
+
+.card-diwan .lapis-band {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--lapis-deep), var(--lapis-medium), var(--lapis-deep));
+}
+
+/* Card style: Ibn Muqla */
+.card-ibn-muqla {
+  background: radial-gradient(ellipse at center, #221a0e 0%, #1a1208 60%, #100e08 100%);
+}
+
+.card-ibn-muqla::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.5) 100%);
+  pointer-events: none;
+}
+
+/* Card style: Sinan */
+.card-sinan {
+  background: #f0ebe0;
+}
+
+.card-sinan .geo-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(197,160,89,0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(197,160,89,0.12) 1px, transparent 1px);
+  background-size: 20px 20px;
+  pointer-events: none;
+}
+
+.card-sinan .geo-border {
+  position: absolute;
+  inset: 8px;
+  border: 1.5px solid rgba(197,160,89,0.45);
+  pointer-events: none;
+}
+
+/* Card style: Zaha */
+.card-zaha {
+  background: #1a1a20;
+  clip-path: none;
+}
+
+.card-zaha .para-lines {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.card-zaha .para-lines::before {
+  content: '';
+  position: absolute;
+  top: -20%;
+  left: -10%;
+  width: 60%;
+  height: 140%;
+  background: linear-gradient(115deg, transparent 45%, rgba(180,180,210,0.06) 46%, rgba(180,180,210,0.06) 47%, transparent 48%),
+              linear-gradient(115deg, transparent 55%, rgba(180,180,210,0.04) 56%, rgba(180,180,210,0.04) 57%, transparent 58%);
+}
+
+.card-zaha .para-lines::after {
+  content: '';
+  position: absolute;
+  top: -20%;
+  right: -10%;
+  width: 50%;
+  height: 140%;
+  background: linear-gradient(-65deg, transparent 40%, rgba(180,180,210,0.05) 41%, rgba(180,180,210,0.05) 42%, transparent 43%);
+}
+
+.card-zaha .zaha-border {
+  position: absolute;
+  inset: 8px;
+  border: 1px solid rgba(180,180,210,0.2);
+  clip-path: polygon(0 5%, 5% 0, 95% 0, 100% 5%, 100% 95%, 95% 100%, 5% 100%, 0 95%);
+  pointer-events: none;
+}
+
+/* Card style: Hassan Fathy */
+.card-hassan {
+  background: radial-gradient(ellipse at 50% 30%, #3d2510 0%, #2d1b0e 60%, #1e1208 100%);
+}
+
+.card-hassan .nubian-arch {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80px;
+  height: 40px;
+  border: 1.5px solid rgba(210,140,80,0.35);
+  border-bottom: none;
+  border-radius: 40px 40px 0 0;
+  pointer-events: none;
+}
+
+.card-hassan .adobe-texture {
+  position: absolute;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.04'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+/* ============================================
+   CARD POEM CONTENT
+   ============================================ */
+.card-content {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+}
+
+.card-divider-top {
+  height: 1px;
+  width: 50%;
+  margin: 0 auto;
+}
+
+.card-diwan .card-divider-top,
+.card-ibn-muqla .card-divider-top {
+  background: linear-gradient(90deg, transparent, rgba(197,160,89,0.5), transparent);
+}
+
+.card-sinan .card-divider-top {
+  background: linear-gradient(90deg, transparent, rgba(160,128,64,0.6), transparent);
+}
+
+.card-zaha .card-divider-top {
+  background: linear-gradient(90deg, transparent, rgba(180,180,210,0.4), transparent);
+}
+
+.card-hassan .card-divider-top {
+  background: linear-gradient(90deg, transparent, rgba(210,140,80,0.5), transparent);
+}
+
+.poem-arabic {
+  text-align: center;
+  direction: rtl;
+}
+
+.poem-arabic .line {
+  display: block;
+  font-family: var(--font-arabic-body);
+  font-size: 14px;
+  line-height: 1.9;
+  letter-spacing: 0.02em;
+}
+
+.card-diwan .poem-arabic .line { color: #e8dfc4; }
+.card-ibn-muqla .poem-arabic .line { color: #d4c4a0; }
+.card-sinan .poem-arabic .line { color: #2a1e0a; }
+.card-zaha .poem-arabic .line { color: #d0d0e0; }
+.card-hassan .poem-arabic .line { color: #e8c896; }
+
+.card-mid-rule {
+  height: 1px;
+  width: 35%;
+}
+
+.card-diwan .card-mid-rule,
+.card-ibn-muqla .card-mid-rule { background: linear-gradient(90deg, transparent, rgba(197,160,89,0.3), transparent); }
+.card-sinan .card-mid-rule { background: linear-gradient(90deg, transparent, rgba(160,128,64,0.3), transparent); }
+.card-zaha .card-mid-rule { background: linear-gradient(90deg, transparent, rgba(180,180,210,0.25), transparent); }
+.card-hassan .card-mid-rule { background: linear-gradient(90deg, transparent, rgba(210,140,80,0.3), transparent); }
+
+.poem-english {
+  text-align: center;
+}
+
+.poem-english .line {
+  display: block;
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 11px;
+  line-height: 1.7;
+  letter-spacing: 0.02em;
+}
+
+.card-diwan .poem-english .line { color: rgba(232,223,196,0.6); }
+.card-ibn-muqla .poem-english .line { color: rgba(212,196,160,0.6); }
+.card-sinan .poem-english .line { color: rgba(42,30,10,0.6); }
+.card-zaha .poem-english .line { color: rgba(208,208,224,0.6); }
+.card-hassan .poem-english .line { color: rgba(232,200,150,0.55); }
+
+.card-divider-bottom {
+  height: 1px;
+  width: 50%;
+}
+
+.card-diwan .card-divider-bottom,
+.card-ibn-muqla .card-divider-bottom { background: linear-gradient(90deg, transparent, rgba(197,160,89,0.5), transparent); }
+.card-sinan .card-divider-bottom { background: linear-gradient(90deg, transparent, rgba(160,128,64,0.6), transparent); }
+.card-zaha .card-divider-bottom { background: linear-gradient(90deg, transparent, rgba(180,180,210,0.4), transparent); }
+.card-hassan .card-divider-bottom { background: linear-gradient(90deg, transparent, rgba(210,140,80,0.5), transparent); }
+
+.poet-byline {
+  text-align: center;
+}
+
+.poet-name-arabic {
+  display: block;
+  font-family: var(--font-arabic-display);
+  font-size: 11px;
+  direction: rtl;
+  letter-spacing: 0.03em;
+}
+
+.poet-name-english {
+  display: block;
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  margin-top: 2px;
+  opacity: 0.65;
+}
+
+.card-diwan .poet-name-arabic { color: var(--gold); }
+.card-diwan .poet-name-english { color: var(--gold); }
+.card-ibn-muqla .poet-name-arabic { color: #c8a870; }
+.card-ibn-muqla .poet-name-english { color: #c8a870; }
+.card-sinan .poet-name-arabic { color: rgba(160,128,64,0.9); }
+.card-sinan .poet-name-english { color: rgba(160,128,64,0.9); }
+.card-zaha .poet-name-arabic { color: rgba(180,180,210,0.8); }
+.card-zaha .poet-name-english { color: rgba(180,180,210,0.8); }
+.card-hassan .poet-name-arabic { color: #d49050; }
+.card-hassan .poet-name-english { color: #d49050; }
+
+/* Style badge */
+.style-badge {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-english-editorial);
+  font-style: italic;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+.card-diwan .style-badge {
+  color: rgba(197,160,89,0.5);
+  border: 1px solid rgba(197,160,89,0.2);
+}
+
+.card-ibn-muqla .style-badge {
+  color: rgba(200,168,112,0.5);
+  border: 1px solid rgba(200,168,112,0.2);
+}
+
+.card-sinan .style-badge {
+  color: rgba(130,100,50,0.5);
+  border: 1px solid rgba(130,100,50,0.25);
+}
+
+.card-zaha .style-badge {
+  color: rgba(160,160,190,0.5);
+  border: 1px solid rgba(160,160,190,0.2);
+}
+
+.card-hassan .style-badge {
+  color: rgba(190,120,60,0.5);
+  border: 1px solid rgba(190,120,60,0.2);
+}
+
+/* ============================================
+   FOOTER SHELF
+   ============================================ */
+.footer-shelf {
+  padding: 8px 20px calc(16px + env(safe-area-inset-bottom, 0px));
+  flex-shrink: 0;
+  animation: fadeSlideUp 0.5s var(--ease-out-expo) 0.8s both;
+}
+
+.footer-rule {
+  height: 1px;
+  background: var(--gold-rule);
+  border: none;
+  margin-bottom: 12px;
+  opacity: 0.5;
+}
+
+.footer-actions {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.btn-share {
+  flex: 1.4;
+  min-height: 46px;
+  height: 46px;
+  background: var(--molten-gold);
+  color: #1a1200;
+  border: none;
+  border-top: 1px solid rgba(255,255,255,0.22);
+  border-bottom: 1px solid rgba(0,0,0,0.3);
+  border-radius: 10px;
+  font-family: var(--font-arabic-display);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  letter-spacing: 0.02em;
+  transition: filter var(--duration-hover) var(--ease-out-quart),
+              transform var(--duration-hover) var(--ease-out-quart),
+              box-shadow var(--duration-hover) var(--ease-out-quart);
+  outline: none;
+  position: relative;
+  overflow: hidden;
+  box-shadow:
+    inset 0 2px 3px rgba(255,255,255,0.3),
+    inset 0 -2px 4px rgba(0,0,0,0.4),
+    0 4px 18px rgba(197,160,89,0.45),
+    0 2px 5px rgba(0,0,0,0.45);
+}
+
+/* Convex top dome sheen */
+.btn-share::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 52%;
+  background: radial-gradient(ellipse 70% 100% at 50% -10%, rgba(255,255,255,0.36) 0%, rgba(255,255,255,0.1) 55%, transparent 100%);
+  border-radius: 10px 10px 50% 50%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Sheen sweep */
+.btn-share::after {
+  content: '';
+  position: absolute;
+  top: -10%; left: 0;
+  width: 45%; height: 120%;
+  background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.35) 50%, transparent 100%);
+  transform: skewX(-18deg) translateX(-180%);
+  animation: s2GoldSheen 3.5s var(--ease-out-quart) 1.2s infinite;
+  pointer-events: none;
+  z-index: 3;
+  border-radius: 0;
+}
+
+@keyframes s2GoldSheen {
+  0%   { transform: skewX(-18deg) translateX(-180%); }
+  40%  { transform: skewX(-18deg) translateX(380%); }
+  100% { transform: skewX(-18deg) translateX(380%); }
+}
+
+.btn-share:hover {
+  filter: brightness(1.07) saturate(1.05);
+  box-shadow:
+    inset 0 2px 3px rgba(255,255,255,0.32),
+    inset 0 -2px 4px rgba(0,0,0,0.38),
+    0 6px 24px rgba(197,160,89,0.55),
+    0 3px 8px rgba(0,0,0,0.45);
+}
+.btn-share:active {
+  transform: scale(0.97) translateY(1px);
+  filter: brightness(0.96);
+  box-shadow:
+    inset 0 2px 6px rgba(0,0,0,0.3),
+    0 2px 8px rgba(197,160,89,0.2);
+}
+
+.btn-share:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-share::after { animation: none; }
+}
+
+.btn-share-icon {
+  font-size: 15px;
+}
+
+.btn-download {
+  flex: 1;
+  min-height: 44px;
+  background: transparent;
+  color: var(--gold);
+  border: 1.5px solid var(--gold-border);
+  border-radius: 10px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: border-color var(--duration-hover) var(--ease-out-quart),
+              background var(--duration-hover) var(--ease-out-quart),
+              color var(--duration-hover) var(--ease-out-quart);
+  outline: none;
+}
+
+.btn-download:hover {
+  border-color: rgba(197,160,89,0.55);
+  background: rgba(197,160,89,0.06);
+  color: var(--gold-bright);
+}
+
+.btn-download:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+.btn-download-icon {
+  font-size: 16px;
+}
+
+.btn-copy {
+  flex: 0.8;
+  min-height: 44px;
+  background: transparent;
+  color: rgba(197,160,89,0.65);
+  border: none;
+  border-radius: 10px;
+  font-family: var(--font-ui);
+  font-size: 9px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: color var(--duration-hover) var(--ease-out-quart),
+              background var(--duration-hover) var(--ease-out-quart);
+  outline: none;
+}
+
+.btn-copy:hover {
+  color: var(--gold-bright);
+  background: rgba(197,160,89,0.05);
+  border-radius: 10px;
+}
+
+.btn-copy:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 2px;
+}
+
+.btn-copy-icon {
+  font-size: 16px;
+}
+
+/* Style indicator dots */
+.style-dots {
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.style-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgba(197,160,89,0.2);
+  transition: background var(--duration-transition) var(--ease-out-quart),
+              transform var(--duration-transition) var(--ease-out-quart);
+}
+
+.style-dot.active {
+  background: var(--gold);
+  transform: scale(1.3);
+}
+</style>
+</head>
+<body>
+
+<!-- ==========================================
+     PHONE FRAME
+     ========================================== -->
+<div class="phone-frame" aria-label="iPhone frame preview">
+
+  <!-- App backdrop -->
+  <div class="app-backdrop">
+    <!-- Caption label -->
+    <div class="caption-label" aria-label="Design caption">
+      <span class="caption-title">Majlis</span>
+      <span class="caption-subtitle">horizontal style carousel · architectural chrome</span>
+    </div>
+  </div>
+
+  <!-- ==========================================
+       MODAL OVERLAY
+       ========================================== -->
+  <div class="modal-overlay">
+    <div
+      class="modal-panel"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Share this poem"
+    >
+      <!-- Pillar decorations -->
+      <div class="pillar-left" aria-hidden="true"></div>
+      <div class="pillar-right" aria-hidden="true"></div>
+
+      <!-- ==========================================
+           HEADER
+           ========================================== -->
+      <header class="modal-header">
+        <div class="header-arch-ornament" aria-hidden="true">
+          <div class="arch-icon">
+            <svg viewBox="0 0 48 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <!-- Pointed arch / muqarnas-inspired ornament -->
+              <path
+                d="M4 32 Q4 12 24 4 Q44 12 44 32"
+                stroke="rgba(197,160,89,0.45)"
+                stroke-width="1"
+                fill="none"
+              />
+              <path
+                d="M10 32 Q10 16 24 10 Q38 16 38 32"
+                stroke="rgba(197,160,89,0.22)"
+                stroke-width="0.75"
+                fill="none"
+              />
+              <circle cx="24" cy="4" r="1.5" fill="rgba(197,160,89,0.5)"/>
+              <!-- Corner finials -->
+              <path d="M4 32 L4 28 M4 32 L8 32" stroke="rgba(197,160,89,0.35)" stroke-width="1" fill="none"/>
+              <path d="M44 32 L44 28 M44 32 L40 32" stroke="rgba(197,160,89,0.35)" stroke-width="1" fill="none"/>
+            </svg>
+          </div>
+        </div>
+
+        <div class="header-content">
+          <div class="header-text">
+            <span class="modal-title-arabic" lang="ar" dir="rtl">شارك هذه القصيدة</span>
+            <span class="modal-title-english">Share this Poem</span>
+            <span class="modal-subtitle">Choose your card style</span>
+          </div>
+          <button class="close-btn" aria-label="Close modal" onclick="/* no-op in preview */">✕</button>
+        </div>
+      </header>
+
+      <hr class="gold-rule" aria-hidden="true">
+
+      <!-- ==========================================
+           CAROUSEL SECTION
+           ========================================== -->
+      <section class="carousel-section" aria-label="Card style selector">
+        <span class="carousel-label" aria-hidden="true">Card Style / طراز البطاقة</span>
+
+        <div class="carousel-track-wrapper">
+          <button
+            class="carousel-nav"
+            id="nav-prev"
+            aria-label="Previous style"
+            onclick="navigate(-1)"
+          >◀</button>
+
+          <div class="carousel-track" id="carousel-track" role="listbox" aria-label="Card styles">
+
+            <!-- Thumb 1: Dīwān -->
+            <div
+              class="thumb thumb-diwan active"
+              id="thumb-0"
+              role="option"
+              aria-selected="true"
+              tabindex="0"
+              aria-label="Dīwān style"
+              onclick="selectStyle(0)"
+              onkeydown="handleThumbKey(event, 0)"
+            >
+              <div class="thumb-border-deco" aria-hidden="true"></div>
+              <div class="thumb-inner" aria-hidden="true">
+                <div class="thumb-line thumb-line-long"></div>
+                <div class="thumb-line thumb-line-short"></div>
+                <div class="thumb-line thumb-line-med"></div>
+              </div>
+              <span class="thumb-name">Dīwān</span>
+            </div>
+
+            <!-- Thumb 2: Ibn Muqla -->
+            <div
+              class="thumb thumb-ibn-muqla"
+              id="thumb-1"
+              role="option"
+              aria-selected="false"
+              tabindex="0"
+              aria-label="Ibn Muqla style"
+              onclick="selectStyle(1)"
+              onkeydown="handleThumbKey(event, 1)"
+            >
+              <div class="thumb-border-deco" aria-hidden="true"></div>
+              <div class="thumb-inner" aria-hidden="true">
+                <div class="thumb-line thumb-line-long"></div>
+                <div class="thumb-line thumb-line-short"></div>
+                <div class="thumb-line thumb-line-med"></div>
+              </div>
+              <span class="thumb-name">Ibn Muqla</span>
+            </div>
+
+            <!-- Thumb 3: Sinan -->
+            <div
+              class="thumb thumb-sinan"
+              id="thumb-2"
+              role="option"
+              aria-selected="false"
+              tabindex="0"
+              aria-label="Sinan style"
+              onclick="selectStyle(2)"
+              onkeydown="handleThumbKey(event, 2)"
+            >
+              <div class="thumb-border-deco" aria-hidden="true"></div>
+              <div class="thumb-inner" aria-hidden="true">
+                <div class="thumb-line thumb-line-long"></div>
+                <div class="thumb-line thumb-line-short"></div>
+                <div class="thumb-line thumb-line-med"></div>
+              </div>
+              <span class="thumb-name">Sinan</span>
+            </div>
+
+            <!-- Thumb 4: Zaha -->
+            <div
+              class="thumb thumb-zaha"
+              id="thumb-3"
+              role="option"
+              aria-selected="false"
+              tabindex="0"
+              aria-label="Zaha Hadid style"
+              onclick="selectStyle(3)"
+              onkeydown="handleThumbKey(event, 3)"
+            >
+              <div class="thumb-border-deco" aria-hidden="true"></div>
+              <div class="thumb-inner" aria-hidden="true">
+                <div class="thumb-line thumb-line-long"></div>
+                <div class="thumb-line thumb-line-short"></div>
+                <div class="thumb-line thumb-line-med"></div>
+              </div>
+              <span class="thumb-name">Zaha</span>
+            </div>
+
+            <!-- Thumb 5: Hassan Fathy -->
+            <div
+              class="thumb thumb-hassan"
+              id="thumb-4"
+              role="option"
+              aria-selected="false"
+              tabindex="0"
+              aria-label="Hassan Fathy style"
+              onclick="selectStyle(4)"
+              onkeydown="handleThumbKey(event, 4)"
+            >
+              <div class="thumb-border-deco" aria-hidden="true"></div>
+              <div class="thumb-inner" aria-hidden="true">
+                <div class="thumb-line thumb-line-long"></div>
+                <div class="thumb-line thumb-line-short"></div>
+                <div class="thumb-line thumb-line-med"></div>
+              </div>
+              <span class="thumb-name">Hassan Fathy</span>
+            </div>
+
+          </div><!-- /carousel-track -->
+
+          <button
+            class="carousel-nav"
+            id="nav-next"
+            aria-label="Next style"
+            onclick="navigate(1)"
+          >▶</button>
+        </div><!-- /carousel-track-wrapper -->
+      </section>
+
+      <hr class="section-rule" aria-hidden="true">
+
+      <!-- ==========================================
+           LARGE CARD PREVIEW
+           ========================================== -->
+      <section class="preview-section" aria-label="Card preview" aria-live="polite">
+        <div class="preview-card-wrapper">
+
+          <!-- Card 0: Dīwān -->
+          <div class="preview-card card-diwan visible-card" id="card-0" aria-hidden="false">
+            <div class="lapis-band" aria-hidden="true"></div>
+            <div class="card-border-frame" aria-hidden="true"></div>
+            <div class="card-content">
+              <div class="card-divider-top" aria-hidden="true"></div>
+              <div class="poem-arabic" lang="ar" dir="rtl">
+                <span class="line">خُذي قَلبي وَلا تَتركيهِ وَحيداً</span>
+                <span class="line">فَفي غيابِكِ يَنسى كَيفَ يَدقّ</span>
+              </div>
+              <div class="card-mid-rule" aria-hidden="true"></div>
+              <div class="poem-english" lang="en">
+                <span class="line">Take my heart, do not leave it alone</span>
+                <span class="line">For in your absence, it forgets how to beat</span>
+              </div>
+              <div class="card-divider-bottom" aria-hidden="true"></div>
+              <div class="poet-byline">
+                <span class="poet-name-arabic" lang="ar" dir="rtl">نزار قباني</span>
+                <span class="poet-name-english">Nizar Qabbani</span>
+              </div>
+            </div>
+            <div class="style-badge" aria-hidden="true">Dīwān</div>
+          </div>
+
+          <!-- Card 1: Ibn Muqla -->
+          <div class="preview-card card-ibn-muqla hidden-card" id="card-1" aria-hidden="true">
+            <div class="card-content">
+              <div class="card-divider-top" aria-hidden="true"></div>
+              <div class="poem-arabic" lang="ar" dir="rtl">
+                <span class="line">خُذي قَلبي وَلا تَتركيهِ وَحيداً</span>
+                <span class="line">فَفي غيابِكِ يَنسى كَيفَ يَدقّ</span>
+              </div>
+              <div class="card-mid-rule" aria-hidden="true"></div>
+              <div class="poem-english" lang="en">
+                <span class="line">Take my heart, do not leave it alone</span>
+                <span class="line">For in your absence, it forgets how to beat</span>
+              </div>
+              <div class="card-divider-bottom" aria-hidden="true"></div>
+              <div class="poet-byline">
+                <span class="poet-name-arabic" lang="ar" dir="rtl">نزار قباني</span>
+                <span class="poet-name-english">Nizar Qabbani</span>
+              </div>
+            </div>
+            <div class="style-badge" aria-hidden="true">Ibn Muqla</div>
+          </div>
+
+          <!-- Card 2: Sinan -->
+          <div class="preview-card card-sinan hidden-card" id="card-2" aria-hidden="true">
+            <div class="geo-grid" aria-hidden="true"></div>
+            <div class="geo-border" aria-hidden="true"></div>
+            <div class="card-content">
+              <div class="card-divider-top" aria-hidden="true"></div>
+              <div class="poem-arabic" lang="ar" dir="rtl">
+                <span class="line">خُذي قَلبي وَلا تَتركيهِ وَحيداً</span>
+                <span class="line">فَفي غيابِكِ يَنسى كَيفَ يَدقّ</span>
+              </div>
+              <div class="card-mid-rule" aria-hidden="true"></div>
+              <div class="poem-english" lang="en">
+                <span class="line">Take my heart, do not leave it alone</span>
+                <span class="line">For in your absence, it forgets how to beat</span>
+              </div>
+              <div class="card-divider-bottom" aria-hidden="true"></div>
+              <div class="poet-byline">
+                <span class="poet-name-arabic" lang="ar" dir="rtl">نزار قباني</span>
+                <span class="poet-name-english">Nizar Qabbani</span>
+              </div>
+            </div>
+            <div class="style-badge" aria-hidden="true">Sinan</div>
+          </div>
+
+          <!-- Card 3: Zaha -->
+          <div class="preview-card card-zaha hidden-card" id="card-3" aria-hidden="true">
+            <div class="para-lines" aria-hidden="true"></div>
+            <div class="zaha-border" aria-hidden="true"></div>
+            <div class="card-content">
+              <div class="card-divider-top" aria-hidden="true"></div>
+              <div class="poem-arabic" lang="ar" dir="rtl">
+                <span class="line">خُذي قَلبي وَلا تَتركيهِ وَحيداً</span>
+                <span class="line">فَفي غيابِكِ يَنسى كَيفَ يَدقّ</span>
+              </div>
+              <div class="card-mid-rule" aria-hidden="true"></div>
+              <div class="poem-english" lang="en">
+                <span class="line">Take my heart, do not leave it alone</span>
+                <span class="line">For in your absence, it forgets how to beat</span>
+              </div>
+              <div class="card-divider-bottom" aria-hidden="true"></div>
+              <div class="poet-byline">
+                <span class="poet-name-arabic" lang="ar" dir="rtl">نزار قباني</span>
+                <span class="poet-name-english">Nizar Qabbani</span>
+              </div>
+            </div>
+            <div class="style-badge" aria-hidden="true">Zaha Hadid</div>
+          </div>
+
+          <!-- Card 4: Hassan Fathy -->
+          <div class="preview-card card-hassan hidden-card" id="card-4" aria-hidden="true">
+            <div class="adobe-texture" aria-hidden="true"></div>
+            <div class="nubian-arch" aria-hidden="true"></div>
+            <div class="card-content">
+              <div class="card-divider-top" aria-hidden="true"></div>
+              <div class="poem-arabic" lang="ar" dir="rtl">
+                <span class="line">خُذي قَلبي وَلا تَتركيهِ وَحيداً</span>
+                <span class="line">فَفي غيابِكِ يَنسى كَيفَ يَدقّ</span>
+              </div>
+              <div class="card-mid-rule" aria-hidden="true"></div>
+              <div class="poem-english" lang="en">
+                <span class="line">Take my heart, do not leave it alone</span>
+                <span class="line">For in your absence, it forgets how to beat</span>
+              </div>
+              <div class="card-divider-bottom" aria-hidden="true"></div>
+              <div class="poet-byline">
+                <span class="poet-name-arabic" lang="ar" dir="rtl">نزار قباني</span>
+                <span class="poet-name-english">Nizar Qabbani</span>
+              </div>
+            </div>
+            <div class="style-badge" aria-hidden="true">Hassan Fathy</div>
+          </div>
+
+        </div><!-- /preview-card-wrapper -->
+      </section>
+
+      <!-- ==========================================
+           FOOTER SHELF
+           ========================================== -->
+      <footer class="footer-shelf">
+        <hr class="footer-rule" aria-hidden="true">
+        <div class="footer-actions" role="group" aria-label="Share actions">
+          <button class="btn-share" aria-label="Share poem">
+            <span class="btn-share-icon" aria-hidden="true">↗</span>
+            <span>مشاركة</span>
+          </button>
+          <button class="btn-download" aria-label="Download PNG">
+            <span class="btn-download-icon" aria-hidden="true">↓</span>
+            <span>PNG</span>
+          </button>
+          <button class="btn-copy" aria-label="Copy link">
+            <span class="btn-copy-icon" aria-hidden="true">⧉</span>
+            <span>Copy Link</span>
+          </button>
+        </div>
+        <!-- Style indicator dots -->
+        <div class="style-dots" id="style-dots" aria-hidden="true">
+          <div class="style-dot active" id="dot-0"></div>
+          <div class="style-dot" id="dot-1"></div>
+          <div class="style-dot" id="dot-2"></div>
+          <div class="style-dot" id="dot-3"></div>
+          <div class="style-dot" id="dot-4"></div>
+        </div>
+      </footer>
+
+    </div><!-- /modal-panel -->
+  </div><!-- /modal-overlay -->
+
+</div><!-- /phone-frame -->
+
+<script>
+  /* ============================================
+     CAROUSEL INTERACTION
+     ============================================ */
+  var currentIndex = 0;
+  var total = 5;
+
+  function selectStyle(index) {
+    if (index === currentIndex) return;
+
+    // Deactivate current thumb
+    var prevThumb = document.getElementById('thumb-' + currentIndex);
+    prevThumb.classList.remove('active');
+    prevThumb.setAttribute('aria-selected', 'false');
+
+    // Deactivate current card
+    var prevCard = document.getElementById('card-' + currentIndex);
+    prevCard.classList.remove('visible-card');
+    prevCard.classList.add('hidden-card');
+    prevCard.setAttribute('aria-hidden', 'true');
+
+    // Deactivate current dot
+    var prevDot = document.getElementById('dot-' + currentIndex);
+    prevDot.classList.remove('active');
+
+    // Update index
+    currentIndex = index;
+
+    // Activate new thumb
+    var newThumb = document.getElementById('thumb-' + currentIndex);
+    newThumb.classList.add('active');
+    newThumb.setAttribute('aria-selected', 'true');
+
+    // Activate new card
+    var newCard = document.getElementById('card-' + currentIndex);
+    newCard.classList.remove('hidden-card');
+    newCard.classList.add('visible-card');
+    newCard.setAttribute('aria-hidden', 'false');
+
+    // Activate new dot
+    var newDot = document.getElementById('dot-' + currentIndex);
+    newDot.classList.add('active');
+
+    // Scroll thumb into view
+    newThumb.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+  }
+
+  function navigate(direction) {
+    var next = (currentIndex + direction + total) % total;
+    selectStyle(next);
+  }
+
+  function handleThumbKey(event, index) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      selectStyle(index);
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      navigate(1);
+      document.getElementById('thumb-' + currentIndex).focus();
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      navigate(-1);
+      document.getElementById('thumb-' + currentIndex).focus();
+    }
+  }
+
+  // Keyboard navigation at document level
+  document.addEventListener('keydown', function(e) {
+    if (e.key === 'ArrowRight') navigate(1);
+    if (e.key === 'ArrowLeft') navigate(-1);
+  });
+</script>
+
+</body>
+</html>

--- a/design-review/share-modal/s3.html
+++ b/design-review/share-modal/s3.html
@@ -1,0 +1,1503 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Maktuba — Share Modal S3</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Reem+Kufi:wght@400;500;600&family=Amiri:ital,wght@0,400;0,700;1,400&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&display=swap" rel="stylesheet">
+
+<style>
+/* ============================================================
+   DESIGN TOKENS — Maktuba
+   ============================================================ */
+:root {
+  --gold:            #c5a059;
+  --gold-bright:     #d4b463;
+  --gold-foil:       linear-gradient(135deg,#b8922e,#c5a059 30%,#e2c67a 55%,#c5a059 75%,#a07d38);
+  --molten-gold:     linear-gradient(135deg,#a8853d,#c5a059 22%,#e0c97a 38%,#d4b463 48%,#b8924a 62%,#d8bc6e 78%,#c5a059);
+  --lapis-deep:      #1e3a6e;
+  --lapis-medium:    #2e5090;
+  --lapis-light:     #4a7cc9;
+  --bg-app:          #0c0c0e;
+  --panel-bg:        linear-gradient(145deg, rgba(20,18,15,0.97), rgba(12,12,14,0.98));
+  --gold-border:     rgba(197,160,89,0.25);
+  --gold-rule:       linear-gradient(90deg, transparent, rgba(160,128,64,0.4) 20%, #C5A059 50%, rgba(160,128,64,0.4) 80%, transparent);
+
+  --font-arabic-display: 'Reem Kufi', system-ui, sans-serif;
+  --font-arabic-body:    'Amiri', Georgia, serif;
+  --font-editorial:      'Cormorant Garamond', Georgia, serif;
+  --font-ui:             system-ui, -apple-system, sans-serif;
+
+  --ease-expo:  cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-quart: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  --radius-sm:  4px;
+  --radius-md:  8px;
+  --radius-lg:  16px;
+  --radius-xl:  24px;
+
+  --space-xs:   4px;
+  --space-sm:   8px;
+  --space-md:   16px;
+  --space-lg:   24px;
+  --space-xl:   32px;
+
+  --shadow-lift: 0 8px 32px rgba(0,0,0,0.6), 0 2px 8px rgba(0,0,0,0.4);
+  --shadow-gold: 0 4px 16px rgba(197,160,89,0.3);
+}
+
+/* ============================================================
+   RESET & BASE
+   ============================================================ */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html, body {
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  background: var(--bg-app);
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  font-family: var(--font-ui);
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+  overflow: hidden;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-family: inherit;
+}
+
+button:focus-visible {
+  outline: 2px solid var(--lapis-light);
+  outline-offset: 3px;
+}
+
+/* ============================================================
+   APP BACKDROP
+   ============================================================ */
+.app-backdrop {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+}
+
+/* Backdrop caption — hidden; the real viewer already shows a label for this mockup */
+.backdrop-caption {
+  display: none;
+}
+
+/* ============================================================
+   PHONE FRAME
+   ============================================================ */
+.phone-frame {
+  width: 100%;
+  height: 100%;
+  background: #111113;
+  border-radius: 0;
+  box-shadow: none;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+/* Phone notch — hidden; real device chrome already provides this */
+.phone-frame::before {
+  display: none;
+}
+
+/* Screen background (app UI behind modal) */
+.phone-screen {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 30% 20%, rgba(30,58,110,0.15), transparent 50%),
+    radial-gradient(ellipse at 70% 80%, rgba(197,160,89,0.04), transparent 50%),
+    #0e0d0b;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+/* Faint app content behind (suggestion of poetry app) */
+.phone-screen::before {
+  content: '';
+  position: absolute;
+  inset: 60px 20px 120px;
+  border-radius: var(--radius-xl);
+  background:
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 28px,
+      rgba(197,160,89,0.03) 28px,
+      rgba(197,160,89,0.03) 29px
+    );
+  opacity: 0.6;
+}
+
+/* ============================================================
+   MODAL OVERLAY
+   ============================================================ */
+.modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.72);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  z-index: 10;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .modal-overlay {
+    animation: overlayIn 0.3s var(--ease-quart) both;
+  }
+
+  @keyframes overlayIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+}
+
+/* ============================================================
+   MODAL PANEL — Maktuba envelope feel
+   ============================================================ */
+.modal-panel {
+  width: 100%;
+  min-height: 100%;
+  background: var(--panel-bg);
+  border-radius: 0;
+  border: none;
+  position: relative;
+  overflow: hidden;
+  padding: 0 0 env(safe-area-inset-bottom, 0px);
+  display: flex;
+  flex-direction: column;
+}
+
+/* Warm parchment overlay */
+.modal-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(197,160,89,0.06), transparent 60%),
+    radial-gradient(ellipse at 20% 100%, rgba(160,120,60,0.03), transparent 40%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Subtle warm paper texture */
+.modal-panel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      transparent,
+      transparent 3px,
+      rgba(197,160,89,0.008) 3px,
+      rgba(197,160,89,0.008) 4px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      transparent,
+      transparent 3px,
+      rgba(197,160,89,0.006) 3px,
+      rgba(197,160,89,0.006) 4px
+    );
+  pointer-events: none;
+  z-index: 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .modal-panel {
+    animation: panelRise 0.5s var(--ease-expo) 0.1s both;
+  }
+
+  @keyframes panelRise {
+    from {
+      transform: translateY(60px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+}
+
+.modal-inner {
+  position: relative;
+  z-index: 1;
+  padding: calc(var(--space-sm) + env(safe-area-inset-top, 0px)) var(--space-md) calc(var(--space-md) + env(safe-area-inset-bottom, 0px));
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+/* ============================================================
+   HEADER
+   ============================================================ */
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 0 var(--space-sm);
+  margin-bottom: 0;
+}
+
+.header-label-en {
+  font-family: var(--font-editorial);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--gold);
+  letter-spacing: 0.06em;
+  opacity: 0.85;
+}
+
+.header-center {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.header-label-ar {
+  font-family: var(--font-arabic-display);
+  font-size: 14px;
+  color: rgba(197,160,89,0.7);
+  letter-spacing: 0.02em;
+  direction: rtl;
+}
+
+.close-btn {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(197,160,89,0.08);
+  border: 1px solid rgba(197,160,89,0.18);
+  color: rgba(197,160,89,0.65);
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.18s var(--ease-quart), color 0.18s var(--ease-quart), border-color 0.18s var(--ease-quart);
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.close-btn:hover {
+  background: rgba(197,160,89,0.15);
+  color: var(--gold);
+}
+
+/* Gold hairline rule */
+.gold-rule {
+  height: 1px;
+  background: var(--gold-rule);
+  margin: 0 0 var(--space-sm);
+}
+
+/* ============================================================
+   ENVELOPE ASSEMBLY
+   ============================================================ */
+.envelope-assembly {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 4px;
+  position: relative;
+}
+
+/* Envelope base (bottom) — decorative container */
+.envelope-base {
+  width: 212px;
+  height: 14px;
+  background: linear-gradient(180deg, #1a1410 0%, #111008 100%);
+  border: 1px solid rgba(197,160,89,0.2);
+  border-top: none;
+  border-radius: 0 0 6px 6px;
+  position: relative;
+  z-index: 1;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+}
+
+.envelope-base::before {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 12px;
+  right: 12px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(197,160,89,0.15), transparent);
+}
+
+/* Envelope sides */
+.envelope-sides {
+  width: 212px;
+  height: 8px;
+  position: relative;
+  z-index: 1;
+}
+
+.envelope-sides::before,
+.envelope-sides::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: rgba(197,160,89,0.2);
+}
+
+.envelope-sides::before { left: 0; }
+.envelope-sides::after  { right: 0; }
+
+/* Envelope flap (the V-shaped fold above card) */
+.envelope-flap {
+  width: 212px;
+  position: relative;
+  z-index: 3;
+  overflow: hidden;
+  height: 28px;
+  flex-shrink: 0;
+}
+
+.envelope-flap-shape {
+  width: 100%;
+  height: 56px;
+  background: linear-gradient(180deg, #1e1a12 0%, #181410 100%);
+  clip-path: polygon(0% 0%, 100% 0%, 50% 100%);
+  border-top: 1px solid rgba(197,160,89,0.22);
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+/* Gold edge on flap */
+.envelope-flap-shape::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  clip-path: polygon(0% 0%, 100% 0%, 50% 100%);
+  background: linear-gradient(180deg, rgba(197,160,89,0.12) 0%, transparent 60%);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .envelope-flap-shape {
+    transform-origin: top center;
+    animation: flapOpen 0.5s var(--ease-expo) 0.2s both;
+  }
+
+  @keyframes flapOpen {
+    from {
+      transform: perspective(400px) rotateX(0deg);
+      opacity: 0.3;
+    }
+    to {
+      transform: perspective(400px) rotateX(-40deg);
+      opacity: 1;
+    }
+  }
+}
+
+/* ============================================================
+   CARD PREVIEW — the letter emerging
+   ============================================================ */
+.card-preview-wrap {
+  width: 212px;
+  position: relative;
+  z-index: 2;
+}
+
+.card-preview {
+  width: 200px;
+  height: 220px;
+  margin: 0 auto;
+  border-radius: var(--radius-md);
+  position: relative;
+  overflow: hidden;
+  box-shadow:
+    0 2px 0 rgba(197,160,89,0.12),
+    0 8px 24px rgba(0,0,0,0.7),
+    0 16px 40px rgba(0,0,0,0.4),
+    0 0 0 1px rgba(197,160,89,0.15);
+  cursor: pointer;
+  transition: box-shadow 0.3s var(--ease-quart);
+}
+
+.card-preview:hover {
+  box-shadow:
+    0 2px 0 rgba(197,160,89,0.2),
+    0 12px 32px rgba(0,0,0,0.7),
+    0 20px 48px rgba(0,0,0,0.4),
+    0 0 0 1px rgba(197,160,89,0.25);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .card-preview {
+    animation: letterEmerge 0.6s var(--ease-expo) 0.45s both;
+  }
+
+  @keyframes letterEmerge {
+    from {
+      transform: translateY(24px);
+      opacity: 0;
+    }
+    to {
+      transform: translateY(0);
+      opacity: 1;
+    }
+  }
+}
+
+/* Paper grain texture on card */
+.card-preview::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(
+      30deg,
+      transparent,
+      transparent 2px,
+      rgba(255,255,255,0.012) 2px,
+      rgba(255,255,255,0.012) 3px
+    ),
+    repeating-linear-gradient(
+      120deg,
+      transparent,
+      transparent 2px,
+      rgba(255,255,255,0.008) 2px,
+      rgba(255,255,255,0.008) 3px
+    );
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* Islamic geometry whisper pattern */
+.card-preview::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  opacity: 0.05;
+  background-image:
+    repeating-linear-gradient(
+      45deg,
+      rgba(197,160,89,0.4) 0px, rgba(197,160,89,0.4) 1px,
+      transparent 1px, transparent 14px
+    ),
+    repeating-linear-gradient(
+      -45deg,
+      rgba(197,160,89,0.4) 0px, rgba(197,160,89,0.4) 1px,
+      transparent 1px, transparent 14px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      rgba(197,160,89,0.2) 0px, rgba(197,160,89,0.2) 1px,
+      transparent 1px, transparent 14px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(197,160,89,0.2) 0px, rgba(197,160,89,0.2) 1px,
+      transparent 1px, transparent 14px
+    );
+}
+
+/* Card style backgrounds — applied via data-style */
+.card-preview[data-style="diwan"] {
+  background: #0c0c0e;
+}
+.card-preview[data-style="ibn-muqla"] {
+  background: radial-gradient(ellipse at 40% 30%, #261c0a 0%, #1a1208 100%);
+}
+.card-preview[data-style="sinan"] {
+  background: linear-gradient(145deg, #f5f0e8, #ede5d0);
+}
+.card-preview[data-style="zaha"] {
+  background: linear-gradient(135deg, #1a1a22, #23232e);
+}
+.card-preview[data-style="hassan"] {
+  background: linear-gradient(145deg, #3d2318, #5c3420);
+}
+
+/* Card geometric border ornament (Dīwān style) */
+.card-ornament {
+  position: absolute;
+  inset: 10px;
+  z-index: 3;
+  pointer-events: none;
+  border: 1px solid rgba(197,160,89,0.2);
+  border-radius: 2px;
+}
+
+.card-ornament::before {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border: 1px solid rgba(197,160,89,0.12);
+  border-radius: 1px;
+}
+
+.card-ornament::after {
+  content: '✦';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: rgba(197,160,89,0.06);
+  font-size: 80px;
+  letter-spacing: 0;
+  line-height: 1;
+  pointer-events: none;
+}
+
+/* Corner ornaments */
+.card-corners {
+  position: absolute;
+  inset: 0;
+  z-index: 4;
+  pointer-events: none;
+}
+
+.card-corners::before,
+.card-corners::after {
+  content: '◆';
+  position: absolute;
+  color: rgba(197,160,89,0.25);
+  font-size: 8px;
+}
+
+.card-corners::before {
+  top: 14px;
+  left: 14px;
+}
+
+.card-corners::after {
+  bottom: 14px;
+  right: 14px;
+}
+
+/* Card content */
+.card-content {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 18px;
+  gap: 8px;
+  text-align: center;
+}
+
+.card-poem-ar {
+  direction: rtl;
+  font-family: var(--font-arabic-body);
+  font-size: 15px;
+  line-height: 1.9;
+  color: #e8dcc8;
+  text-align: center;
+  letter-spacing: 0.01em;
+}
+
+.card-preview[data-style="sinan"] .card-poem-ar,
+.card-preview[data-style="sinan"] .card-poem-en {
+  color: #1a150a;
+}
+
+.card-preview[data-style="sinan"] .card-ornament {
+  border-color: rgba(197,160,89,0.35);
+}
+
+.card-divider {
+  width: 40px;
+  height: 1px;
+  background: var(--gold-rule);
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.card-poem-en {
+  font-family: var(--font-editorial);
+  font-style: italic;
+  font-size: 11px;
+  line-height: 1.7;
+  color: rgba(232,220,200,0.55);
+  text-align: center;
+  letter-spacing: 0.01em;
+}
+
+.card-poet {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  margin-top: 4px;
+}
+
+.card-poet-ar {
+  direction: rtl;
+  font-family: var(--font-arabic-display);
+  font-size: 10px;
+  color: var(--gold);
+  opacity: 0.7;
+  letter-spacing: 0.03em;
+}
+
+.card-poet-en {
+  font-family: var(--font-editorial);
+  font-style: italic;
+  font-size: 9px;
+  color: rgba(197,160,89,0.45);
+  letter-spacing: 0.06em;
+}
+
+/* Decorative parametric lines for Zaha style */
+.card-preview[data-style="zaha"] .card-ornament::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    repeating-linear-gradient(
+      -35deg,
+      transparent,
+      transparent 18px,
+      rgba(197,160,89,0.06) 18px,
+      rgba(197,160,89,0.06) 19px
+    );
+}
+
+/* Terracotta texture for Hassan style */
+.card-preview[data-style="hassan"] .card-ornament {
+  border-color: rgba(220,160,90,0.3);
+}
+
+.card-preview[data-style="hassan"] .card-poem-ar,
+.card-preview[data-style="hassan"] .card-poem-en {
+  color: #f0d8b8;
+}
+
+/* Sepia warmth for Ibn Muqla */
+.card-preview[data-style="ibn-muqla"] .card-poem-ar,
+.card-preview[data-style="ibn-muqla"] .card-poem-en {
+  color: #e8d5a8;
+}
+
+.card-preview[data-style="ibn-muqla"] .card-ornament {
+  border-color: rgba(210,170,90,0.2);
+}
+
+/* ============================================================
+   STAMP GRID — style picker
+   ============================================================ */
+.stamp-section {
+  margin-bottom: 4px;
+}
+
+.stamp-label {
+  font-family: var(--font-editorial);
+  font-style: italic;
+  font-size: 10px;
+  color: rgba(197,160,89,0.45);
+  letter-spacing: 0.08em;
+  text-align: center;
+  margin-bottom: 2px;
+}
+
+.stamp-grid {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .stamp-grid {
+    /* Stagger handled per-stamp via animation-delay */
+  }
+}
+
+.stamp {
+  width: 50px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  cursor: pointer;
+  position: relative;
+  min-height: 44px;
+  padding: 0;
+  transition: transform 0.18s var(--ease-spring);
+}
+
+.stamp:hover {
+  transform: scale(1.06) translateY(-2px);
+}
+
+.stamp:active {
+  transform: scale(0.96);
+}
+
+.stamp-img {
+  width: 50px;
+  height: 58px;
+  border-radius: 2px;
+  position: relative;
+  overflow: hidden;
+  /* Perforation border effect */
+  border: 2px dashed rgba(197,160,89,0.4);
+  transition:
+    border-color 0.2s var(--ease-quart),
+    box-shadow 0.2s var(--ease-quart);
+}
+
+/* Perforation notch effect — simulate stamp edge */
+.stamp-img::before {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border: 1px solid rgba(197,160,89,0.1);
+  border-radius: 1px;
+  z-index: 2;
+}
+
+/* Style previews in stamps */
+.stamp[data-style="diwan"]      .stamp-img { background: #0c0c0e; }
+.stamp[data-style="ibn-muqla"]  .stamp-img { background: radial-gradient(ellipse at 40% 30%, #261c0a, #1a1208); }
+.stamp[data-style="sinan"]      .stamp-img { background: linear-gradient(145deg, #f5f0e8, #ede5d0); }
+.stamp[data-style="zaha"]       .stamp-img { background: linear-gradient(135deg, #1a1a22, #23232e); }
+.stamp[data-style="hassan"]     .stamp-img { background: linear-gradient(145deg, #3d2318, #5c3420); }
+
+/* Geometric whisper in stamp previews */
+.stamp-img::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  opacity: 0.18;
+}
+
+.stamp[data-style="diwan"] .stamp-img::after {
+  background:
+    repeating-linear-gradient(45deg, rgba(197,160,89,0.5) 0, rgba(197,160,89,0.5) 1px, transparent 1px, transparent 8px),
+    repeating-linear-gradient(-45deg, rgba(197,160,89,0.5) 0, rgba(197,160,89,0.5) 1px, transparent 1px, transparent 8px);
+}
+
+.stamp[data-style="sinan"] .stamp-img::after {
+  background:
+    repeating-linear-gradient(0deg, rgba(197,160,89,0.6) 0, rgba(197,160,89,0.6) 1px, transparent 1px, transparent 10px),
+    repeating-linear-gradient(90deg, rgba(197,160,89,0.6) 0, rgba(197,160,89,0.6) 1px, transparent 1px, transparent 10px);
+}
+
+.stamp[data-style="zaha"] .stamp-img::after {
+  background:
+    repeating-linear-gradient(-35deg, rgba(197,160,89,0.4) 0, rgba(197,160,89,0.4) 1px, transparent 1px, transparent 8px);
+}
+
+.stamp[data-style="ibn-muqla"] .stamp-img::after {
+  background: radial-gradient(circle at 50% 50%, rgba(197,160,89,0.3) 0%, transparent 60%);
+}
+
+.stamp[data-style="hassan"] .stamp-img::after {
+  background:
+    repeating-linear-gradient(0deg, rgba(220,160,90,0.4) 0, rgba(220,160,90,0.4) 1px, transparent 1px, transparent 6px);
+}
+
+/* Stamp selected state */
+.stamp.selected .stamp-img {
+  border-color: var(--gold);
+  border-style: solid;
+  box-shadow:
+    0 0 0 1px rgba(197,160,89,0.15),
+    0 4px 12px rgba(197,160,89,0.25);
+}
+
+/* Lapis corner flourish on selected */
+.stamp.selected .stamp-img::before {
+  border-color: rgba(74,124,201,0.35);
+  background: linear-gradient(135deg, rgba(30,58,110,0.3), transparent 50%);
+}
+
+.stamp-name {
+  font-family: var(--font-editorial);
+  font-style: italic;
+  font-size: 9px;
+  color: rgba(197,160,89,0.45);
+  text-align: center;
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+  transition: color 0.2s var(--ease-quart);
+}
+
+.stamp.selected .stamp-name {
+  color: var(--gold-bright);
+}
+
+/* Small Arabic tag in stamp */
+.stamp-ar {
+  position: absolute;
+  bottom: 4px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-family: var(--font-arabic-display);
+  font-size: 7px;
+  color: rgba(197,160,89,0.3);
+  z-index: 3;
+  direction: rtl;
+}
+
+/* Stamp entrance animations */
+@media (prefers-reduced-motion: no-preference) {
+  .stamp:nth-child(1) { animation: stampAppear 0.3s var(--ease-expo) 0.65s both; }
+  .stamp:nth-child(2) { animation: stampAppear 0.3s var(--ease-expo) 0.70s both; }
+  .stamp:nth-child(3) { animation: stampAppear 0.3s var(--ease-expo) 0.75s both; }
+  .stamp:nth-child(4) { animation: stampAppear 0.3s var(--ease-expo) 0.80s both; }
+  .stamp:nth-child(5) { animation: stampAppear 0.3s var(--ease-expo) 0.85s both; }
+
+  @keyframes stampAppear {
+    from { opacity: 0; transform: translateY(8px) scale(0.9); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+}
+
+/* ============================================================
+   ACTIONS — stamp-and-send motif
+   ============================================================ */
+.actions-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 0 0;
+  width: 100%;
+}
+
+.actions-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  justify-content: center;
+}
+
+/* PRIMARY — Wax Seal Share button */
+.btn-wax-seal {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: var(--molten-gold);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  /* Strong convex gold dome */
+  box-shadow:
+    inset 0 3px 6px rgba(255,255,255,0.32),
+    inset 0 -3px 6px rgba(0,0,0,0.45),
+    inset 3px 0 4px rgba(255,255,255,0.1),
+    inset -3px 0 4px rgba(0,0,0,0.2),
+    0 5px 20px rgba(197,160,89,0.5),
+    0 2px 8px rgba(0,0,0,0.55);
+  border: 1px solid rgba(255,255,255,0.18);
+  border-bottom-color: rgba(0,0,0,0.3);
+  transition:
+    transform 0.2s var(--ease-spring),
+    box-shadow 0.2s var(--ease-quart),
+    filter 0.2s var(--ease-quart);
+  min-width: 50px;
+  overflow: hidden;
+}
+
+/* Convex dome highlight — top radial sheen */
+.btn-wax-seal::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 80%;
+  height: 50%;
+  background: radial-gradient(ellipse 80% 100% at 50% -20%, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0.18) 45%, transparent 100%);
+  border-radius: 50% 50% 60% 60%;
+  pointer-events: none;
+  z-index: 2;
+}
+
+/* Inner ring detail */
+.btn-wax-seal::after {
+  content: '';
+  position: absolute;
+  inset: 6px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(0,0,0,0.18);
+  box-shadow: inset 0 1px 2px rgba(255,255,255,0.15);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.btn-wax-seal:hover {
+  transform: rotate(4deg) scale(1.09);
+  filter: brightness(1.06) saturate(1.08);
+  box-shadow:
+    inset 0 3px 6px rgba(255,255,255,0.32),
+    inset 0 -3px 6px rgba(0,0,0,0.42),
+    0 8px 28px rgba(197,160,89,0.6),
+    0 4px 12px rgba(0,0,0,0.5);
+}
+
+.btn-wax-seal:active {
+  transform: rotate(1deg) scale(0.94);
+  filter: brightness(0.95);
+  box-shadow:
+    inset 0 3px 8px rgba(0,0,0,0.4),
+    inset 0 1px 2px rgba(255,255,255,0.1),
+    0 2px 8px rgba(197,160,89,0.25);
+}
+
+.seal-icon {
+  font-size: 22px;
+  color: #1a1200;
+  line-height: 1;
+  position: relative;
+  z-index: 1;
+  font-weight: 700;
+}
+
+.seal-label {
+  font-family: var(--font-editorial);
+  font-style: italic;
+  font-size: 9px;
+  color: rgba(197,160,89,0.55);
+  text-align: center;
+  letter-spacing: 0.08em;
+  margin-top: 4px;
+}
+
+.seal-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+/* SECONDARY — Postmark Download button */
+.btn-postmark {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  flex: 1;
+  max-width: 120px;
+}
+
+.btn-postmark-inner {
+  width: 100%;
+  height: 44px;
+  border-radius: 22px;
+  border: 1.5px solid rgba(197,160,89,0.3);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  position: relative;
+  transition:
+    border-color 0.18s var(--ease-quart),
+    background 0.18s var(--ease-quart);
+  overflow: hidden;
+}
+
+/* Postmark wave texture */
+.btn-postmark-inner::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 22px;
+  background: repeating-linear-gradient(
+    90deg,
+    transparent,
+    transparent 4px,
+    rgba(197,160,89,0.05) 4px,
+    rgba(197,160,89,0.05) 5px
+  );
+  pointer-events: none;
+}
+
+.btn-postmark-inner:hover {
+  border-color: rgba(197,160,89,0.55);
+  background: rgba(197,160,89,0.05);
+}
+
+.btn-postmark-inner:active {
+  background: rgba(197,160,89,0.1);
+}
+
+.postmark-icon {
+  font-size: 14px;
+  color: var(--gold);
+  opacity: 0.8;
+}
+
+.postmark-text {
+  font-family: var(--font-editorial);
+  font-variant: small-caps;
+  font-size: 11px;
+  font-weight: 600;
+  color: rgba(197,160,89,0.7);
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+}
+
+.postmark-sub {
+  font-family: var(--font-editorial);
+  font-style: italic;
+  font-size: 9px;
+  color: rgba(197,160,89,0.35);
+  text-align: center;
+  letter-spacing: 0.05em;
+}
+
+/* COPY LINK — postal tracking string */
+.btn-copy-link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px var(--space-sm);
+  min-height: 44px;
+  font-family: 'Courier New', 'Courier', monospace;
+  font-size: 10.5px;
+  color: rgba(197,160,89,0.55);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  position: relative;
+  transition: color 0.18s var(--ease-quart);
+  white-space: nowrap;
+}
+
+.btn-copy-link::after {
+  content: '';
+  position: absolute;
+  bottom: 6px;
+  left: 8px;
+  right: 8px;
+  height: 1px;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(197,160,89,0.4) 0px,
+    rgba(197,160,89,0.4) 4px,
+    transparent 4px,
+    transparent 8px
+  );
+}
+
+.btn-copy-link:hover {
+  color: var(--gold);
+}
+
+.btn-copy-link:active {
+  color: var(--gold-bright);
+}
+
+.copy-track-icon {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+/* ============================================================
+   FOOTER BYLINE
+   ============================================================ */
+.modal-footer {
+  display: none;
+}
+
+/* ============================================================
+   ACTIONS ENTRANCE
+   ============================================================ */
+@media (prefers-reduced-motion: no-preference) {
+  .actions-section {
+    animation: actionsIn 0.4s var(--ease-expo) 0.9s both;
+  }
+
+  @keyframes actionsIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .modal-footer {
+    animation: actionsIn 0.4s var(--ease-expo) 1.0s both;
+  }
+}
+</style>
+</head>
+
+<body>
+<div class="app-backdrop">
+
+  <div class="backdrop-caption">
+    <strong>Maktuba — مكتوبة</strong>
+    Envelope-and-stamp motif · letter-as-art · wax-seal share
+  </div>
+
+  <!-- Phone Frame -->
+  <div class="phone-frame" role="presentation">
+
+    <!-- App screen behind modal -->
+    <div class="phone-screen" aria-hidden="true"></div>
+
+    <!-- Modal Overlay -->
+    <div class="modal-overlay" role="presentation">
+
+      <!-- Share Modal Panel -->
+      <div
+        class="modal-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Share poem"
+      >
+        <div class="modal-inner">
+
+          <!-- ── Header ── -->
+          <header class="modal-header">
+            <span class="header-label-en" aria-hidden="true">Share</span>
+
+            <div class="header-center">
+              <span class="header-label-ar" dir="rtl" lang="ar" aria-hidden="true">شارك</span>
+              <button
+                class="close-btn"
+                aria-label="Close share modal"
+                title="Close"
+              >✕</button>
+            </div>
+          </header>
+
+          <!-- Gold rule -->
+          <div class="gold-rule" role="separator" aria-hidden="true"></div>
+
+          <!-- ── Envelope Assembly ── -->
+          <div class="envelope-assembly" aria-hidden="true">
+
+            <!-- Envelope flap (decorative) -->
+            <div class="envelope-flap">
+              <div class="envelope-flap-shape"></div>
+            </div>
+
+            <!-- Card preview (the letter) -->
+            <div class="card-preview-wrap">
+              <div
+                class="card-preview"
+                data-style="diwan"
+                id="card-preview"
+                role="img"
+                aria-label="Poem card preview in Dīwān style"
+                tabindex="0"
+              >
+                <!-- Ornament layers -->
+                <div class="card-ornament" aria-hidden="true"></div>
+                <div class="card-corners" aria-hidden="true"></div>
+
+                <!-- Poem content -->
+                <div class="card-content">
+                  <p class="card-poem-ar" dir="rtl" lang="ar">
+                    إِذا أَحبَبتَ اخترْ جَيِّداً<br>
+                    فالحُبُّ لا يُعلَّمُ بَعدَ الأوانِ
+                  </p>
+
+                  <div class="card-divider" aria-hidden="true"></div>
+
+                  <p class="card-poem-en" lang="en">
+                    If you love, choose wisely<br>
+                    For love cannot be taught after its time has passed
+                  </p>
+
+                  <div class="card-poet" aria-label="Poet: Nizar Qabbani">
+                    <span class="card-poet-ar" dir="rtl" lang="ar">نزار قباني</span>
+                    <span class="card-poet-en">Nizar Qabbani</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Envelope sides -->
+            <div class="envelope-sides"></div>
+            <!-- Envelope base -->
+            <div class="envelope-base"></div>
+
+          </div>
+
+          <!-- ── Stamp Grid ── -->
+          <section class="stamp-section" aria-label="Card style selection">
+            <p class="stamp-label" aria-hidden="true">— choose your style —</p>
+
+            <div
+              class="stamp-grid"
+              role="radiogroup"
+              aria-label="Card styles"
+            >
+              <!-- Stamp 1: Dīwān -->
+              <button
+                class="stamp selected"
+                data-style="diwan"
+                role="radio"
+                aria-checked="true"
+                aria-label="Dīwān style"
+                title="Dīwān"
+              >
+                <div class="stamp-img">
+                  <span class="stamp-ar" dir="rtl" lang="ar">ديوان</span>
+                </div>
+                <span class="stamp-name">Dīwān</span>
+              </button>
+
+              <!-- Stamp 2: Ibn Muqla -->
+              <button
+                class="stamp"
+                data-style="ibn-muqla"
+                role="radio"
+                aria-checked="false"
+                aria-label="Ibn Muqla style"
+                title="Ibn Muqla"
+              >
+                <div class="stamp-img">
+                  <span class="stamp-ar" dir="rtl" lang="ar">مقلة</span>
+                </div>
+                <span class="stamp-name">Ibn Muqla</span>
+              </button>
+
+              <!-- Stamp 3: Sinan -->
+              <button
+                class="stamp"
+                data-style="sinan"
+                role="radio"
+                aria-checked="false"
+                aria-label="Sinan style"
+                title="Sinan"
+              >
+                <div class="stamp-img">
+                  <span class="stamp-ar" dir="rtl" lang="ar">سنان</span>
+                </div>
+                <span class="stamp-name">Sinan</span>
+              </button>
+
+              <!-- Stamp 4: Zaha Hadid -->
+              <button
+                class="stamp"
+                data-style="zaha"
+                role="radio"
+                aria-checked="false"
+                aria-label="Zaha Hadid style"
+                title="Zaha"
+              >
+                <div class="stamp-img">
+                  <span class="stamp-ar" dir="rtl" lang="ar">زها</span>
+                </div>
+                <span class="stamp-name">Zaha</span>
+              </button>
+
+              <!-- Stamp 5: Hassan Fathy -->
+              <button
+                class="stamp"
+                data-style="hassan"
+                role="radio"
+                aria-checked="false"
+                aria-label="Hassan Fathy style"
+                title="Hassan Fathy"
+              >
+                <div class="stamp-img">
+                  <span class="stamp-ar" dir="rtl" lang="ar">فتحي</span>
+                </div>
+                <span class="stamp-name">Hassan Fathy</span>
+              </button>
+
+            </div>
+          </section>
+
+          <!-- ── Actions ── -->
+          <div class="actions-section">
+
+            <!-- Primary row: Wax Seal Share + Download Postmark -->
+            <div class="actions-row">
+
+              <!-- Wax Seal Share -->
+              <div class="seal-wrapper">
+                <button
+                  class="btn-wax-seal"
+                  aria-label="Share poem card"
+                  title="Share"
+                >
+                  <span class="seal-icon" aria-hidden="true">↗</span>
+                </button>
+                <span class="seal-label">Share</span>
+              </div>
+
+              <!-- Postmark Download -->
+              <div class="btn-postmark">
+                <button
+                  class="btn-postmark-inner"
+                  aria-label="Download as PNG"
+                  title="Download PNG"
+                >
+                  <span class="postmark-icon" aria-hidden="true">⬇</span>
+                  <span class="postmark-text">Download</span>
+                </button>
+                <span class="postmark-sub">PNG · 2× resolution</span>
+              </div>
+
+            </div>
+
+            <!-- Copy Link — postal tracking string -->
+            <button
+              class="btn-copy-link"
+              aria-label="Copy link to poem"
+              title="Copy link"
+            >
+              <span class="copy-track-icon" aria-hidden="true">⬡</span>
+              TRACK·2024-NQ-0731·COPY LINK
+            </button>
+
+          </div>
+
+          <!-- ── Footer ── -->
+          <footer class="modal-footer">
+            <p class="footer-byline">
+              Poetry bil-Araby · <span dir="rtl" lang="ar">بالعربي</span>
+            </p>
+          </footer>
+
+        </div><!-- /.modal-inner -->
+      </div><!-- /.modal-panel -->
+
+    </div><!-- /.modal-overlay -->
+  </div><!-- /.phone-frame -->
+
+</div><!-- /.app-backdrop -->
+
+<script>
+(function () {
+  'use strict';
+
+  var stamps = document.querySelectorAll('.stamp');
+  var cardPreview = document.getElementById('card-preview');
+
+  // Style name → aria label map
+  var styleLabels = {
+    'diwan':     'Dīwān style',
+    'ibn-muqla': 'Ibn Muqla style',
+    'sinan':     'Sinan style',
+    'zaha':      'Zaha Hadid style',
+    'hassan':    'Hassan Fathy style'
+  };
+
+  stamps.forEach(function (stamp) {
+    stamp.addEventListener('click', function () {
+      var style = this.getAttribute('data-style');
+
+      // Update stamps
+      stamps.forEach(function (s) {
+        s.classList.remove('selected');
+        s.setAttribute('aria-checked', 'false');
+      });
+      this.classList.add('selected');
+      this.setAttribute('aria-checked', 'true');
+
+      // Update card preview with a quick fade transition
+      cardPreview.style.transition = 'opacity 0.18s ease';
+      cardPreview.style.opacity = '0';
+
+      setTimeout(function () {
+        cardPreview.setAttribute('data-style', style);
+        cardPreview.setAttribute('aria-label', 'Poem card preview in ' + (styleLabels[style] || style));
+        cardPreview.style.opacity = '1';
+      }, 180);
+    });
+
+    // Keyboard: space/enter already fire click; add arrow key nav
+    stamp.addEventListener('keydown', function (e) {
+      var idx = Array.prototype.indexOf.call(stamps, this);
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        var next = stamps[(idx + 1) % stamps.length];
+        next.focus();
+        next.click();
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        var prev = stamps[(idx - 1 + stamps.length) % stamps.length];
+        prev.focus();
+        prev.click();
+      }
+    });
+  });
+
+  // Close button
+  var closeBtn = document.querySelector('.close-btn');
+  closeBtn.addEventListener('click', function () {
+    // In demo context: subtle opacity pulse to acknowledge
+    var overlay = document.querySelector('.modal-overlay');
+    overlay.style.transition = 'opacity 0.2s ease';
+    overlay.style.opacity = '0.4';
+    setTimeout(function () {
+      overlay.style.opacity = '1';
+    }, 300);
+  });
+
+  // Copy link — visual feedback
+  var copyBtn = document.querySelector('.btn-copy-link');
+  copyBtn.addEventListener('click', function () {
+    var orig = this.textContent;
+    this.textContent = '⬡ COPIED · LINK SENT ·✓';
+    this.style.color = 'var(--gold-bright)';
+    var self = this;
+    setTimeout(function () {
+      self.textContent = orig;
+      self.style.color = '';
+    }, 1800);
+  });
+
+  // Download — visual feedback
+  var dlBtn = document.querySelector('.btn-postmark-inner');
+  dlBtn.addEventListener('click', function () {
+    var textEl = this.querySelector('.postmark-text');
+    var origText = textEl.textContent;
+    textEl.textContent = 'Preparing...';
+    setTimeout(function () {
+      textEl.textContent = origText;
+    }, 1400);
+  });
+
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
These are the on-brand Dīwān design-sprint outputs for the share and login experiences — static HTML mockups for picking a direction to implement into the real `ShareCardModal` / `AuthModal` later. No production source is touched (no `src/` changes, no account-menu viewer links).

## Share directions (`design-review/share-modal/`)
- **s1 — Folio** (flagship): manuscript folio treatment
- **s2 — Majlis**: gathering/salon aesthetic
- **s3 — Maktuba**: written-word / letterform focus

## Login directions (`design-review/login-modal/`)
- **l1 — Wax Seal**: seal-and-sign motif
- **l2 — Tessellated Bottom Sheet**: geometric tessellation bottom sheet
- **l3 — Threshold** (flagship): doorway / threshold entry

Each set ships an `index.html` viewer so every direction is viewable full-screen. Reviewable via the `/design-review` route and the repo's html-preview bot.

## Files (8)
- `design-review/share-modal/{index,s1,s2,s3}.html`
- `design-review/login-modal/{index,l1,l2,l3}.html`

Note: this branch was cut fresh off up-to-date `main` (after PR #580's squash-merge) and restores only the mockup files, so the diff is limited to these 8 static HTML files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EMYWTfrYbjuPCqUpJQMi9)_