### PR TITLE
chore(test): expose DEV-gated window.__audioStore for e2e (extracted from #547)

### DIFF
--- a/src/stores/audioStore.js
+++ b/src/stores/audioStore.js
@@ -22,3 +22,12 @@ export const useAudioStore = create((set) => ({
 
   reset: () => set(initialState),
 }));
+
+// Test/dev observability hook. Real audio can't play in headless Chromium, so
+// the only reliable signal that the playback pipeline ran is the store's
+// isPlaying flag. Expose the store on window in dev builds (the target of the
+// E2E suite via `npm run dev`) so Playwright can assert playback state. Gated
+// to import.meta.env.DEV — never present in production bundles.
+if (import.meta.env.DEV && typeof window !== 'undefined') {
+  window.__audioStore = useAudioStore;
+}


### PR DESCRIPTION
## What it does

Appends a small, DEV-gated observability hook to `src/stores/audioStore.js`:

```js
if (import.meta.env.DEV && typeof window !== 'undefined') {
  window.__audioStore = useAudioStore;
}
```

This exposes the Zustand audio store on `window.__audioStore` **only in dev builds** (`import.meta.env.DEV`), so it is never present in production bundles.

## What it accomplishes

Playwright E2E specs run against `npm run dev`, where real audio cannot play in headless Chromium. The only reliable signal that the playback pipeline actually ran is the store's `isPlaying` / `isGenerating` flags. This hook lets the audio spec read those flags directly (e.g. `window.__audioStore.getState().isPlaying`) to assert playback state without depending on real audio output.

## What it relates to

Extracted as a standalone unit from #547 (branch `test/workflow-guards-pr-a`). It is one of the enablers for the audio E2E work / the #605 audio-testing overhaul — PR5's hook is the value the `audio.spec` reads. Pairs with the companion PR that adds the Playwright `--autoplay-policy=no-user-gesture-required` launch flag.

## Static validation

`npm ci` is currently broken in the extraction environment (Z_DATA_ERROR), so no build/tests were run. Validated statically:
- `node --check src/stores/audioStore.js` passes.
- Diffed the branch version against current `main`; applied only the DEV-gated hook onto main's current store (no unrelated store changes clobbered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3q5fSt6VosmHWvSGKsUsW)_