### PR TITLE
fix(ci): repair README Auto-Update — empty ${{ }} broke it at startup

### DIFF
--- a/.github/workflows/readme-autoupdate.yml
+++ b/.github/workflows/readme-autoupdate.yml
@@ -118,8 +118,9 @@ jobs:
       - name: Build PR title, body, and commit message
         id: prbody
         run: |
-          # All values come from git / GitHub env — no untrusted text is interpolated into
-          # the shell via ${{ }}, so a crafted commit message cannot inject commands.
+          # All values come from git / GitHub env via shell variables — no untrusted text is
+          # interpolated through GitHub template expressions, so a crafted commit message
+          # cannot inject commands.
           SHA="$(git rev-parse HEAD)"
           SHORT="$(git rev-parse --short HEAD)"
           SUBJECT="$(git log -1 --pretty=%s)"


### PR DESCRIPTION
## What you saw

In the Workflows list, **README Auto-Update** shows as the raw path `.github/workflows/readme-autoupdate.yml` with **no friendly name**, while every other workflow shows a proper title. That's the tell: GitHub couldn't parse the file, so it fell back to the filename. Your instinct was right.

The workflow **did** run on your #580 merge — but it failed at **startup** (0 jobs, instant "failure"), so no PR was ever produced. Same for every push since #598, on `main` and every feature branch.

## Root cause

GitHub Actions evaluates `${{ }}` expressions **everywhere** in a workflow file — including inside `run:` script bodies and their comments. The "Build PR title" step (added in #598) had a comment explaining the shell-injection guard that contained a **literal empty expression**:

```yaml
# the shell via ${{ }}, so a crafted commit message cannot inject commands.
```

An empty `${{ }}` is an invalid expression, so GitHub rejected the entire workflow at validation time — before any job could start. That's why it failed instantly with no jobs and no logs, and why runs appeared even on non-`main` branches (GitHub emits a startup-failure run wherever the broken file exists).

(Python's YAML parser accepts the file — this is a GitHub-expression error, not a YAML syntax error, which is why it slipped through.)

## Fix

Reworded the comment so it no longer contains the `${{ }}` sequence. **No behavioral change** — the workflow logic is untouched. The remaining `${{ }}` in the file are all valid (`secrets.*`, `steps.prbody.outputs.*`, `runner.temp`, `github.ref`).

## After merge

- The workflow parses again and will show its real name ("README Auto-Update").
- The next non-README merge to `main` will trigger it and (if the README needs updating) open the auto-PR as designed.
- Since the two prior startup-failure fixes never actually ran, this is the first time the rich-PR-body path from #598 will execute end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_