### PR TITLE
test(tts): read-along word-advancement cases for useTTSHighlight

### DIFF
--- a/src/test/useTTSHighlight.test.jsx
+++ b/src/test/useTTSHighlight.test.jsx
@@ -61,6 +61,14 @@ function flushRaf() {
   toFlush.forEach(({ cb }) => cb(performance.now()));
 }
 
+// Deterministic "elapsed time" control. The hook computes
+// elapsed = Date.now()/1000 - playbackStartTime.value + pauseOffset.value,
+// so pinning playbackStartTime to (now - seconds) makes elapsed ≈ seconds.
+function setElapsed(seconds) {
+  playbackStartTime.value = Date.now() / 1000 - seconds;
+  pauseOffset.value = 0;
+}
+
 describe('useTTSHighlight', () => {
   it('does not start rAF loop when isPlaying is false', () => {
     useAudioStore.getState.mockReturnValue({ isPlaying: false, player: null });
@@ -160,6 +168,69 @@ describe('useTTSHighlight', () => {
     const wordRefs = [];
     renderHook(() => useTTSHighlight({ wordRefs, timings: [], totalDuration: 5 }));
     expect(mockRaf).toHaveBeenCalled();
+  });
+});
+
+describe('useTTSHighlight — word advancement over time (@wf-readalong)', () => {
+  function threeWords() {
+    const spans = [0, 1, 2].map(() => document.createElement('span'));
+    const wordRefs = spans.map((s) => ({ current: s }));
+    const timings = [
+      { word: 'one', start: 0, end: 1 },
+      { word: 'two', start: 1, end: 2 },
+      { word: 'three', start: 2, end: 3 },
+    ];
+    return { spans, wordRefs, timings, totalDuration: 3 };
+  }
+
+  it('moves the active word forward as elapsed crosses each timing boundary', () => {
+    const { spans, wordRefs, timings, totalDuration } = threeWords();
+
+    setElapsed(0.5); // inside word 0 [0,1)
+    renderHook(() => useTTSHighlight({ wordRefs, timings, totalDuration }));
+    act(() => triggerIsPlaying(true, false));
+    act(() => flushRaf());
+    expect(spans[0].classList.contains('tts-active')).toBe(true);
+    expect(spans[1].classList.contains('tts-active')).toBe(false);
+
+    setElapsed(1.5); // inside word 1 [1,2)
+    act(() => flushRaf());
+    expect(spans[1].classList.contains('tts-active')).toBe(true);
+    expect(spans[0].classList.contains('tts-active')).toBe(false);
+    expect(spans[0].classList.contains('tts-past')).toBe(true);
+
+    setElapsed(2.5); // inside word 2 [2,3)
+    act(() => flushRaf());
+    expect(spans[2].classList.contains('tts-active')).toBe(true);
+    expect(spans[0].classList.contains('tts-past')).toBe(true);
+    expect(spans[1].classList.contains('tts-past')).toBe(true);
+  });
+
+  it('pins the final word active once elapsed passes total duration', () => {
+    const { spans, wordRefs, timings, totalDuration } = threeWords();
+
+    setElapsed(totalDuration + 1); // 4s, past the 3s end
+    renderHook(() => useTTSHighlight({ wordRefs, timings, totalDuration }));
+    act(() => triggerIsPlaying(true, false));
+    act(() => flushRaf());
+    expect(spans[2].classList.contains('tts-active')).toBe(true);
+  });
+
+  it('freezes highlight in place on pause (no class change after stop)', () => {
+    const { spans, wordRefs, timings, totalDuration } = threeWords();
+
+    setElapsed(1.5);
+    renderHook(() => useTTSHighlight({ wordRefs, timings, totalDuration }));
+    act(() => triggerIsPlaying(true, false));
+    act(() => flushRaf());
+    expect(spans[1].classList.contains('tts-active')).toBe(true);
+
+    // Pause: loop stops, highlight should stay on word 1 even though time moves on.
+    act(() => triggerIsPlaying(false, true));
+    setElapsed(2.5); // time advances past word 2...
+    act(() => flushRaf()); // ...but the loop is stopped, so no rAF work happens
+    expect(spans[1].classList.contains('tts-active'), 'active word frozen on pause').toBe(true);
+    expect(spans[2].classList.contains('tts-active')).toBe(false);
   });
 });
 

--- a/src/test/useTTSHighlight.test.jsx
+++ b/src/test/useTTSHighlight.test.jsx
@@ -10,7 +10,13 @@ vi.mock('../stores/audioStore', () => ({
 }));
 
 import { useAudioStore } from '../stores/audioStore';
-import { useTTSHighlight, playbackStartTime, pauseOffset, startPlayer, recordPause } from '../hooks/useTTSHighlight.js';
+import {
+  useTTSHighlight,
+  playbackStartTime,
+  pauseOffset,
+  startPlayer,
+  recordPause,
+} from '../hooks/useTTSHighlight.js';
 
 // rAF mock
 let rafCallbacks = [];
@@ -49,9 +55,7 @@ afterEach(() => {
 
 // Trigger a state transition via the captured subscribe listener
 function triggerIsPlaying(isPlaying, wasPlaying) {
-  subscribeListeners.forEach((l) =>
-    l({ isPlaying }, { isPlaying: wasPlaying })
-  );
+  subscribeListeners.forEach((l) => l({ isPlaying }, { isPlaying: wasPlaying }));
 }
 
 // Helper: flush one rAF tick
@@ -226,11 +230,34 @@ describe('useTTSHighlight — word advancement over time (@wf-readalong)', () =>
     expect(spans[1].classList.contains('tts-active')).toBe(true);
 
     // Pause: loop stops, highlight should stay on word 1 even though time moves on.
-    act(() => triggerIsPlaying(false, true));
+    // recordPause() is what marks the stop as a user pause (togglePlay.js calls it
+    // immediately before player.stop()). Without it the hook treats the stop as a
+    // natural end of playback and snaps the highlight to the final word.
+    act(() => {
+      recordPause();
+      triggerIsPlaying(false, true);
+    });
     setElapsed(2.5); // time advances past word 2...
     act(() => flushRaf()); // ...but the loop is stopped, so no rAF work happens
     expect(spans[1].classList.contains('tts-active'), 'active word frozen on pause').toBe(true);
     expect(spans[2].classList.contains('tts-active')).toBe(false);
+  });
+
+  it('snaps to the final word on a natural end (stop without recordPause)', () => {
+    const { spans, wordRefs, timings, totalDuration } = threeWords();
+
+    setElapsed(1.5);
+    renderHook(() => useTTSHighlight({ wordRefs, timings, totalDuration }));
+    act(() => triggerIsPlaying(true, false));
+    act(() => flushRaf());
+    expect(spans[1].classList.contains('tts-active')).toBe(true);
+
+    // Playback ends on its own — no recordPause(). The whole poem should read as
+    // completed rather than freezing one word short of the end.
+    act(() => triggerIsPlaying(false, true));
+    expect(spans[2].classList.contains('tts-active')).toBe(true);
+    expect(spans[0].classList.contains('tts-past')).toBe(true);
+    expect(spans[1].classList.contains('tts-past')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What this does

Extends `src/test/useTTSHighlight.test.jsx` with a new `@wf-readalong` describe block covering **word advancement over time** for the read-along TTS highlighter — a gap the existing suite didn't cover.

The existing tests in this file only assert highlight state at `t=0` (playback start). This PR adds 3 tests that drive the mocked rAF loop across multiple ticks to verify:

1. **Active word advances span0 → span1 → span2** as elapsed time crosses each word's `[start, end)` timing boundary, with `tts-past` correctly applied to words already spoken.
2. **Final-word pin past `totalDuration`** — once elapsed time exceeds the poem's total duration, the last word stays marked `tts-active` rather than falling off the end.
3. **Freeze-on-pause** — once playback pauses, the active-word highlight should stay put even as (simulated) time continues to advance, i.e. the rAF loop must actually stop doing work.

A `setElapsed(seconds)` helper is added alongside the existing `flushRaf()` helper to deterministically pin the hook's internal elapsed-time formula (`Date.now()/1000 - playbackStartTime.value + pauseOffset.value`) to a given value for each assertion.

## What it accomplishes

Closes the "only tests t=0" gap in `useTTSHighlight` coverage — advancement of the read-along highlight *over time* was previously untested, even though that's the core behavior of the feature (the highlight tracking the spoken word as audio plays).

## What it relates to

This is extracted from #547 (`test/workflow-guards-pr-a`), which was stacked on #545 and couldn't merge to `main` as-is. This PR pulls just the read-along word-advancement unit out of that stack so it can land independently. Companion extractions from the same stack:

- #631 — togglePlay fallback test
- #625 / #626 / #627 — audio e2e + fixture + store hook

## Append, not replace

`main` already has its own `src/test/useTTSHighlight.test.jsx` (it has diverged from #547's copy — most notably `main`'s `useTTSHighlight` hook now tracks `lastStopWasPause` to distinguish a user pause from a natural end-of-playback, which #547's branch version does not have). Rather than overwriting the file, this PR diffed `main`'s version against #547's and **appended only the new `@wf-readalong` describe block plus the `setElapsed` helper** onto `main`'s existing file, leaving every pre-existing test untouched.

## Static validation (npm ci is broken in this environment — see PR comment)

`node --check` passes on the modified file, and all symbols the new tests reference (`playbackStartTime`, `pauseOffset`, `useTTSHighlight`, the `elapsed` formula, `tts-active`/`tts-past` classes) exist in `main`'s current `src/hooks/useTTSHighlight.js`. One likely test-vs-implementation mismatch was found during review — see the PR comment for details and a suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3q5fSt6VosmHWvSGKsUsW)_