### PR TITLE
chore(design): add TiledPatternMaker reference submodule (from #475)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = poetry_quality_and_curation/tashkeel-fixer-for-recitation
 	url = https://github.com/lesmartiepants/mishkal.git
 	branch = fix/tashkeel-bugs
+[submodule "docs/design/TiledPatternMaker"]
+	path = docs/design/TiledPatternMaker
+	url = git@github.com:ChortleMortal/TiledPatternMaker.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = fix/tashkeel-bugs
 [submodule "docs/design/TiledPatternMaker"]
 	path = docs/design/TiledPatternMaker
-	url = git@github.com:ChortleMortal/TiledPatternMaker.git
+	url = https://github.com/ChortleMortal/TiledPatternMaker.git


### PR DESCRIPTION
## Summary

Isolates the `TiledPatternMaker` git submodule registration that was bundled into PR #475 (`feature/islamic-patterns-bg`) into its own PR, per request. This PR brings in **only**:

- `.gitmodules` — adds the `docs/design/TiledPatternMaker` submodule entry
- `docs/design/TiledPatternMaker` — a gitlink (submodule reference) pinned to commit `ae9f0465ea07a5be599ed1b70085ea6d4db50605`

Nothing else from `feature/islamic-patterns-bg` is included. Nothing has been removed from the original branch — this is a pure isolation/extraction, not a rewrite.

## ⚠️ RISK WARNING — READ BEFORE MERGING

This submodule registration is a **known CI hazard** and is being surfaced deliberately rather than silently dropped or silently merged.

### 1. SSH URL will break anonymous / CI / Vercel / Render clones
The submodule is registered with an **SSH URL**:

```
git@github.com:ChortleMortal/TiledPatternMaker.git
```

Any environment that clones this repo over HTTPS with no SSH key configured — GitHub Actions runners (unless an SSH key/deploy key is explicitly provisioned), Vercel builds, Render builds, or any anonymous/token-based clone — will fail as soon as `git clone --recursive` or `git submodule update --init` touches this submodule, with an SSH authentication error (`Permission denied (publickey)` / `Host key verification failed`). Because submodule init typically runs as part of the overall checkout, **this can red CI for the entire repository**, not just changes related to this submodule.

### 2. Third-party, unpinned-org supply chain risk
`ChortleMortal/TiledPatternMaker` is **not** in the project's GitHub org — it's an external, third-party repository, pinned to an arbitrary commit (`ae9f046`). If that repo is made private, renamed, or deleted, the submodule reference breaks with no recourse from this project. There is no vendoring, mirroring, or fork-and-pin safety net in place.

### 3. This could not be reproduced in this environment
This session's sandbox runs outbound git/HTTPS through a proxy that **auto-rewrites SSH URLs to HTTPS**, so the SSH-clone failure described above did **not** reproduce here. That means the failure mode is a *hypothesis based on the URL scheme*, not a confirmed local repro — **it must be verified against real CI / Vercel / Render before merging**, since those environments do not have that rewrite.

## Suggested fixes (not yet applied — TODO for follow-up)

Pick at least one before merging:

1. **Switch the URL to HTTPS**: `https://github.com/ChortleMortal/TiledPatternMaker.git` — removes the SSH-key dependency entirely (recommended minimum fix).
2. **Vendor only the needed files** instead of a full submodule — avoids the external dependency and the submodule-init step altogether.
3. **Reference it in docs only** (a link/README note) rather than wiring it into the git submodule graph, if the design assets aren't actually consumed by the build.

## Recommendation

**Do not merge until the URL is switched to HTTPS at minimum.** As currently registered, this PR is expected to break clones/CI for any consumer without an SSH deploy key configured for `ChortleMortal/TiledPatternMaker`.

## Test plan

- [ ] Confirm CI actually exercises `git submodule update --init` (or `--recursive` clone) and observe whether it fails on the SSH URL as predicted
- [ ] Confirm Vercel/Render preview builds either skip submodules or fail the same way
- [ ] If proceeding, switch `.gitmodules` URL to HTTPS and re-verify clone/CI succeeds
- [ ] Decide whether the submodule is actually needed at build time, or whether options 2/3 above are preferable long-term

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3q5fSt6VosmHWvSGKsUsW)_