### PR TITLE
test(auth-modal): update header/subtitle assertions to the shipped copy

### DIFF
--- a/src/test/auth-modal.test.jsx
+++ b/src/test/auth-modal.test.jsx
@@ -86,12 +86,12 @@ describe('AuthModal', () => {
 
     it('renders the Arabic header title', () => {
       render(<AuthModal onSignInWithGoogle={onSignInWithGoogle} />);
-      expect(screen.getByText('اكتشف رحلتك في الشعر')).toBeInTheDocument();
+      expect(screen.getByText('مجموعة مختارة في انتظارك')).toBeInTheDocument();
     });
 
     it('renders the English subtitle', () => {
       render(<AuthModal onSignInWithGoogle={onSignInWithGoogle} />);
-      expect(screen.getByText('Unlock your Journey Through Poetry')).toBeInTheDocument();
+      expect(screen.getByText('A Curated Collection Awaits')).toBeInTheDocument();
     });
 
     it('renders all three feature items', () => {
@@ -147,7 +147,7 @@ describe('AuthModal', () => {
 
     it('Arabic title has dir="rtl" attribute', () => {
       render(<AuthModal onSignInWithGoogle={onSignInWithGoogle} />);
-      const arabicTitle = screen.getByText('اكتشف رحلتك في الشعر');
+      const arabicTitle = screen.getByText('مجموعة مختارة في انتظارك');
       expect(arabicTitle).toHaveAttribute('dir', 'rtl');
     });
   });


### PR DESCRIPTION
## Why

While watching CI on the safety-net/font PRs, I found the **Unit Tests gate is red on `main`** — 3 stale tests in `auth-modal.test.jsx`, unrelated to any of those PRs. The login-modal redesign changed the AuthModal header copy, but the test wasn't updated, so it still asserts the old strings.

This blocks the Unit Tests gate on **every open PR** (#619, #621), so fixing it here unblocks all of them.

## Fix

Align the 3 assertions with the current `AuthModal.jsx` (the source of truth):

| | Old (asserted) | Current (rendered) |
|---|---|---|
| Arabic title | `اكتشف رحلتك في الشعر` | `مجموعة مختارة في انتظارك` |
| English subtitle | `Unlock your Journey Through Poetry` | `A Curated Collection Awaits` |

The `dir="rtl"` test uses the same Arabic string, updated too.

Verified: `auth-modal.test.jsx` now passes 13/13, and the full unit project goes green (680 passing).

> Note: the **Smoke Tests** red you'll see on the other PRs is the separate, known, non-required e2e issue (stale specs for removed UI, tracked in the e2e overhaul) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMsM8793mZ2JtBZHzLda9X)_