### PR TITLE
feat(tour): re-wire the guided walkthrough to the redesigned reader nav

### DIFF
--- a/e2e/tour.spec.js
+++ b/e2e/tour.spec.js
@@ -24,6 +24,17 @@ import { TOUR_STEPS } from '../src/constants/tourSteps.js';
 // of the tour omits it — mirror the launcher's filter.
 const STEPS = TOUR_STEPS.filter((s) => !s.when);
 
+// Two axis-aligned rects (Playwright boundingBox: {x,y,width,height}) overlap unless
+// one is fully to the left/right/above/below the other.
+function rectsOverlap(a, b) {
+  return !(
+    a.x + a.width <= b.x ||
+    b.x + b.width <= a.x ||
+    a.y + a.height <= b.y ||
+    b.y + b.height <= a.y
+  );
+}
+
 const MOCK_POEM = {
   id: 50001,
   poet: 'أبو الطيب المتنبي',
@@ -113,6 +124,23 @@ test('every step anchors to a real element and the tour walks to completion', as
         page.locator(step.target).first(),
         `Tour step "${step.key}" target ${step.target} is missing — did a control/data-tour change?`
       ).toBeVisible({ timeout: 8000 });
+
+      // 2b. ACCESS: the coachmark must NOT cover the control it highlights — the user
+      // has to see and tap it. Assert the card and the target rects do not overlap.
+      await expect
+        .poll(
+          async () => {
+            const cardBox = await card.boundingBox();
+            const targetBox = await page.locator(step.target).first().boundingBox();
+            if (!cardBox || !targetBox) return true; // not laid out yet — keep polling
+            return rectsOverlap(cardBox, targetBox);
+          },
+          {
+            timeout: 4000,
+            message: `Tour coachmark overlaps the "${step.key}" control (${step.target}) — the highlighted button is covered and cannot be tapped.`,
+          }
+        )
+        .toBe(false);
     }
 
     // Feature steps: perform the real action the tour is guiding.

--- a/e2e/tour.spec.js
+++ b/e2e/tour.spec.js
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
 import { TOUR_STEPS } from '../src/constants/tourSteps.js';
-import { FEATURES } from '../src/constants/features.js';
 
 /**
  * Walkthrough (tour) smoke test — the anti-drift guard.
@@ -92,9 +91,6 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('every step anchors to a real element and the tour walks to completion', async ({ page }) => {
-  // The tour is disabled (FEATURES.tour = false) until its steps are re-wired to the
-  // redesigned reader nav; its launcher never mounts, so skip this end-to-end walk until then.
-  test.skip(!FEATURES.tour, 'tour feature disabled — re-wire steps to the redesigned nav first');
   await setupMocks(page);
   await page.goto('/?tour=1');
   await page.waitForSelector('[dir="rtl"]', { timeout: 15000 });

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1869,6 +1869,7 @@ export default function DiwanApp() {
                 {/* Listen moved into the reader's action buttons (ReaderActions) — removed from nav. */}
                 <div className="flex flex-col items-center gap-0.5 min-w-[52px]">
                   <button
+                    data-tour="save"
                     onClick={() =>
                       isPoemSaved(displayedPoem) ? handleUnsavePoem() : handleSavePoem()
                     }
@@ -1895,6 +1896,7 @@ export default function DiwanApp() {
                 {/* Library — opens the saved-poems drawer (Khazana) */}
                 <div className="flex flex-col items-center gap-0.5 min-w-[52px]">
                   <button
+                    data-tour="library"
                     onClick={handleOpenSavedPoems}
                     aria-label={
                       savedPoems.length > 0 ? `Library, ${savedPoems.length} saved` : 'Library'
@@ -1925,6 +1927,7 @@ export default function DiwanApp() {
                 {/* Discover */}
                 <div className="flex flex-col items-center gap-0.5 min-w-[52px]">
                   <button
+                    data-tour="discover"
                     onClick={() => {
                       setFireTapped(true);
                       setTimeout(() => setFireTapped(false), 400);

--- a/src/components/feed/ReaderActions.jsx
+++ b/src/components/feed/ReaderActions.jsx
@@ -99,6 +99,7 @@ export default function ReaderActions({
           className="ra-disc ra-disc-play"
           onClick={onTogglePlay}
           aria-label={isGeneratingAudio ? 'Preparing audio' : isPlaying ? 'Pause' : 'Play'}
+          data-tour="listen"
         >
           {isGeneratingAudio ? <IconSpinner /> : isPlaying ? <IconPause /> : <IconPlay />}
         </button>
@@ -113,6 +114,7 @@ export default function ReaderActions({
         className="ra-btn ra-btn-secondary"
         onClick={handleListen}
         aria-label="Start recitation"
+        data-tour="listen"
       >
         <span className="ra-label">Listen</span>
       </button>
@@ -141,7 +143,7 @@ export default function ReaderActions({
     );
   } else if (idle) {
     right = (
-      <button className="ra-btn ra-btn-primary" onClick={onSeeMeaning}>
+      <button className="ra-btn ra-btn-primary" onClick={onSeeMeaning} data-tour="explain">
         <span className="ra-label">Poem Insights</span>
       </button>
     );

--- a/src/components/tour/SpotlightTour.jsx
+++ b/src/components/tour/SpotlightTour.jsx
@@ -593,8 +593,10 @@ function computePosition({ mode, rect, barTop, aboveRect, size, side = 'auto', a
   }
 
   if (s === 'top') {
-    // Bottom-anchored above the whole control bar (or the target) — never overlaps.
-    const refTop = barTop != null ? barTop : rect.top;
+    // Bottom-anchored above the target (or the control bar if higher) — never overlaps.
+    // Use the minimum (highest on-screen) of the two so the card clears elements that
+    // sit above the bar (e.g. the Listen pill in ReaderActions).
+    const refTop = Math.min(rect.top, barTop != null ? barTop : rect.top);
     return placeAbove(refTop - GAP, leftFor());
   }
   // bottom

--- a/src/constants/features.js
+++ b/src/constants/features.js
@@ -10,7 +10,7 @@ export const FEATURES = {
   onboarding: false, // Show kinetic walkthrough (phases 1-3) on first visit
   forceOnboarding: false, // Bypass hasSeenOnboarding check (enable to force onboarding every visit)
   designReview: false, // Show design review shortcut icon (still accessible via /design-review URL)
-  tour: false, // Guided walkthrough — disabled: its steps target the pre-redesign nav (PlayControlsStrip/VerticalSidebar); re-wire to the new reader UI before re-enabling
+  tour: true, // Guided walkthrough — re-wired to the redesigned reader nav (ReaderActions Listen/Poem Insights + bottom-nav Save/Library/Discover); insights are inline so the 'explain' step is a plain spotlight (no drawer)
 
   verticalFeed: true, // Vertical swipe feed + tap-to-reveal stanza blooms (replaces horizontal carousel)
   share: true, // Sharing — reader Share action + share card (the vertical-sidebar icon is gone)

--- a/src/constants/tourSteps.js
+++ b/src/constants/tourSteps.js
@@ -78,14 +78,14 @@ export const TOUR_STEPS = [
     target: '[data-tour="explain"]',
     arabic: 'اشرح',
     title: 'Understand the meaning',
-    body: 'Explain helps you understand by explaining the imagery and poetic nuance of the poem.',
-    hint: 'Tap for an explanation',
+    body: 'Tap Poem Insights to unfold the meaning inline — the imagery, the poetic nuance, and a note about the poet — right under the verses.',
+    hint: 'Tap for the meaning',
     advanceOn: 'click',
     side: 'top',
     align: 'end',
-    // Tapping Explain opens the insight panel; the engine moves the card in
-    // front of it (un-blurred) and closes it on Next.
-    tray: 'insight',
+    // Insights are now INLINE (they swap the poem body for the meaning, rather
+    // than opening a drawer). So there's no overlay to sit above / close — this
+    // is a plain spotlight step: tapping the "Poem Insights" action unlocks Next.
   },
   {
     key: 'favourite',

--- a/src/constants/tourTrays.js
+++ b/src/constants/tourTrays.js
@@ -13,7 +13,10 @@
  */
 export const TOUR_TRAYS = {
   discover: { stateKey: 'discoverDrawer', setter: 'setDiscoverDrawer', above: null },
-  insight: { stateKey: 'insightsDrawer', setter: 'setInsightsDrawer', above: null },
+  // NOTE: no `insight` tray — insights are now rendered INLINE in the reader
+  // (PoemReader/InlineInsights swap the poem body for the meaning) rather than in
+  // a Vaul drawer, so the 'explain' step is a plain spotlight with no overlay to
+  // open/close. See src/constants/tourSteps.js.
   auth: { stateKey: 'authModal', setter: 'setAuthModal', above: '[data-tour-anchor="auth"]' },
   saved: { stateKey: 'savedPoems', setter: 'setSavedPoemsOpen', above: null },
 };


### PR DESCRIPTION
## Summary

The guided tour was merged but disabled (`FEATURES.tour = false`) because its steps targeted the pre-redesign UI (PlayControlsStrip / VerticalSidebar). This PR re-points every step at the redesigned reader nav and re-enables the feature.

## data-tour anchors added

Each `tourSteps` target now resolves to a real, visible control:

| Step | Anchor | Element |
| --- | --- | --- |
| `listen` / `pause` | `[data-tour="listen"]` | The ReaderActions **Listen** pill — and, because tapping Listen morphs the left half into a transport, the play/pause disc **also** carries `data-tour="listen"` so the `pause` step still resolves after the morph. |
| `explain` | `[data-tour="explain"]` | The ReaderActions **Poem Insights** affordance (shown in the idle end-state). |
| `discover` | `[data-tour="discover"]` | The bottom-nav **Discover** button. |
| `favourite` (save) | `[data-tour="save"]` | The bottom-nav **Save** button. |
| `library` | `[data-tour="library"]` | The bottom-nav **Library** button. |

`restart` is still rendered by `TourLauncher` itself and was left untouched.

## Inline-insight adaptation of the `explain` step

Insights are now rendered **inline** — `PoemReader` / `InlineInsights` swap the poem body for the meaning in place, rather than opening the old Vaul drawer. So the `explain` step no longer has a drawer to sit above and close:

- Dropped its `tray: 'insight'` — it is now a plain spotlight step that unlocks **Next** when the reader taps **Poem Insights**.
- Removed the now-unused `insight` tray entry from `tourTrays.js` (with a note explaining why). The remaining trays (`discover`, `auth`, `saved`) are unchanged, and the anti-drift contract (`tour-contract.test.js`) — every `above` is a `[data-tour-anchor="..."]` selector — still holds.
- Refreshed the step copy to reflect the inline behaviour.

## Re-enabling

- Flipped `FEATURES.tour = true` and updated its comment.
- Removed the `test.skip(!FEATURES.tour, ...)` guard from `e2e/tour.spec.js` (and its now-unused `FEATURES` import).

## Verification

- `npm run build` — passes
- `npm run lint` — 0 errors
- `CI=true npm run test:coverage` — 667 unit tests pass, exit 0 (tour unit + contract tests green)
- e2e (`e2e/tour.spec.js`) was **not runnable locally** due to a dual `@playwright/test` version conflict from the Storybook addon; CI verifies it. The added anchors match what `tour.spec.js` / `tourSteps` expect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018EMYWTfrYbjuPCqUpJQMi9)_