### PR TITLE
feat(fonts): add Aref Ruqaa as a 10th Arabic typeface

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- Load fonts with display=swap for better performance -->
-    <link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Alexandria:wght@400;700&family=El+Messiri:wght@400;700&family=Lalezar&family=Rakkas&family=Fustat:wght@400;700&family=Kufam:wght@400;700&family=Katibeh&family=Scheherazade+New:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Forum&family=Reem+Kufi:wght@400;700&family=Bodoni+Moda:opsz,wght@6..96,400;6..96,500&family=IM+Fell+English:ital@0;1&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Amiri:ital,wght@0,400;0,700;1,400&family=Alexandria:wght@400;700&family=El+Messiri:wght@400;700&family=Lalezar&family=Rakkas&family=Fustat:wght@400;700&family=Kufam:wght@400;700&family=Katibeh&family=Scheherazade+New:wght@400;700&family=Aref+Ruqaa:wght@400;700&family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Forum&family=Reem+Kufi:wght@400;700&family=Bodoni+Moda:opsz,wght@6..96,400;6..96,500&family=IM+Fell+English:ital@0;1&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/constants/fonts.js
+++ b/src/constants/fonts.js
@@ -13,4 +13,5 @@ export const FONTS = [
     labelAr: 'شهرزاد',
     family: 'font-scheherazade',
   },
+  { id: 'Aref Ruqaa', label: 'Aref Ruqaa', labelAr: 'عارف رقعة', family: 'font-aref-ruqaa' },
 ];

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -61,6 +61,9 @@
 .font-scheherazade {
   font-family: 'Scheherazade New', serif;
 }
+.font-aref-ruqaa {
+  font-family: 'Aref Ruqaa', serif;
+}
 
 .header-luminescence {
   text-shadow: 0 0 30px rgba(197, 160, 89, 0.3);


### PR DESCRIPTION
## What

Adds **Aref Ruqaa** — a classical Ruqaa-style Arabic typeface well suited to poetry — to the reader's font picker, wired identically to the existing nine:
- `src/constants/fonts.js` — new `FONTS` entry
- `src/styles/app.css` — `.font-aref-ruqaa` class
- `index.html` — added to the Google Fonts `<link>`

## Why this PR exists (the test)

This is deliberately a **small, meaningful, easily revertible** change whose purpose is to **prove the README Auto-Update happy path end to end**. The README documents the typeface count and list ("Nine Arabic typefaces (…)"). Merging this makes that line inaccurate, so it should:

1. trigger the `README Auto-Update` workflow (a `src/**` change, not README-only),
2. run the Claude CLI in per-commit mode, which updates the README to "Ten … Aref Ruqaa",
3. open an auto-generated `chore/readme-autoupdate` PR with the rich title/body from #598 — **the first time that path runs successfully in production.**

Once we've confirmed that auto-PR appears and looks right, this font addition can be reverted in a follow-up PR (as planned) — or kept, since it's a genuine, working feature.

Suggested merge order: after #620 (the README refresh) to avoid a trivial overlap on the same README line, though either order resolves cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_