### PR TITLE
feat(categorization): distillation implementation + audit (draft)

### DIFF
--- a/poetry_quality_and_curation/categorization/audit/README.md
+++ b/poetry_quality_and_curation/categorization/audit/README.md
@@ -1,0 +1,38 @@
+# Categorization audit — artifacts
+
+Read-only audit of the poem categorization layer (coverage, duplication,
+over-tagging) plus an opinionated distillation plan. Nothing here writes to the
+DB or the pipeline.
+
+Full findings + fix plan: [`ideas/categorization-audit.md`](../../../ideas/categorization-audit.md)
+
+## Contents
+- `prompts/current_classification_prompt_v2.md` — the production prompt the corpus
+  was tagged with (caps 4/4/5), verbatim, for comparison.
+- `prompts/distilled_classification_prompt.md` — the proposed prompt (caps 2/2/2,
+  dominant-concept, one-per-synonym-family, confidence floor, rationale). Not yet
+  wired into `config.py`.
+- `queries/audit.sql` — the read-only SQL that reproduces every number in the audit.
+- `samples/before_after.json` — a live 3-poem before/after (13 → 6 tags).
+  **Illustrative only; not persisted to the DB.**
+- `check_audit.mjs` — a lightweight diagnostic asserting the key facts.
+
+## Run the check
+```bash
+# static only (distilled sample stays <= 6 tags) — no DB needed:
+node poetry_quality_and_curation/categorization/audit/check_audit.mjs
+
+# with live DB checks (coverage ~100%, avg labels > 6, a value on > 40% of poems):
+DATABASE_URL="postgres://..." node poetry_quality_and_curation/categorization/audit/check_audit.mjs
+```
+It skips the DB checks gracefully (exit 0) when `DATABASE_URL` or `pg` is
+unavailable, so it is safe to wire into CI. Exit 1 only on a real assertion failure.
+
+## Reproduce the SQL
+```bash
+psql "$DATABASE_URL" -f poetry_quality_and_curation/categorization/audit/queries/audit.sql
+```
+
+## Status
+Draft for later review. The substantive change — re-tagging the ~9k corpus with
+the distilled prompt (rough $5–15) — is **held for user approval**.

--- a/poetry_quality_and_curation/categorization/audit/README.md
+++ b/poetry_quality_and_curation/categorization/audit/README.md
@@ -1,21 +1,45 @@
-# Categorization audit — artifacts
+# Categorization audit + distillation implementation
 
-Read-only audit of the poem categorization layer (coverage, duplication,
-over-tagging) plus an opinionated distillation plan. Nothing here writes to the
-DB or the pipeline.
+Audit of the poem categorization layer (coverage, duplication, over-tagging) plus
+the **implemented** distillation change. The audit artifacts here are read-only;
+the pipeline changes live one level up in `config.py`, `classify_poems.py`, and
+`import_categories.py`. Two runtime steps are **held for approval** (below):
+applying the migration and running the mass re-tag. Nothing in this PR writes to
+the DB or runs the classifier against prod.
 
 Full findings + fix plan: [`ideas/categorization-audit.md`](../../../ideas/categorization-audit.md)
 
-## Contents
+## What the implementation changes (already in this PR)
+- `config.py` — distilled prompt (dominant-concept, one label per synonym family,
+  `rationale`); caps **2/2/2** (`MAX_LABELS_PER_DIM`); `CONFIDENCE_FLOOR = 65`;
+  `DIMENSION_MIN_LABELS` (required/optional contract); `SYNONYM_GROUPS`;
+  `TAXONOMY_VERSION = "3"` + `PROMPT_VERSION`; default model fixed to
+  `gemini-3.6-flash`.
+- `import_categories.py` — applies the confidence floor at import
+  (`config.apply_confidence_floor`), filtering both `poem_categories` and the
+  `categories` JSONB so they stay consistent; stamps `prompt_version` + `rationale`.
+- `classify_poems.py` — emits `rationale` + `prompt_version` in the parquet.
+- `supabase/migrations/20260727000000_categorization_v3_distillation.sql` — adds
+  `min_labels` / `max_labels` to `category_dimensions`; documents `accessibility_level`.
+- `classify_new.sh` — categorizes only new/unclassified poems (coverage for inserts).
+- `test_distillation.py` — unit tests for caps, the floor, and prompt/seed consistency.
+
+## Audit artifacts (read-only)
 - `prompts/current_classification_prompt_v2.md` — the production prompt the corpus
   was tagged with (caps 4/4/5), verbatim, for comparison.
-- `prompts/distilled_classification_prompt.md` — the proposed prompt (caps 2/2/2,
-  dominant-concept, one-per-synonym-family, confidence floor, rationale). Not yet
-  wired into `config.py`.
+- `prompts/distilled_classification_prompt.md` — the distilled prompt; now
+  **implemented** in `config.build_classification_prompt()` (this file is the
+  human-readable spec).
 - `queries/audit.sql` — the read-only SQL that reproduces every number in the audit.
 - `samples/before_after.json` — a live 3-poem before/after (13 → 6 tags).
   **Illustrative only; not persisted to the DB.**
 - `check_audit.mjs` — a lightweight diagnostic asserting the key facts.
+
+## Run the unit tests (no DB)
+```bash
+python poetry_quality_and_curation/categorization/test_distillation.py     # standalone
+pytest poetry_quality_and_curation/categorization/test_distillation.py -q   # or via pytest
+```
 
 ## Run the check
 ```bash
@@ -33,6 +57,50 @@ unavailable, so it is safe to wire into CI. Exit 1 only on a real assertion fail
 psql "$DATABASE_URL" -f poetry_quality_and_curation/categorization/audit/queries/audit.sql
 ```
 
+## Runbook — HELD steps (run ONLY after user approval)
+
+These are the two runtime steps this PR intentionally does **not** perform. Run
+them, in order, once approved. Both need `DATABASE_URL` and `GEMINI_API_KEY` in
+the environment (never echo the values).
+
+### 1. Apply the v3 migration (adds min/max_labels; documents accessibility_level)
+```bash
+# HELD — applies schema changes to the shared DB.
+supabase db push
+# or, to apply just this file against a connection string:
+psql "$DATABASE_URL" -f supabase/migrations/20260727000000_categorization_v3_distillation.sql
+```
+
+### 2. Re-tag the corpus with the distilled prompt (~$5–15)
+```bash
+# --- 2a. PREVIEW first: 50 poems, no DB writes (parquet only) ---
+python -m poetry_quality_and_curation.categorization.classify_poems \
+  --model gemini/gemini-3.6-flash --scope top --top-k 50 --resume \
+  --output poetry_quality_and_curation/categorization/data/preview_distilled.parquet
+python -m poetry_quality_and_curation.categorization.import_categories \
+  --input poetry_quality_and_curation/categorization/data/preview_distilled.parquet --dry-run
+
+# --- 2b. HELD — full re-tag of all ~9k poems, then import + century backfill ---
+python -m poetry_quality_and_curation.categorization.classify_poems \
+  --model gemini/gemini-3.6-flash --scope all --resume --max-cost 15 \
+  --output poetry_quality_and_curation/categorization/data/categories_distilled_v3.parquet
+python -m poetry_quality_and_curation.categorization.import_categories \
+  --input poetry_quality_and_curation/categorization/data/categories_distilled_v3.parquet
+python -m poetry_quality_and_curation.categorization.import_categories --backfill-century
+```
+`--resume` + `--max-cost` make the run restartable and cost-capped. The import is
+idempotent per poem (delete-then-insert), so re-running is safe.
+
+### 3. New-insert coverage (ongoing) — NOT scheduled here
+```bash
+# categorize only poems inserted since the last run (idempotent, cheap):
+./poetry_quality_and_curation/categorization/classify_new.sh
+```
+Schedule this nightly once approved (cron / Render / GitHub Actions). See the
+header of `classify_new.sh` for an example crontab line. It is **not** wired to
+any scheduler in this PR.
+
 ## Status
-Draft for later review. The substantive change — re-tagging the ~9k corpus with
-the distilled prompt (rough $5–15) — is **held for user approval**.
+Implementation PR (draft) for later review. The two runtime steps above — apply
+the migration and run the mass re-tag (~$5–15) — are **held for user approval**.
+The code, migration file, tests, and runbook are complete and verified.

--- a/poetry_quality_and_curation/categorization/audit/check_audit.mjs
+++ b/poetry_quality_and_curation/categorization/audit/check_audit.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * check_audit.mjs — lightweight, read-only diagnostic for the categorization audit.
+ *
+ * Asserts the audit's key facts. Two parts:
+ *   1. STATIC (always runs, no network): the distilled sample output stays <= 6
+ *      tags/poem and is strictly smaller than the production tagging.
+ *   2. LIVE DB (skips gracefully if no DATABASE_URL / no `pg` / can't connect):
+ *      coverage ~100%, avg labels/poem > 6 (documents over-tagging), and at least
+ *      one value on > 40% of poems (documents weak filters).
+ *
+ * This is a diagnostic, not a unit test. It is READ-ONLY: it never writes to the
+ * DB. Exit 0 on pass OR skip; exit 1 only when data is present and an assertion
+ * actually fails.
+ *
+ *   node poetry_quality_and_curation/categorization/audit/check_audit.mjs
+ *   DATABASE_URL=... node .../check_audit.mjs        # includes live DB checks
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+let failures = 0;
+const ok = (msg) => console.log(`  PASS  ${msg}`);
+const bad = (msg) => { console.log(`  FAIL  ${msg}`); failures++; };
+const check = (cond, msg) => { try { assert.ok(cond); ok(msg); } catch { bad(msg); } };
+
+// -- Part 1: static assertions on the committed sample -----------------------
+console.log('\n[1] Distilled sample (static, no DB)');
+const CAP_TOTAL = 6; // mood 2 + topic 2 + motif 2
+const sample = JSON.parse(readFileSync(join(HERE, 'samples', 'before_after.json'), 'utf8'));
+assert.ok(Array.isArray(sample.samples) && sample.samples.length >= 1, 'sample file has entries');
+for (const s of sample.samples) {
+  const a = s.after;
+  const afterTotal = (a.moods?.length || 0) + (a.topics?.length || 0) + (a.motifs?.length || 0);
+  const beforeTotal =
+    (s.before.mood?.length || 0) + (s.before.topic?.length || 0) + (s.before.motif?.length || 0);
+  check(afterTotal <= CAP_TOTAL, `poem ${s.id}: distilled output ${afterTotal} tags <= ${CAP_TOTAL}`);
+  check((a.moods?.length || 0) <= 2 && (a.topics?.length || 0) <= 2 && (a.motifs?.length || 0) <= 2,
+    `poem ${s.id}: each dimension <= 2 labels`);
+  check(afterTotal < beforeTotal, `poem ${s.id}: distilled (${afterTotal}) < production (${beforeTotal})`);
+  check(a.mood_primary && a.moods?.includes(a.mood_primary),
+    `poem ${s.id}: mood_primary present and within moods`);
+}
+
+// -- Part 2: live DB assertions (skip if unavailable) ------------------------
+console.log('\n[2] Live corpus (skips gracefully)');
+const url = process.env.DATABASE_URL;
+if (!url) { console.log('  SKIP  DATABASE_URL not set — live checks skipped.'); report(); }
+
+let pg;
+try { pg = (await import('pg')).default ?? (await import('pg')); }
+catch { console.log('  SKIP  `pg` not installed here — live checks skipped.'); report(); }
+
+const client = new pg.Client({ connectionString: url, ssl: { rejectUnauthorized: false } });
+try {
+  await client.connect();
+} catch (e) {
+  console.log(`  SKIP  could not connect (${e.code || e.message}) — live checks skipped.`);
+  report();
+}
+
+try {
+  const cov = (await client.query(`
+    SELECT count(*) FILTER (WHERE content IS NOT NULL AND content <> '') AS with_content,
+           count(*) FILTER (WHERE content IS NOT NULL AND content <> '' AND categorized_at IS NOT NULL) AS categorized
+    FROM poems`)).rows[0];
+  const ratio = cov.categorized / cov.with_content;
+  console.log(`        coverage: ${cov.categorized}/${cov.with_content} = ${(ratio * 100).toFixed(2)}%`);
+  check(ratio >= 0.99, `coverage >= 99% of content-bearing poems (got ${(ratio * 100).toFixed(2)}%)`);
+
+  const avg = (await client.query(`
+    WITH t AS (SELECT poem_id, count(*) n FROM poem_categories GROUP BY poem_id)
+    SELECT round(avg(n), 2)::float AS avg_total, max(n) AS max FROM t`)).rows[0];
+  console.log(`        avg labels/poem: ${avg.avg_total} (max ${avg.max})`);
+  check(avg.avg_total > 6, `over-tagging present: avg labels/poem > 6 (got ${avg.avg_total})`);
+
+  const top = (await client.query(`
+    WITH cat AS (SELECT count(*) n FROM poems WHERE categorized_at IS NOT NULL)
+    SELECT v.key, round(100.0 * count(DISTINCT pc.poem_id) / (SELECT n FROM cat), 1)::float AS pct
+    FROM poem_categories pc JOIN category_values v ON pc.value_id = v.id
+    GROUP BY v.key ORDER BY pct DESC LIMIT 1`)).rows[0];
+  console.log(`        most prevalent value: ${top.key} on ${top.pct}% of poems`);
+  check(top.pct > 40, `weak filters: at least one value on > 40% of poems (${top.key} @ ${top.pct}%)`);
+} finally {
+  await client.end();
+}
+report();
+
+function report() {
+  console.log(`\n${failures === 0 ? 'OK' : 'FAILED'} — ${failures} failure(s).`);
+  process.exit(failures === 0 ? 0 : 1);
+}

--- a/poetry_quality_and_curation/categorization/audit/prompts/current_classification_prompt_v2.md
+++ b/poetry_quality_and_curation/categorization/audit/prompts/current_classification_prompt_v2.md
@@ -1,0 +1,89 @@
+# Current production classification prompt (taxonomy v2)
+
+This is the prompt the corpus was actually tagged with — rendered verbatim from
+`poetry_quality_and_curation/categorization/config.py :: build_classification_prompt()`
+with the production caps `MAX_LABELS_PER_DIM = {mood: 4, topic: 4, motif: 5}`.
+
+It is reproduced here **for comparison** with the proposed distilled prompt in
+`distilled_classification_prompt.md`. Do not hand-edit; the source of truth is
+`config.py`.
+
+The two weaknesses this audit targets are visible in it:
+- caps allow up to **13 labels per poem** (4 + 4 + 5),
+- "be selective" (`كن انتقائياً`) is the only pressure against over-tagging, and it
+  loses to a model that hedges — hence avg 7.59 labels/poem in production.
+
+---
+
+```text
+أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر عدة أبعاد لتمكين القارئ من التصفية والاكتشاف حسب المزاج والموضوع والصورة.
+
+لكل قصيدة، اختر التصنيفات من القوائم المغلقة التالية فقط. استخدم الرمز الإنجليزي (key) في إجابتك، لا الاسم العربي.
+
+■ المزاج (mood) — اختر من 1 إلى 4 مزاجاً يغلب على القصيدة:
+  - melancholy  (حزن / Melancholy)
+  - nostalgia  (حنين / Nostalgia)
+  - joy  (فرح / Joy)
+  - amorous  (غزل / Amorous)
+  - passion  (وجد / Passion)
+  - contemplation  (تأمّل / Contemplation)
+  - serenity  (سكينة / Serenity)
+  - defiance  (تحدٍّ / Defiance)
+  - pride  (اعتزاز / Pride)
+  - grief  (أسى / Grief)
+  - hope  (أمل / Hope)
+  - despair  (يأس / Despair)
+  - satire  (سخرية / Satire)
+  - reverence  (خشوع / Reverence)
+  - bittersweet  (حلوٌ مرّ / Bittersweet)
+  - yearning  (شوق / Yearning)
+
+■ الموضوع (topic) — اختر من 1 إلى 4 موضوعاً:
+  - love  (الحب / Love)
+  - loss-death  (الفقد والموت / Loss & Death)
+  - exile-longing  (الغربة والحنين / Exile & Longing)
+  - homeland  (الوطن / Homeland)
+  - nature  (الطبيعة / Nature)
+  - war-conflict  (الحرب والصراع / War & Conflict)
+  - faith-spirit  (الإيمان والروحانية / Faith & Spirituality)
+  - wine-pleasure  (الخمر واللذّة / Wine & Pleasure)
+  - friendship  (الصداقة والوفاء / Friendship & Loyalty)
+  - time-mortality  (الزمن والفناء / Time & Mortality)
+  - wisdom-ethics  (الحكمة والأخلاق / Wisdom & Ethics)
+  - justice-oppression  (العدل والظلم / Justice & Oppression)
+  - freedom  (الحرية / Freedom)
+  - beauty  (الجمال / Beauty)
+  - honor-pride  (الفخر والشرف / Honor & Pride)
+  - women-feminine  (المرأة والأنوثة / Women & the Feminine)
+
+■ الصورة والرموز (motif) — اختر من 0 إلى 5 من الصور الحسية الحاضرة فعلاً في النص:
+  - night  (الليل / Night)
+  - desert-ruins  (الصحراء والطلل / Desert & Ruins)
+  - moon-stars  (القمر والنجوم / Moon & Stars)
+  - sea-water  (البحر والماء / Sea & Water)
+  - garden-flowers  (الروض والزهر / Garden & Flowers)
+  - wine-cup  (الكأس والخمر / The Wine Cup)
+  - sword-battle  (السيف والمعركة / Sword & Battle)
+  - birds  (الطير / Birds)
+  - fire-light  (النار والضوء / Fire & Light)
+  - tears  (الدموع / Tears)
+  - journey  (الرحلة والراحلة / Journey & Mount)
+  - dawn  (الفجر والصبح / Dawn)
+
+كما تنتج الحقول التالية:
+- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج).
+- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.
+- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).
+- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {"amorous": 90, "love": 80}.
+
+إرشادات:
+- صنّف بناءً على النص نفسه لا على شهرة الشاعر.
+- لا تخترع رموزاً خارج القوائم. إن لم تنطبق صورة حسية، اترك motifs فارغة.
+- كن انتقائياً: اختر أقوى التصنيفات لا كل ما هو محتمل.
+- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء واللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرد وصف طبيعة.
+
+أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح:
+{"id": "...", "moods": ["..."], "mood_primary": "...", "topics": ["..."], "motifs": ["..."], "emotional_intensity": N, "accessibility_level": N, "confidences": {"<key>": N}}
+
+إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.
+```

--- a/poetry_quality_and_curation/categorization/audit/prompts/distilled_classification_prompt.md
+++ b/poetry_quality_and_curation/categorization/audit/prompts/distilled_classification_prompt.md
@@ -1,9 +1,11 @@
 # Proposed DISTILLED classification prompt
 
 This is the prompt used in the live 3-poem illustrative pass (see
-`../samples/before_after.json`). It is the concrete proposal from the audit
-(`ideas/categorization-audit.md`, §5c). It has **not** been wired into
-`config.py` or run on the corpus — that is the pending, approval-gated change.
+`../samples/before_after.json`) and the human-readable spec for the audit's
+proposal (`ideas/categorization-audit.md`, §5c). It is now **implemented** in
+`config.build_classification_prompt()` (built from the taxonomy, so this text and
+the code render the same rules). What remains approval-gated is **running** it on
+the corpus — the code is in place; the re-tag is not.
 
 ## What changed vs. the current prompt
 1. **Tight caps: mood 2 / topic 2 / motif 2** (was 4 / 4 / 5). Hard ceiling drops 13 → 6.

--- a/poetry_quality_and_curation/categorization/audit/prompts/distilled_classification_prompt.md
+++ b/poetry_quality_and_curation/categorization/audit/prompts/distilled_classification_prompt.md
@@ -1,0 +1,54 @@
+# Proposed DISTILLED classification prompt
+
+This is the prompt used in the live 3-poem illustrative pass (see
+`../samples/before_after.json`). It is the concrete proposal from the audit
+(`ideas/categorization-audit.md`, §5c). It has **not** been wired into
+`config.py` or run on the corpus — that is the pending, approval-gated change.
+
+## What changed vs. the current prompt
+1. **Tight caps: mood 2 / topic 2 / motif 2** (was 4 / 4 / 5). Hard ceiling drops 13 → 6.
+2. **Dominant-concept framing.** Name the ONE dominant mood (`mood_primary`); add a
+   second mood only if genuinely distinct, not a shade of the first.
+3. **One-per-synonym-family.** From the sadness family
+   (melancholy/grief/despair/bittersweet) pick exactly one; from the desire family
+   (amorous/passion/yearning) pick exactly one. This kills the redundant stacking
+   the audit measured (2,191 poems carry ≥2 sadness synonyms; 524 carry all three
+   desire synonyms).
+4. **Confidence floor 65.** Do not emit any label with confidence < 65.
+5. **`rationale` field.** One Arabic line naming the poem's core concept, forcing a
+   coherent read instead of a scatter of plausible tags.
+
+## Tradeoff
+Trades recall for precision. A multi-theme poem surfaces under its dominant
+theme(s), not four topics. For a discovery UX, precision is the right bet — a
+filter that returns ~half the corpus (today `love` is on 46% of poems) is the
+worse failure.
+
+---
+
+## Prompt (verbatim, as run)
+
+```text
+أنت ناقد أدبي عربي خبير. صنّف القصيدة بأقل عدد من التصنيفات التي تعبّر عن جوهرها، لا كل ما هو محتمل.
+
+القوائم المغلقة (استخدم الرمز الإنجليزي key فقط):
+■ mood: melancholy, nostalgia, joy, amorous, passion, contemplation, serenity, defiance, pride, grief, hope, despair, satire, reverence, bittersweet, yearning
+■ topic: love, loss-death, exile-longing, homeland, nature, war-conflict, faith-spirit, wine-pleasure, friendship, time-mortality, wisdom-ethics, justice-oppression, freedom, beauty, honor-pride, women-feminine
+■ motif: night, desert-ruins, moon-stars, sea-water, garden-flowers, wine-cup, sword-battle, birds, fire-light, tears, journey, dawn
+
+قواعد التقطير (مهمة):
+1) mood: اختر مزاجاً مهيمناً واحداً (mood_primary)، وأضف مزاجاً ثانوياً واحداً فقط إن كان مختلفاً جوهرياً عنه. لا تكدّس مرادفات: من عائلة الحزن (melancholy/grief/despair/bittersweet) اختر الأدق واحداً؛ ومن عائلة الهوى (amorous/passion/yearning) اختر الأدق واحداً.
+2) topic: 1 موضوع، أو 2 إن حمل النص موضوعين متمايزين حقاً.
+3) motif: 0 إلى 2، فقط الصور الحسية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة.
+4) لكل رمز تختاره، أعطِ ثقة 0-100، ولا تُدرج أي رمز ثقته دون 65.
+5) أضف حقلاً "rationale": جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة تبرّر بها اختيارك.
+
+أجب بJSON فقط:
+{"id":"...","mood_primary":"...","moods":["..."],"topics":["..."],"motifs":["..."],"emotional_intensity":N,"accessibility_level":N,"confidences":{"<key>":N},"rationale":"..."}
+```
+
+## Generation config used
+- model: `gemini-3.6-flash` (via the app proxy `POST /api/ai/:model/generateContent`)
+- temperature: 0.2
+- responseMimeType: `application/json`
+- maxOutputTokens: 1400 (needs headroom for the Arabic rationale + JSON; 800 truncated)

--- a/poetry_quality_and_curation/categorization/audit/queries/audit.sql
+++ b/poetry_quality_and_curation/categorization/audit/queries/audit.sql
@@ -1,0 +1,153 @@
+-- Categorization audit — READ-ONLY diagnostic queries.
+-- Reproduces the numbers in ideas/categorization-audit.md against the live corpus.
+-- Run:  psql "$DATABASE_URL" -f audit.sql
+-- SELECT-only. Nothing here writes.
+
+\echo '== 1. Corpus totals + coverage =='
+SELECT
+  count(*)                                                              AS total_poems,
+  count(*) FILTER (WHERE content IS NOT NULL AND content <> '')         AS with_content,
+  count(*) FILTER (WHERE content IS NULL OR content = '')               AS empty_content,
+  count(*) FILTER (WHERE categorized_at IS NOT NULL)                    AS categorized_at_set,
+  count(*) FILTER (WHERE categories IS NOT NULL)                        AS jsonb_set
+FROM poems;
+
+\echo '== 2. Uncategorized poems that DO have content (the real coverage gap) =='
+SELECT id, left(title, 40) AS title, length(content) AS content_len
+FROM poems
+WHERE content IS NOT NULL AND content <> '' AND categorized_at IS NULL
+ORDER BY id
+LIMIT 20;
+
+\echo '== 3. Poems with >=1 poem_categories row + total links =='
+SELECT
+  (SELECT count(DISTINCT poem_id) FROM poem_categories) AS poems_with_links,
+  (SELECT count(*)                FROM poem_categories) AS total_links;
+
+\echo '== 4. Per-dimension coverage (poems with >=1 value in each dimension) =='
+-- motif deliberately lags mood/topic: motif is OPTIONAL (0-N) by taxonomy design.
+SELECT d.key AS dimension, count(DISTINCT pc.poem_id) AS poems_with_dim
+FROM poem_categories pc
+JOIN category_values v      ON pc.value_id = v.id
+JOIN category_dimensions d  ON v.dimension_id = d.id
+GROUP BY d.key
+ORDER BY d.key;
+
+\echo '== 5. Categorized poems MISSING each dimension (motif misses are by design) =='
+WITH cat AS (SELECT id FROM poems WHERE categorized_at IS NOT NULL),
+dims AS (
+  SELECT pc.poem_id, d.key AS dim
+  FROM poem_categories pc
+  JOIN category_values v     ON pc.value_id = v.id
+  JOIN category_dimensions d ON v.dimension_id = d.id
+)
+SELECT
+  (SELECT count(*) FROM cat) AS categorized_poems,
+  (SELECT count(*) FROM cat WHERE id NOT IN (SELECT poem_id FROM dims WHERE dim='mood'))  AS missing_mood,
+  (SELECT count(*) FROM cat WHERE id NOT IN (SELECT poem_id FROM dims WHERE dim='topic')) AS missing_topic,
+  (SELECT count(*) FROM cat WHERE id NOT IN (SELECT poem_id FROM dims WHERE dim='motif')) AS missing_motif;
+
+\echo '== 6. JSONB cache vs normalized table consistency (expect all zeros) =='
+SELECT
+  count(*) FILTER (WHERE categorized_at IS NOT NULL AND id NOT IN (SELECT poem_id FROM poem_categories)) AS catAt_but_no_links,
+  count(*) FILTER (WHERE categorized_at IS NULL     AND id     IN (SELECT poem_id FROM poem_categories)) AS links_but_no_catAt,
+  count(*) FILTER (WHERE categories IS NOT NULL     AND id NOT IN (SELECT poem_id FROM poem_categories)) AS jsonb_but_no_links
+FROM poems;
+
+\echo '== 7. OVER-TAGGING: labels-per-dimension distribution =='
+WITH pd AS (
+  SELECT pc.poem_id, d.key AS dim, count(*) AS n
+  FROM poem_categories pc
+  JOIN category_values v     ON pc.value_id = v.id
+  JOIN category_dimensions d ON v.dimension_id = d.id
+  GROUP BY pc.poem_id, d.key
+)
+SELECT dim,
+  round(avg(n), 2) AS avg_labels, min(n) AS min, max(n) AS max,
+  count(*) FILTER (WHERE n = 1)  AS poems_1,
+  count(*) FILTER (WHERE n = 2)  AS poems_2,
+  count(*) FILTER (WHERE n = 3)  AS poems_3,
+  count(*) FILTER (WHERE n >= 4) AS poems_4plus
+FROM pd GROUP BY dim ORDER BY dim;
+
+\echo '== 8. OVER-TAGGING: total labels per poem (all dimensions) =='
+WITH t AS (SELECT poem_id, count(*) n FROM poem_categories GROUP BY poem_id)
+SELECT round(avg(n), 2) AS avg_total, min(n) AS min, max(n) AS max,
+  count(*) FILTER (WHERE n >= 8)  AS poems_8plus,
+  count(*) FILTER (WHERE n >= 10) AS poems_10plus
+FROM t;
+
+\echo '== 9. Filters barely discriminate: value prevalence (% of categorized poems) =='
+-- Any value on >40% of poems is a near-useless discovery filter.
+WITH cat AS (SELECT count(*) n FROM poems WHERE categorized_at IS NOT NULL)
+SELECT d.key AS dim, v.key AS value, v.label_en,
+  count(DISTINCT pc.poem_id) AS poems,
+  round(100.0 * count(DISTINCT pc.poem_id) / (SELECT n FROM cat), 1) AS pct
+FROM poem_categories pc
+JOIN category_values v     ON pc.value_id = v.id
+JOIN category_dimensions d ON v.dimension_id = d.id
+GROUP BY d.key, v.key, v.label_en
+ORDER BY poems DESC
+LIMIT 20;
+
+\echo '== 10. Synonym stacking: top co-occurring MOOD pairs =='
+WITH m AS (
+  SELECT pc.poem_id, v.key
+  FROM poem_categories pc
+  JOIN category_values v     ON pc.value_id = v.id
+  JOIN category_dimensions d ON v.dimension_id = d.id
+  WHERE d.key = 'mood'
+)
+SELECT a.key || ' + ' || b.key AS pair, count(*) AS n
+FROM m a JOIN m b ON a.poem_id = b.poem_id AND a.key < b.key
+GROUP BY 1 ORDER BY n DESC LIMIT 15;
+
+\echo '== 11. Synonym stacking: sadness + desire family redundancy =='
+WITH sad AS (
+  SELECT pc.poem_id, count(*) n
+  FROM poem_categories pc
+  JOIN category_values v     ON pc.value_id = v.id
+  JOIN category_dimensions d ON v.dimension_id = d.id
+  WHERE d.key = 'mood' AND v.key IN ('melancholy','grief','despair','bittersweet')
+  GROUP BY pc.poem_id
+),
+des AS (
+  SELECT pc.poem_id, count(*) n
+  FROM poem_categories pc
+  JOIN category_values v     ON pc.value_id = v.id
+  JOIN category_dimensions d ON v.dimension_id = d.id
+  WHERE d.key = 'mood' AND v.key IN ('amorous','passion','yearning')
+  GROUP BY pc.poem_id
+)
+SELECT
+  (SELECT count(*) FROM sad WHERE n >= 2) AS sadness_2plus,
+  (SELECT count(*) FROM sad WHERE n >= 3) AS sadness_3plus,
+  (SELECT count(*) FROM des WHERE n >= 2) AS desire_2plus,
+  (SELECT count(*) FROM des WHERE n  = 3) AS desire_all3;
+
+\echo '== 12. Confidence distribution (headroom for a floor at ~65-70) =='
+SELECT
+  count(*)                                                     AS total,
+  count(*) FILTER (WHERE confidence IS NULL)                   AS null_conf,
+  count(*) FILTER (WHERE confidence < 50)                      AS lt50,
+  count(*) FILTER (WHERE confidence >= 50 AND confidence < 70) AS c50_70,
+  count(*) FILTER (WHERE confidence >= 70 AND confidence < 85) AS c70_85,
+  count(*) FILTER (WHERE confidence >= 85)                     AS c85plus,
+  round(avg(confidence), 1)                                    AS avg_conf
+FROM poem_categories;
+
+\echo '== 13. DISTILLATION projection: prune to top-2 per dim by confidence =='
+-- Deterministic lower bound on the fix (no re-classification): shows link volume drop.
+WITH ranked AS (
+  SELECT pc.poem_id, d.key AS dim, pc.confidence,
+         row_number() OVER (PARTITION BY pc.poem_id, d.key
+                            ORDER BY pc.confidence DESC NULLS LAST) AS rn
+  FROM poem_categories pc
+  JOIN category_values v     ON pc.value_id = v.id
+  JOIN category_dimensions d ON v.dimension_id = d.id
+)
+SELECT
+  (SELECT count(*) FROM poem_categories)                                           AS current_links,
+  count(*) FILTER (WHERE rn <= 2)                                                   AS cap_2_2_2_links,
+  count(*) FILTER (WHERE rn <= 2 AND (confidence IS NULL OR confidence >= 70))      AS cap_2_2_2_floor70_links
+FROM ranked;

--- a/poetry_quality_and_curation/categorization/audit/samples/before_after.json
+++ b/poetry_quality_and_curation/categorization/audit/samples/before_after.json
@@ -1,0 +1,81 @@
+{
+  "_meta": {
+    "purpose": "ILLUSTRATIVE ONLY — a live 3-poem before/after from the distilled prompt.",
+    "not_persisted": "These 'after' results were NOT written to the database. The corpus is unchanged. This file exists to show the distillation effect qualitatively.",
+    "how_generated": "Real production tags (poem_categories) as 'before'; 'after' produced by re-classifying the same poem text with prompts/distilled_classification_prompt.md via the app proxy POST /api/ai/gemini-3.6-flash/generateContent (temperature 0.2, responseMimeType application/json).",
+    "effect": "Every sample collapsed from 13 tags to 6 (mood/topic/motif each 2), dropping low-confidence noise (e.g. sword-battle@60 on a love/ruins poem) and keeping the poem's core, with an Arabic rationale naming the dominant concept.",
+    "before_format": "value(confidence) from the production poem_categories rows.",
+    "after_format": "raw JSON returned by the distilled prompt."
+  },
+  "samples": [
+    {
+      "id": 5027,
+      "title": "فتنة الحسن وندى الشباب",
+      "poet": "أبو المعالي الطالوي",
+      "before_tag_count": 13,
+      "after_tag_count": 6,
+      "before": {
+        "mood": ["amorous(90)", "pride(85)", "bittersweet(75)", "nostalgia(70)"],
+        "topic": ["love(90)", "honor-pride(85)", "women-feminine(80)", "wisdom-ethics(60)"],
+        "motif": ["garden-flowers(80)", "moon-stars(75)", "dawn(70)", "sea-water(65)", "birds(65)"]
+      },
+      "after": {
+        "id": "5027",
+        "mood_primary": "reverence",
+        "moods": ["reverence", "amorous"],
+        "topics": ["honor-pride", "love"],
+        "motifs": ["garden-flowers", "moon-stars"],
+        "emotional_intensity": 75,
+        "accessibility_level": 65,
+        "confidences": {"reverence": 85, "amorous": 80, "honor-pride": 90, "love": 80, "garden-flowers": 75, "moon-stars": 70},
+        "rationale": "قصيدة مديح كلاسيكية تبدأ بمقدمة غزلية في وصف الحسن والشباب، ثم تنتقل إلى إجلال الممدوح وذكر مناقبه وفضله."
+      }
+    },
+    {
+      "id": 6299,
+      "title": "أطلال الديار وصوت الحمام",
+      "poet": "العرجي",
+      "before_tag_count": 13,
+      "after_tag_count": 6,
+      "before": {
+        "mood": ["nostalgia(95)", "yearning(90)", "melancholy(85)", "amorous(80)"],
+        "topic": ["love(90)", "exile-longing(85)", "time-mortality(75)", "women-feminine(70)"],
+        "motif": ["desert-ruins(95)", "birds(90)", "tears(75)", "night(70)", "sword-battle(60)"]
+      },
+      "after": {
+        "id": "6299",
+        "mood_primary": "nostalgia",
+        "moods": ["nostalgia", "yearning"],
+        "topics": ["love", "exile-longing"],
+        "motifs": ["desert-ruins", "birds"],
+        "emotional_intensity": 80,
+        "accessibility_level": 65,
+        "confidences": {"nostalgia": 90, "yearning": 85, "love": 90, "exile-longing": 80, "desert-ruins": 90, "birds": 85},
+        "rationale": "تستحضر القصيدة لوعة الحنين إلى أطلال الأحبة وحسرة الفراق وذكراهم المؤلمة من وراء أسباب العزلة والقيد."
+      }
+    },
+    {
+      "id": 5288,
+      "title": "شوق بغداد ودموع الفراق",
+      "poet": "أبو الحسن الجرجاني",
+      "before_tag_count": 13,
+      "after_tag_count": 6,
+      "before": {
+        "mood": ["nostalgia(95)", "yearning(90)", "bittersweet(80)", "serenity(70)"],
+        "topic": ["exile-longing(95)", "homeland(85)", "nature(85)", "love(80)"],
+        "motif": ["garden-flowers(85)", "tears(85)", "sea-water(80)", "moon-stars(70)", "sword-battle(60)"]
+      },
+      "after": {
+        "id": "5288",
+        "mood_primary": "nostalgia",
+        "moods": ["nostalgia", "yearning"],
+        "topics": ["exile-longing", "nature"],
+        "motifs": ["tears", "garden-flowers"],
+        "emotional_intensity": 80,
+        "accessibility_level": 75,
+        "confidences": {"nostalgia": 90, "yearning": 85, "exile-longing": 90, "nature": 75, "tears": 85, "garden-flowers": 75},
+        "rationale": "قصيدة حنين وشوق لأيام بغداد ومحاسنها، تمتزج فيها لوعة الفراق بوصف جمال طبيعتها ورياضها."
+      }
+    }
+  ]
+}

--- a/poetry_quality_and_curation/categorization/classify_new.sh
+++ b/poetry_quality_and_curation/categorization/classify_new.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# classify_new.sh — categorize only poems that don't have categories yet.
+#
+# Closes the new-insert coverage gap: brand-new poems (INSERTed after the last
+# bulk run) have no poem_categories rows and NULL categorized_at until something
+# classifies them. There is no DB trigger; this is that "something". It chains
+# the pipeline's existing --scope unclassified path:
+#
+#   classify_poems --scope unclassified  ->  import_categories  ->  backfill-century
+#
+# Idempotent and cheap: --scope unclassified only pulls poems with
+# categorized_at IS NULL, and --resume skips anything already in the output file.
+# Safe to run repeatedly; a run with nothing to do costs one quick query.
+#
+# Requires (in the environment, never echoed): DATABASE_URL, GEMINI_API_KEY.
+#
+# Schedule it nightly (do NOT enable without approval). Example crontab line —
+# 03:17 local, off the top of the hour on purpose:
+#   17 3 * * *  cd /path/to/repo && ./poetry_quality_and_curation/categorization/classify_new.sh >> /var/log/classify_new.log 2>&1
+# or as a Render/GitHub-Actions scheduled job invoking the same command.
+set -euo pipefail
+
+MODEL="${CLASSIFY_MODEL:-gemini/gemini-3.6-flash}"   # matches config.DEFAULT_GEMINI_MODEL
+MAX_COST="${CLASSIFY_MAX_COST:-5}"                    # hard cost cap per run (USD)
+OUT="poetry_quality_and_curation/categorization/data/new_$(date +%Y%m%d_%H%M%S).parquet"
+
+cd "$(git rev-parse --show-toplevel)"
+
+: "${DATABASE_URL:?set DATABASE_URL}"
+: "${GEMINI_API_KEY:?set GEMINI_API_KEY}"
+
+echo "[classify_new] scope=unclassified model=$MODEL max_cost=\$$MAX_COST"
+python -m poetry_quality_and_curation.categorization.classify_poems \
+  --model "$MODEL" --scope unclassified --resume --max-cost "$MAX_COST" --output "$OUT"
+
+# The classifier writes the parquet only when it had poems to classify.
+if [[ -f "$OUT" ]]; then
+  python -m poetry_quality_and_curation.categorization.import_categories --input "$OUT"
+  python -m poetry_quality_and_curation.categorization.import_categories --backfill-century
+  echo "[classify_new] imported $OUT"
+else
+  echo "[classify_new] nothing to classify — no new poems."
+fi

--- a/poetry_quality_and_curation/categorization/classify_poems.py
+++ b/poetry_quality_and_curation/categorization/classify_poems.py
@@ -208,6 +208,7 @@ def parse_categories(text: str, batch: list[dict]) -> list[dict]:
         if mood_primary not in config.VALID_KEYS["mood"]:
             mood_primary = moods[0] if moods else None
         confidences = _clean_confidences(item.get("confidences"), moods + topics + motifs)
+        rationale = str(item.get("rationale", "")).strip() or None
         results.append({
             "poem_id": str(poem["id"]),
             "moods": moods,
@@ -220,8 +221,12 @@ def parse_categories(text: str, batch: list[dict]) -> list[dict]:
             # stays a plain string (keys vary per row; a struct would fight
             # pyarrow's schema inference). import_categories decodes it.
             "confidences": json.dumps(confidences, ensure_ascii=False),
-            # Provenance: which taxonomy version produced this row.
+            # Distillation (v3): the model's one-line justification of the poem's
+            # core concept. Stored as provenance in the categories JSONB.
+            "rationale": rationale,
+            # Provenance: which taxonomy + prompt build produced this row.
             "taxonomy_version": config.TAXONOMY_VERSION,
+            "prompt_version": config.PROMPT_VERSION,
             # `century` is NOT here: it's derived from poet era on the import
             # side (import_categories --backfill-century), never model-guessed.
             "model_used": "",  # filled by caller

--- a/poetry_quality_and_curation/categorization/config.py
+++ b/poetry_quality_and_curation/categorization/config.py
@@ -31,14 +31,26 @@ DATA_DIR.mkdir(parents=True, exist_ok=True)
 # Taxonomy schema version. Bump when the vocabularies, families, or output
 # contract change. Stamped into per-poem provenance by the pipeline so we can
 # tell which taxonomy a row was classified under.
-TAXONOMY_VERSION = "2"
+#
+# v3 (distillation): the vocabularies + families are unchanged from v2, but the
+# OUTPUT CONTRACT changed — tighter caps (2/2/2), a dominant-concept prompt that
+# picks one label per synonym family, a confidence floor at import, and a new
+# `rationale` field. Rows tagged under v3 are sharper (a few core labels) than
+# the v2 rows (avg 7.6 labels/poem). See ideas/categorization-audit.md.
+TAXONOMY_VERSION = "3"
+
+# Prompt revision, stamped alongside TAXONOMY_VERSION so we can distinguish rows
+# produced by different prompt builds even within one taxonomy version.
+PROMPT_VERSION = "distill-1"
 
 # -- Run defaults ----------------------------------------------------------
 DEFAULT_MODEL = DEFAULT_HAIKU_MODEL       # bulk classification is cheap on Haiku
 # Gemini is the working bulk provider in this environment (the Anthropic/Bedrock
-# proxy needs a token we don't have here). `gemini-2.5-flash` is the cheap bulk
-# model; `gemini-2.5-pro` is used as the eval judge / reference labeler.
-DEFAULT_GEMINI_MODEL = "gemini/gemini-2.5-flash"
+# proxy needs a token we don't have here). `gemini-3.6-flash` is the cheap bulk
+# model the v2 corpus was actually tagged with (the earlier default said
+# 2.5-flash but every categorization_model value in prod is 3.6-flash);
+# `gemini-2.5-pro` is used as the eval judge / reference labeler.
+DEFAULT_GEMINI_MODEL = "gemini/gemini-3.6-flash"
 DEFAULT_BATCH_SIZE = 4
 DEFAULT_CONCURRENCY = 15
 DEFAULT_MAX_COST = 60
@@ -188,6 +200,14 @@ ERA_CENTURY = {
 CONFIDENCE_MIN = 0
 CONFIDENCE_MAX = 100
 
+# Distillation floor. Labels the model assigns with a confidence below this are
+# dropped at import time (import_categories.py), so weak/hedged tags never reach
+# poem_categories. The distilled prompt also asks the model not to emit anything
+# below this, but the floor is enforced in code as the authoritative guarantee.
+# The one exception is mood_primary, which is always kept so mood is never empty
+# (mood is a required dimension — see DIMENSION_MIN_LABELS).
+CONFIDENCE_FLOOR = 65
+
 
 def clamp_confidence(value):
     """Clamp a model-provided confidence into [CONFIDENCE_MIN, CONFIDENCE_MAX].
@@ -203,6 +223,35 @@ def clamp_confidence(value):
         return None
     return max(CONFIDENCE_MIN, min(CONFIDENCE_MAX, n))
 
+
+def apply_confidence_floor(dim_lists: dict, confidences: dict, mood_primary,
+                           floor: int = CONFIDENCE_FLOOR) -> dict:
+    """Drop labels whose confidence is known and below ``floor``.
+
+    Distillation (v3): weak/hedged tags never reach the DB. Rules:
+      * a label is dropped only when its confidence is present AND < floor
+        (a missing confidence is ambiguous, so it is kept);
+      * ``mood_primary`` is always kept, so the required mood dimension is never
+        emptied by the floor.
+
+    Returns a new ``dim_key -> [value_key]`` dict; inputs are not mutated. The
+    same filtered lists feed both poem_categories and the categories JSONB
+    (see import_categories.import_rows), so the normalized table and the
+    denormalized cache stay consistent. Lives here, in the import-light config
+    module, so it is unit-testable without pulling in pandas/psycopg.
+    """
+    kept = {}
+    for dim, keys in dim_lists.items():
+        out = []
+        for k in keys:
+            c = confidences.get(k)
+            if c is None or c >= floor or (dim == "mood" and k == mood_primary):
+                out.append(k)
+        kept[dim] = out
+    if mood_primary and mood_primary not in kept.get("mood", []):
+        kept.setdefault("mood", []).insert(0, mood_primary)
+    return kept
+
 # Valid key sets, for fast validation in the classifier.
 VALID_KEYS = {dim: {v[0] for v in spec["values"]} for dim, spec in DIMENSIONS.items()}
 
@@ -210,7 +259,12 @@ VALID_KEYS = {dim: {v[0] for v in spec["values"]} for dim, spec in DIMENSIONS.it
 # Max labels we accept per multi-label dimension (keeps output focused). Any
 # dimension not listed here falls back to DEFAULT_MAX_LABELS_PER_DIM, so adding
 # a new dimension needs no edit to this map.
-DEFAULT_MAX_LABELS_PER_DIM = 4
+#
+# DISTILLATION (v3): tightened from 4/4/5 to 2/2/2. The v2 corpus averaged 7.6
+# labels/poem (up to 13), which made discovery filters useless (e.g. `love` sat
+# on 46% of poems). A hard ceiling of 2 per dimension caps a poem at 6 labels
+# and forces the model to name only the dominant concepts.
+DEFAULT_MAX_LABELS_PER_DIM = 2
 
 
 class _MaxLabels(dict):
@@ -222,7 +276,29 @@ class _MaxLabels(dict):
         return DEFAULT_MAX_LABELS_PER_DIM
 
 
-MAX_LABELS_PER_DIM = _MaxLabels({"mood": 4, "topic": 4, "motif": 5})
+MAX_LABELS_PER_DIM = _MaxLabels({"mood": 2, "topic": 2, "motif": 2})
+
+# Minimum labels per dimension = the required-vs-optional contract. mood and
+# topic are REQUIRED (>=1); motif is OPTIONAL (0 allowed) — an abstract or
+# gnomic poem legitimately has no sensory image. This mirrors the min_labels /
+# max_labels columns added to category_dimensions in the v3 migration, so the
+# DB, the prompt, and validation all agree. Dimensions not listed default to 0
+# (optional), so a new dimension needs no edit here.
+DIMENSION_MIN_LABELS = {"mood": 1, "topic": 1, "motif": 0}
+
+
+# Synonym groups: within a dimension, values in the same group are near-synonyms
+# that the v2 model piled on together (audit: 2,191 poems carried >=2 of the
+# sadness group; 524 carried all three of the desire group). The distilled
+# prompt asks for AT MOST ONE label from each group, so a poem is tagged with
+# the sharpest shade, not the whole gradient. Config-driven so the rule extends
+# with the taxonomy — add a group here and the prompt picks it up automatically.
+SYNONYM_GROUPS = {
+    "mood": [
+        ["melancholy", "grief", "despair", "bittersweet"],  # الأسى/الحزن gradient
+        ["amorous", "passion", "yearning"],                 # الهوى/الشوق gradient
+    ],
+}
 
 
 # ==========================================================================
@@ -370,35 +446,70 @@ def _vocab_block(dim: str) -> str:
     return "\n".join(lines)
 
 
+def _ar_label(dim: str, key: str) -> str:
+    """Arabic label for a (dimension, value key), for rendering prompt guidance."""
+    for k, ar, en in DIMENSIONS[dim]["values"]:
+        if k == key:
+            return ar
+    return key
+
+
+def _synonym_block() -> str:
+    """Render the one-per-synonym-group rule from SYNONYM_GROUPS (config-driven).
+
+    Empty string if no groups are defined, so the prompt degrades cleanly.
+    """
+    lines = []
+    for dim, groups in SYNONYM_GROUPS.items():
+        for group in groups:
+            pretty = "، ".join(f"{_ar_label(dim, k)} ({k})" for k in group)
+            lines.append(f"  - اختر رمزاً واحداً على الأكثر من: {pretty}")
+    return "\n".join(lines)
+
+
 def build_classification_prompt() -> str:
-    """Build the Arabic system prompt from the controlled vocabularies."""
-    return f"""أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر عدة أبعاد لتمكين القارئ من التصفية والاكتشاف حسب المزاج والموضوع والصورة.
+    """Build the distilled Arabic system prompt from the controlled vocabularies.
 
-لكل قصيدة، اختر التصنيفات من القوائم المغلقة التالية فقط. استخدم الرمز الإنجليزي (key) في إجابتك، لا الاسم العربي.
+    Distillation (v3): the model is asked to name the DOMINANT concept of the
+    poem in a few sharp labels rather than every plausible tag. Caps come from
+    MAX_LABELS_PER_DIM (2/2/2); the required-vs-optional contract from
+    DIMENSION_MIN_LABELS (mood/topic >=1, motif 0); the one-per-synonym-group
+    rule from SYNONYM_GROUPS; and a confidence floor from CONFIDENCE_FLOOR. Every
+    number is interpolated from config so prompt and validation never drift.
+    """
+    mn, mx = DIMENSION_MIN_LABELS, MAX_LABELS_PER_DIM
+    return f"""أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.
 
-■ المزاج (mood) — اختر من 1 إلى {MAX_LABELS_PER_DIM['mood']} مزاجاً يغلب على القصيدة:
+اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.
+
+■ المزاج (mood) — اختر من {mn['mood']} إلى {mx['mood']}: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:
 {_vocab_block('mood')}
 
-■ الموضوع (topic) — اختر من 1 إلى {MAX_LABELS_PER_DIM['topic']} موضوعاً:
+■ الموضوع (topic) — اختر من {mn['topic']} إلى {mx['topic']}: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:
 {_vocab_block('topic')}
 
-■ الصورة والرموز (motif) — اختر من 0 إلى {MAX_LABELS_PER_DIM['motif']} من الصور الحسية الحاضرة فعلاً في النص:
+■ الصورة والرموز (motif) — اختر من {mn['motif']} إلى {mx['motif']} من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:
 {_vocab_block('motif')}
 
+قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:
+{_synonym_block()}
+
 كما تنتج الحقول التالية:
-- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج).
+- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).
+- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.
 - emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.
 - accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).
 - confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {{"amorous": 90, "love": 80}}.
 
 إرشادات:
 - صنّف بناءً على النص نفسه لا على شهرة الشاعر.
-- لا تخترع رموزاً خارج القوائم. إن لم تنطبق صورة حسية، اترك motifs فارغة.
-- كن انتقائياً: اختر أقوى التصنيفات لا كل ما هو محتمل.
-- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء واللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرد وصف طبيعة.
+- لا تخترع رموزاً خارج القوائم.
+- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.
+- لا تُدرج أي رمز درجة ثقتك فيه دون {CONFIDENCE_FLOOR}.
+- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.
 
-أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح:
-{{"id": "...", "moods": ["..."], "mood_primary": "...", "topics": ["..."], "motifs": ["..."], "emotional_intensity": N, "accessibility_level": N, "confidences": {{"<key>": N}}}}
+أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:
+{{"id": "...", "moods": ["..."], "mood_primary": "...", "topics": ["..."], "motifs": ["..."], "emotional_intensity": N, "accessibility_level": N, "confidences": {{"<key>": N}}, "rationale": "..."}}
 
 إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد."""
 
@@ -422,6 +533,16 @@ def print_seed_sql() -> None:
             "INSERT INTO category_dimensions (key, label_ar, label_en, cardinality, sort_order) "
             f"VALUES ('{dim}', '{spec['label_ar']}', '{spec['label_en']}', "
             f"'{spec['cardinality']}', {spec['order']}) ON CONFLICT (key) DO NOTHING;"
+        )
+    print()
+    # v3: required-vs-optional contract (min_labels/max_labels). Idempotent
+    # UPDATEs; harmless no-op if the columns don't exist yet is NOT true, so the
+    # v3 migration adds the columns before applying an equivalent of these.
+    for dim, spec in sorted(DIMENSIONS.items(), key=lambda kv: kv[1]["order"]):
+        print(
+            "UPDATE category_dimensions SET "
+            f"min_labels = {DIMENSION_MIN_LABELS.get(dim, 0)}, "
+            f"max_labels = {MAX_LABELS_PER_DIM[dim]} WHERE key = '{dim}';"
         )
     print()
     for dim, spec in sorted(DIMENSIONS.items(), key=lambda kv: kv[1]["order"]):

--- a/poetry_quality_and_curation/categorization/data/spotcheck_versions.json
+++ b/poetry_quality_and_curation/categorization/data/spotcheck_versions.json
@@ -9,6 +9,12 @@
       "name": "v4 · calibrated intensity + accessibility rubric",
       "changed": "Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -> derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.",
       "access": "factors_0_10"
+    },
+    "distill-1": {
+      "name": "v5 · distillation (caps 2/2/2, floor 65)",
+      "changed": "Distillation pass: pick the DOMINANT concept, not everything plausible. Hard caps of <=2 labels per dimension (mood/topic/motif), a confidence floor of 65 (drop anything the model is less than 65% sure of), and no synonym-stacking (one label per idea, no near-duplicate shades). Taxonomy v3. Single-model production run on gemini-3.6-flash (no judge / 2.5-flash columns). Accessibility back to a holistic 1-5 level.",
+      "access": "level_1_5",
+      "prompt_text": "أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.\n\nاختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.\n\n■ المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:\n  - melancholy  (حزن / Melancholy)\n  - nostalgia  (حنين / Nostalgia)\n  - joy  (فرح / Joy)\n  - amorous  (غزل / Amorous)\n  - passion  (وجد / Passion)\n  - contemplation  (تأمّل / Contemplation)\n  - serenity  (سكينة / Serenity)\n  - defiance  (تحدٍّ / Defiance)\n  - pride  (اعتزاز / Pride)\n  - grief  (أسى / Grief)\n  - hope  (أمل / Hope)\n  - despair  (يأس / Despair)\n  - satire  (سخرية / Satire)\n  - reverence  (خشوع / Reverence)\n  - bittersweet  (حلوٌ مرّ / Bittersweet)\n  - yearning  (شوق / Yearning)\n\n■ الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:\n  - love  (الحب / Love)\n  - loss-death  (الفقد والموت / Loss & Death)\n  - exile-longing  (الغربة والحنين / Exile & Longing)\n  - homeland  (الوطن / Homeland)\n  - nature  (الطبيعة / Nature)\n  - war-conflict  (الحرب والصراع / War & Conflict)\n  - faith-spirit  (الإيمان والروحانية / Faith & Spirituality)\n  - wine-pleasure  (الخمر واللذّة / Wine & Pleasure)\n  - friendship  (الصداقة والوفاء / Friendship & Loyalty)\n  - time-mortality  (الزمن والفناء / Time & Mortality)\n  - wisdom-ethics  (الحكمة والأخلاق / Wisdom & Ethics)\n  - justice-oppression  (العدل والظلم / Justice & Oppression)\n  - freedom  (الحرية / Freedom)\n  - beauty  (الجمال / Beauty)\n  - honor-pride  (الفخر والشرف / Honor & Pride)\n  - women-feminine  (المرأة والأنوثة / Women & the Feminine)\n\n■ الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:\n  - night  (الليل / Night)\n  - desert-ruins  (الصحراء والطلل / Desert & Ruins)\n  - moon-stars  (القمر والنجوم / Moon & Stars)\n  - sea-water  (البحر والماء / Sea & Water)\n  - garden-flowers  (الروض والزهر / Garden & Flowers)\n  - wine-cup  (الكأس والخمر / The Wine Cup)\n  - sword-battle  (السيف والمعركة / Sword & Battle)\n  - birds  (الطير / Birds)\n  - fire-light  (النار والضوء / Fire & Light)\n  - tears  (الدموع / Tears)\n  - journey  (الرحلة والراحلة / Journey & Mount)\n  - dawn  (الفجر والصبح / Dawn)\n\nقاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:\n  - اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)\n  - اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)\n\nكما تنتج الحقول التالية:\n- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).\n- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.\n- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.\n- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).\n- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {\"amorous\": 90, \"love\": 80}.\n\nإرشادات:\n- صنّف بناءً على النص نفسه لا على شهرة الشاعر.\n- لا تخترع رموزاً خارج القوائم.\n- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.\n- لا تُدرج أي رمز درجة ثقتك فيه دون 65.\n- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.\n\nأجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:\n{\"id\": \"...\", \"moods\": [\"...\"], \"mood_primary\": \"...\", \"topics\": [\"...\"], \"motifs\": [\"...\"], \"emotional_intensity\": N, \"accessibility_level\": N, \"confidences\": {\"<key>\": N}, \"rationale\": \"...\"}\n\nإذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد."
     }
   },
   "models": [
@@ -161,6 +167,24 @@
               "narrativity": 1
             },
             "accessibility_score": 2.5
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "amorous"
+            ],
+            "mood_primary": "amorous",
+            "topics": [
+              "love",
+              "wine-pleasure"
+            ],
+            "motifs": [
+              "wine-cup",
+              "garden-flowers"
+            ],
+            "emotional_intensity": 75,
+            "accessibility_level": 3
           }
         }
       }
@@ -328,6 +352,25 @@
             },
             "accessibility_score": 5.8
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "joy",
+              "serenity"
+            ],
+            "mood_primary": "joy",
+            "topics": [
+              "nature",
+              "beauty"
+            ],
+            "motifs": [
+              "garden-flowers",
+              "birds"
+            ],
+            "emotional_intensity": 80,
+            "accessibility_level": 3
+          }
         }
       }
     },
@@ -476,6 +519,23 @@
               "narrativity": 1
             },
             "accessibility_score": 2.3
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "contemplation"
+            ],
+            "mood_primary": "contemplation",
+            "topics": [
+              "nature"
+            ],
+            "motifs": [
+              "garden-flowers",
+              "tears"
+            ],
+            "emotional_intensity": 65,
+            "accessibility_level": 3
           }
         }
       }
@@ -628,6 +688,25 @@
               "narrativity": 2
             },
             "accessibility_score": 5.6
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "nostalgia",
+              "melancholy"
+            ],
+            "mood_primary": "nostalgia",
+            "topics": [
+              "love",
+              "exile-longing"
+            ],
+            "motifs": [
+              "desert-ruins",
+              "tears"
+            ],
+            "emotional_intensity": 80,
+            "accessibility_level": 3
           }
         }
       }
@@ -800,6 +879,25 @@
             },
             "accessibility_score": 5.8
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "nostalgia",
+              "pride"
+            ],
+            "mood_primary": "nostalgia",
+            "topics": [
+              "time-mortality",
+              "war-conflict"
+            ],
+            "motifs": [
+              "night",
+              "moon-stars"
+            ],
+            "emotional_intensity": 75,
+            "accessibility_level": 4
+          }
         }
       }
     },
@@ -943,6 +1041,24 @@
               "narrativity": 4
             },
             "accessibility_score": 6.9
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "pride",
+              "defiance"
+            ],
+            "mood_primary": "pride",
+            "topics": [
+              "honor-pride"
+            ],
+            "motifs": [
+              "night",
+              "sword-battle"
+            ],
+            "emotional_intensity": 85,
+            "accessibility_level": 5
           }
         }
       }
@@ -1106,6 +1222,25 @@
             },
             "accessibility_score": 2.9
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "nostalgia",
+              "bittersweet"
+            ],
+            "mood_primary": "nostalgia",
+            "topics": [
+              "love",
+              "exile-longing"
+            ],
+            "motifs": [
+              "desert-ruins",
+              "night"
+            ],
+            "emotional_intensity": 82,
+            "accessibility_level": 3
+          }
         }
       }
     },
@@ -1256,6 +1391,25 @@
             },
             "accessibility_score": 4.8
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "grief",
+              "reverence"
+            ],
+            "mood_primary": "grief",
+            "topics": [
+              "loss-death",
+              "faith-spirit"
+            ],
+            "motifs": [
+              "tears",
+              "desert-ruins"
+            ],
+            "emotional_intensity": 90,
+            "accessibility_level": 3
+          }
         }
       }
     },
@@ -1402,6 +1556,22 @@
             },
             "accessibility_score": 4.0
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "grief"
+            ],
+            "mood_primary": "grief",
+            "topics": [
+              "loss-death"
+            ],
+            "motifs": [
+              "tears"
+            ],
+            "emotional_intensity": 90,
+            "accessibility_level": 3
+          }
         }
       }
     },
@@ -1543,6 +1713,23 @@
             },
             "accessibility_score": 2.7
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "passion",
+              "despair"
+            ],
+            "mood_primary": "passion",
+            "topics": [
+              "love"
+            ],
+            "motifs": [
+              "journey"
+            ],
+            "emotional_intensity": 85,
+            "accessibility_level": 3
+          }
         }
       }
     },
@@ -1674,6 +1861,22 @@
               "narrativity": 1
             },
             "accessibility_score": 6.0
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "pride"
+            ],
+            "mood_primary": "pride",
+            "topics": [
+              "honor-pride"
+            ],
+            "motifs": [
+              "sword-battle"
+            ],
+            "emotional_intensity": 85,
+            "accessibility_level": 4
           }
         }
       }
@@ -1841,6 +2044,25 @@
             },
             "accessibility_score": 3.8
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "grief",
+              "defiance"
+            ],
+            "mood_primary": "grief",
+            "topics": [
+              "homeland",
+              "war-conflict"
+            ],
+            "motifs": [
+              "tears",
+              "fire-light"
+            ],
+            "emotional_intensity": 88,
+            "accessibility_level": 3
+          }
         }
       }
     },
@@ -1979,6 +2201,24 @@
               "narrativity": 2
             },
             "accessibility_score": 2.9
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "amorous",
+              "nostalgia"
+            ],
+            "mood_primary": "amorous",
+            "topics": [
+              "love",
+              "nature"
+            ],
+            "motifs": [
+              "garden-flowers"
+            ],
+            "emotional_intensity": 75,
+            "accessibility_level": 3
           }
         }
       }
@@ -2126,6 +2366,23 @@
               "narrativity": 3
             },
             "accessibility_score": 4.8
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "grief"
+            ],
+            "mood_primary": "grief",
+            "topics": [
+              "love"
+            ],
+            "motifs": [
+              "journey",
+              "tears"
+            ],
+            "emotional_intensity": 90,
+            "accessibility_level": 4
           }
         }
       }
@@ -2276,6 +2533,25 @@
               "narrativity": 2
             },
             "accessibility_score": 4.0
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "amorous",
+              "nostalgia"
+            ],
+            "mood_primary": "amorous",
+            "topics": [
+              "love",
+              "women-feminine"
+            ],
+            "motifs": [
+              "night",
+              "moon-stars"
+            ],
+            "emotional_intensity": 70,
+            "accessibility_level": 3
           }
         }
       }
@@ -2428,6 +2704,24 @@
             },
             "accessibility_score": 7.7
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "reverence",
+              "nostalgia"
+            ],
+            "mood_primary": "reverence",
+            "topics": [
+              "honor-pride"
+            ],
+            "motifs": [
+              "desert-ruins",
+              "journey"
+            ],
+            "emotional_intensity": 75,
+            "accessibility_level": 4
+          }
         }
       }
     },
@@ -2551,6 +2845,19 @@
               "narrativity": 1
             },
             "accessibility_score": 6.7
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "contemplation",
+              "reverence"
+            ],
+            "mood_primary": "contemplation",
+            "topics": [],
+            "motifs": [],
+            "emotional_intensity": 70,
+            "accessibility_level": 4
           }
         }
       }
@@ -2725,6 +3032,25 @@
             },
             "accessibility_score": 6.9
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "yearning",
+              "pride"
+            ],
+            "mood_primary": "yearning",
+            "topics": [
+              "love",
+              "honor-pride"
+            ],
+            "motifs": [
+              "night",
+              "desert-ruins"
+            ],
+            "emotional_intensity": 80,
+            "accessibility_level": 5
+          }
         }
       }
     },
@@ -2885,6 +3211,24 @@
             },
             "accessibility_score": 4.0
           }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "yearning",
+              "nostalgia"
+            ],
+            "mood_primary": "yearning",
+            "topics": [
+              "exile-longing"
+            ],
+            "motifs": [
+              "tears",
+              "birds"
+            ],
+            "emotional_intensity": 82,
+            "accessibility_level": 3
+          }
         }
       }
     },
@@ -3021,6 +3365,24 @@
               "narrativity": 3
             },
             "accessibility_score": 1.9
+          }
+        },
+        "distill-1": {
+          "gemini-3.6-flash": {
+            "moods": [
+              "yearning",
+              "melancholy"
+            ],
+            "mood_primary": "yearning",
+            "topics": [
+              "love"
+            ],
+            "motifs": [
+              "journey",
+              "desert-ruins"
+            ],
+            "emotional_intensity": 85,
+            "accessibility_level": 3
           }
         }
       }

--- a/poetry_quality_and_curation/categorization/data/spotcheck_viewer.html
+++ b/poetry_quality_and_curation/categorization/data/spotcheck_viewer.html
@@ -23,6 +23,7 @@
  .pbody{display:none;flex-direction:column;overflow:auto}
  #promptbar.pv-v2baseline .pbody-v2baseline{display:block}
  #promptbar.pv-v4rubric .pbody-v4rubric{display:block}
+ #promptbar.pv-distill1 .pbody-distill1{display:block}
  .vmeta{padding:8px 16px;border-bottom:1px solid #23272e;background:#0f1216}
  .vname{color:var(--gold);font-size:13px;font-weight:600} .vchg{color:#9aa0a8;font-size:11px;line-height:1.5;margin-top:3px}
  #promptbar.show-en .pbmd.ar{display:none} #promptbar:not(.show-en) .pbmd.en{display:none}
@@ -58,6 +59,7 @@
  .cmpwrap{display:none}
  body.ver-v2baseline .cmp-v2baseline{display:block}
  body.ver-v4rubric .cmp-v4rubric{display:block}
+ body.ver-distill1 .cmp-distill1{display:block}
  table.cmp{width:100%;border-collapse:collapse} table.cmp th{text-align:left;font-size:12px;color:#9aa0a8;padding:4px 8px;border-bottom:1px solid #2a2f37} .ref{color:#565c66}
  table.cmp td{vertical-align:top;padding:7px 8px;border-top:1px solid #1c2026;border-right:1px solid #1c2026}
  table.cmp td.rl{color:#8a909a;font-size:11px;white-space:nowrap;width:64px;border-right:1px solid #2a2f37;background:#111418}
@@ -81,11 +83,11 @@
  .mtr b{color:#c7ccd3}
  .dlt{margin-left:6px;font-size:10px;padding:0 5px;border-radius:8px;font-weight:600}
  .dlt.up{background:#3a1f1c;color:#f0a58a;border:1px solid #5a2f28} .dlt.down{background:#16263a;color:#8ab6e6;border:1px solid #274867} .dlt.zero{background:#1c2026;color:#6b7280;border:1px solid #2a2f37}
-</style></head><body class='lang-both ver-v4rubric'>
+</style></head><body class='lang-both ver-distill1'>
 <header>
- <h1>Spot-check — judge 3.1-pro vs 2.5-flash vs 3.6-flash · 20 poems · 2 prompt versions</h1>
+ <h1>Spot-check — judge 3.1-pro vs 2.5-flash vs 3.6-flash · 20 poems · 3 prompt versions</h1>
  <div class='ctrl'>
-   <span class='verwrap'><span>prompt version</span><span class='verseg' id='verpick'><button class='verbtn' data-vid='v2baseline'>v2 · baseline</button><button class='verbtn on' data-vid='v4rubric'>v4 · calibrated intensity + accessibility rubric</button></span></span>
+   <span class='verwrap'><span>prompt version</span><span class='verseg' id='verpick'><button class='verbtn' data-vid='v2baseline'>v2 · baseline</button><button class='verbtn' data-vid='v4rubric'>v4 · calibrated intensity + accessibility rubric</button><button class='verbtn on' data-vid='distill1'>v5 · distillation (caps 2/2/2, floor 65)</button></span></span>
    <span>lang</span><span class='seg' id='lang'><button data-l='ar'>عربي</button><button data-l='en'>EN</button><button data-l='both' class='on'>both</button></span>
    <span>sort</span><span id='sort'>
      <button class='sortbtn on' data-s='num'>poem#</button><button class='sortbtn' data-s='int'>intensity</button>
@@ -97,9 +99,9 @@
    <span class='leg'><span class='chip agree'>green</span> match · <span class='chip extra'>red</span> flash added · <span class='chip missed'>blue</span> judge had, flash missed · ★ primary</span>
  </div>
 </header>
-<aside id='promptbar'><div class='pbhd'><span>Classification prompt</span><span class='pbright'><span class='pseg' id='ptab'><button data-t='view' class='on'>view</button><button data-t='diff'>diff</button></span><span class='pseg' id='plang'><button data-pl='ar' class='on'>عربي</button><button data-pl='en'>EN</button></span><button id='closeprompt' title='close'>✕</button></span></div><div class='pmode pmode-view'><div class='pvsel'><span class='pvl'>version</span><span class='pseg' id='pver'><button data-vid='v2baseline' class=''>v2 · baseline</button><button data-vid='v4rubric' class='on'>v4 · calibrated intensity + accessibility rubric</button></span></div><div class='pbody pbody-v2baseline'><div class='vmeta'><div class='vname'>v2 · baseline</div><div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div><div class='pbmd ar' dir='rtl'><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر عدة أبعاد لتمكين القارئ من التصفية والاكتشاف حسب المزاج والموضوع والصورة.</p>
-<p>لكل قصيدة، اختر التصنيفات من القوائم المغلقة التالية فقط. استخدم الرمز الإنجليزي (key) في إجابتك، لا الاسم العربي.</p>
-<h3>المزاج (mood) — اختر من 1 إلى 4 مزاجاً يغلب على القصيدة:</h3>
+<aside id='promptbar'><div class='pbhd'><span>Classification prompt</span><span class='pbright'><span class='pseg' id='ptab'><button data-t='view' class='on'>view</button><button data-t='diff'>diff</button></span><span class='pseg' id='plang'><button data-pl='ar' class='on'>عربي</button><button data-pl='en'>EN</button></span><button id='closeprompt' title='close'>✕</button></span></div><div class='pmode pmode-view'><div class='pvsel'><span class='pvl'>version</span><span class='pseg' id='pver'><button data-vid='v2baseline' class=''>v2 · baseline</button><button data-vid='v4rubric' class=''>v4 · calibrated intensity + accessibility rubric</button><button data-vid='distill1' class='on'>v5 · distillation (caps 2/2/2, floor 65)</button></span></div><div class='pbody pbody-v2baseline'><div class='vmeta'><div class='vname'>v2 · baseline</div><div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div><div class='pbmd ar' dir='rtl'><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن <strong>جوهر</strong> القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</p>
+<p>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</p>
+<h3>المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</h3>
 <ul>
 <li>melancholy  (حزن / Melancholy)</li>
 <li>nostalgia  (حنين / Nostalgia)</li>
@@ -118,7 +120,7 @@
 <li>bittersweet  (حلوٌ مرّ / Bittersweet)</li>
 <li>yearning  (شوق / Yearning)</li>
 </ul>
-<h3>الموضوع (topic) — اختر من 1 إلى 4 موضوعاً:</h3>
+<h3>الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</h3>
 <ul>
 <li>love  (الحب / Love)</li>
 <li>loss-death  (الفقد والموت / Loss &amp; Death)</li>
@@ -137,7 +139,7 @@
 <li>honor-pride  (الفخر والشرف / Honor &amp; Pride)</li>
 <li>women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</li>
 </ul>
-<h3>الصورة والرموز (motif) — اختر من 0 إلى 5 من الصور الحسية الحاضرة فعلاً في النص:</h3>
+<h3>الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</h3>
 <ul>
 <li>night  (الليل / Night)</li>
 <li>desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</li>
@@ -152,9 +154,13 @@
 <li>journey  (الرحلة والراحلة / Journey &amp; Mount)</li>
 <li>dawn  (الفجر والصبح / Dawn)</li>
 </ul>
+<p>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:
+- اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)
+- اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</p>
 <h3>كما تنتج الحقول التالية:</h3>
 <ul>
-<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج).</li>
+<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</li>
+<li>rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</li>
 <li>emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</li>
 <li>accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</li>
 <li>confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {"amorous": 90, "love": 80}.</li>
@@ -162,88 +168,17 @@
 <h3>إرشادات:</h3>
 <ul>
 <li>صنّف بناءً على النص نفسه لا على شهرة الشاعر.</li>
-<li>لا تخترع رموزاً خارج القوائم. إن لم تنطبق صورة حسية، اترك motifs فارغة.</li>
-<li>كن انتقائياً: اختر أقوى التصنيفات لا كل ما هو محتمل.</li>
-<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء واللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرد وصف طبيعة.</li>
+<li>لا تخترع رموزاً خارج القوائم.</li>
+<li>سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</li>
+<li>لا تُدرج أي رمز درجة ثقتك فيه دون 65.</li>
+<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</li>
 </ul>
-<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح:</h3>
-<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}
+<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</h3>
+<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}
 </code></pre>
-<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div><div class='pbmd en' dir='ltr'><p>You are an expert Arabic literary critic specializing in classical and modern poetry. Your task is to classify the presented poem across several dimensions to enable readers to filter and discover based on mood, topic, and imagery.</p>
-<p>For each poem, select classifications <em>only</em> from the following closed lists. Use the English key in your answer, not the Arabic name.</p>
-<h3>Mood (mood) — Choose 1 to 4 predominant moods for the poem:</h3>
-<ul>
-<li>melancholy (Sadness / Melancholy)</li>
-<li>nostalgia (Longing / Nostalgia)</li>
-<li>joy (Joy / Joy)</li>
-<li>amorous (Courtship / Amorous)</li>
-<li>passion (Ecstasy / Passion)</li>
-<li>contemplation (Reflection / Contemplation)</li>
-<li>serenity (Tranquility / Serenity)</li>
-<li>defiance (Defiance / Defiance)</li>
-<li>pride (Pride / Pride)</li>
-<li>grief (Sorrow / Grief)</li>
-<li>hope (Hope / Hope)</li>
-<li>despair (Despair / Despair)</li>
-<li>satire (Sarcasm / Satire)</li>
-<li>reverence (Devotion / Reverence)</li>
-<li>bittersweet (Sweet-bitter / Bittersweet)</li>
-<li>yearning (Yearning / Yearning)</li>
-</ul>
-<h3>Topic (topic) — Choose 1 to 4 topics:</h3>
-<ul>
-<li>love (Love / Love)</li>
-<li>loss-death (Loss and Death / Loss &amp; Death)</li>
-<li>exile-longing (Exile and Longing / Exile &amp; Longing)</li>
-<li>homeland (Homeland / Homeland)</li>
-<li>nature (Nature / Nature)</li>
-<li>war-conflict (War and Conflict / War &amp; Conflict)</li>
-<li>faith-spirit (Faith and Spirituality / Faith &amp; Spirituality)</li>
-<li>wine-pleasure (Wine and Pleasure / Wine &amp; Pleasure)</li>
-<li>friendship (Friendship and Loyalty / Friendship &amp; Loyalty)</li>
-<li>time-mortality (Time and Mortality / Time &amp; Mortality)</li>
-<li>wisdom-ethics (Wisdom and Ethics / Wisdom &amp; Ethics)</li>
-<li>justice-oppression (Justice and Oppression / Justice &amp; Oppression)</li>
-<li>freedom (Freedom / Freedom)</li>
-<li>beauty (Beauty / Beauty)</li>
-<li>honor-pride (Honor and Pride / Honor &amp; Pride)</li>
-<li>women-feminine (Woman and the Feminine / Women &amp; the Feminine)</li>
-</ul>
-<h3>Imagery and Symbols (motif) — Choose 0 to 5 sensory images actually present in the text:</h3>
-<ul>
-<li>night (Night / Night)</li>
-<li>desert-ruins (Desert and Ruins / Desert &amp; Ruins)</li>
-<li>moon-stars (Moon and Stars / Moon &amp; Stars)</li>
-<li>sea-water (Sea and Water / Sea &amp; Water)</li>
-<li>garden-flowers (Garden and Flowers / Garden &amp; Flowers)</li>
-<li>wine-cup (The Cup and Wine / The Wine Cup)</li>
-<li>sword-battle (Sword and Battle / Sword &amp; Battle)</li>
-<li>birds (Birds / Birds)</li>
-<li>fire-light (Fire and Light / Fire &amp; Light)</li>
-<li>tears (Tears / Tears)</li>
-<li>journey (Journey and Mount / Journey &amp; Mount)</li>
-<li>dawn (Dawn and Morning / Dawn)</li>
-</ul>
-<h3>You also produce the following fields:</h3>
-<ul>
-<li>mood_primary: The single most dominant mood (one key from the mood list).</li>
-<li>emotional_intensity: A number from 0 to 100 measuring the intensity of the emotional charge.</li>
-<li>accessibility_level: A number from 1 to 5 (1 = easy for an Arabic learner, 5 = requires deep classical knowledge).</li>
-<li>confidences: An object linking each key you chose (from any dimension) to your confidence level in it from 0 to 100, e.g., {"amorous": 90, "love": 80}.</li>
-</ul>
-<h3>Instructions:</h3>
-<ul>
-<li>Classify based on the text itself, not on the poet's fame.</li>
-<li>Do not invent keys outside the lists. If a sensory image does not apply, leave motifs empty.</li>
-<li>Be selective: Choose the strongest classifications, not every possibility.</li>
-<li>Subtle distinctions: Yearning (شوق) is longing for a person, while nostalgia (حنين) is longing for a homeland or places; satire (سخرية) means scathing satire, not gentle humor; and garden-flowers (الروض والزهر) often refer to the beloved's garden, not just a general description of nature.</li>
-</ul>
-<h3>Answer in JSON format only for each poem, without any explanation:</h3>
-<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}
-</code></pre>
-<p>If multiple poems are presented, respond with a JSON array ordered in the same sequence as the poems.</p></div></div><div class='pbody pbody-v4rubric'><div class='vmeta'><div class='vname'>v4 · calibrated intensity + accessibility rubric</div><div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div><div class='pbmd ar' dir='rtl'><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر عدة أبعاد لتمكين القارئ من التصفية والاكتشاف حسب المزاج والموضوع والصورة.</p>
-<p>لكل قصيدة، اختر التصنيفات من القوائم المغلقة التالية فقط. استخدم الرمز الإنجليزي (key) في إجابتك، لا الاسم العربي.</p>
-<h3>المزاج (mood) — اختر من 1 إلى 4 مزاجاً يغلب على القصيدة:</h3>
+<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div><div class='pbmd en' dir='ltr'><p class='noen'>(English translation unavailable — showing Arabic source)</p><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن <strong>جوهر</strong> القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</p>
+<p>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</p>
+<h3>المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</h3>
 <ul>
 <li>melancholy  (حزن / Melancholy)</li>
 <li>nostalgia  (حنين / Nostalgia)</li>
@@ -262,7 +197,7 @@
 <li>bittersweet  (حلوٌ مرّ / Bittersweet)</li>
 <li>yearning  (شوق / Yearning)</li>
 </ul>
-<h3>الموضوع (topic) — اختر من 1 إلى 4 موضوعاً:</h3>
+<h3>الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</h3>
 <ul>
 <li>love  (الحب / Love)</li>
 <li>loss-death  (الفقد والموت / Loss &amp; Death)</li>
@@ -281,7 +216,7 @@
 <li>honor-pride  (الفخر والشرف / Honor &amp; Pride)</li>
 <li>women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</li>
 </ul>
-<h3>الصورة والرموز (motif) — اختر من 0 إلى 5 من الصور الحسية الحاضرة فعلاً في النص:</h3>
+<h3>الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</h3>
 <ul>
 <li>night  (الليل / Night)</li>
 <li>desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</li>
@@ -296,9 +231,90 @@
 <li>journey  (الرحلة والراحلة / Journey &amp; Mount)</li>
 <li>dawn  (الفجر والصبح / Dawn)</li>
 </ul>
+<p>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:
+- اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)
+- اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</p>
 <h3>كما تنتج الحقول التالية:</h3>
 <ul>
-<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج).</li>
+<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</li>
+<li>rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</li>
+<li>emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</li>
+<li>accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</li>
+<li>confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {"amorous": 90, "love": 80}.</li>
+</ul>
+<h3>إرشادات:</h3>
+<ul>
+<li>صنّف بناءً على النص نفسه لا على شهرة الشاعر.</li>
+<li>لا تخترع رموزاً خارج القوائم.</li>
+<li>سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</li>
+<li>لا تُدرج أي رمز درجة ثقتك فيه دون 65.</li>
+<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</li>
+</ul>
+<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</h3>
+<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}
+</code></pre>
+<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div></div><div class='pbody pbody-v4rubric'><div class='vmeta'><div class='vname'>v4 · calibrated intensity + accessibility rubric</div><div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div><div class='pbmd ar' dir='rtl'><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن <strong>جوهر</strong> القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</p>
+<p>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</p>
+<h3>المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</h3>
+<ul>
+<li>melancholy  (حزن / Melancholy)</li>
+<li>nostalgia  (حنين / Nostalgia)</li>
+<li>joy  (فرح / Joy)</li>
+<li>amorous  (غزل / Amorous)</li>
+<li>passion  (وجد / Passion)</li>
+<li>contemplation  (تأمّل / Contemplation)</li>
+<li>serenity  (سكينة / Serenity)</li>
+<li>defiance  (تحدٍّ / Defiance)</li>
+<li>pride  (اعتزاز / Pride)</li>
+<li>grief  (أسى / Grief)</li>
+<li>hope  (أمل / Hope)</li>
+<li>despair  (يأس / Despair)</li>
+<li>satire  (سخرية / Satire)</li>
+<li>reverence  (خشوع / Reverence)</li>
+<li>bittersweet  (حلوٌ مرّ / Bittersweet)</li>
+<li>yearning  (شوق / Yearning)</li>
+</ul>
+<h3>الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</h3>
+<ul>
+<li>love  (الحب / Love)</li>
+<li>loss-death  (الفقد والموت / Loss &amp; Death)</li>
+<li>exile-longing  (الغربة والحنين / Exile &amp; Longing)</li>
+<li>homeland  (الوطن / Homeland)</li>
+<li>nature  (الطبيعة / Nature)</li>
+<li>war-conflict  (الحرب والصراع / War &amp; Conflict)</li>
+<li>faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</li>
+<li>wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</li>
+<li>friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</li>
+<li>time-mortality  (الزمن والفناء / Time &amp; Mortality)</li>
+<li>wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</li>
+<li>justice-oppression  (العدل والظلم / Justice &amp; Oppression)</li>
+<li>freedom  (الحرية / Freedom)</li>
+<li>beauty  (الجمال / Beauty)</li>
+<li>honor-pride  (الفخر والشرف / Honor &amp; Pride)</li>
+<li>women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</li>
+</ul>
+<h3>الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</h3>
+<ul>
+<li>night  (الليل / Night)</li>
+<li>desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</li>
+<li>moon-stars  (القمر والنجوم / Moon &amp; Stars)</li>
+<li>sea-water  (البحر والماء / Sea &amp; Water)</li>
+<li>garden-flowers  (الروض والزهر / Garden &amp; Flowers)</li>
+<li>wine-cup  (الكأس والخمر / The Wine Cup)</li>
+<li>sword-battle  (السيف والمعركة / Sword &amp; Battle)</li>
+<li>birds  (الطير / Birds)</li>
+<li>fire-light  (النار والضوء / Fire &amp; Light)</li>
+<li>tears  (الدموع / Tears)</li>
+<li>journey  (الرحلة والراحلة / Journey &amp; Mount)</li>
+<li>dawn  (الفجر والصبح / Dawn)</li>
+</ul>
+<p>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:
+- اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)
+- اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</p>
+<h3>كما تنتج الحقول التالية:</h3>
+<ul>
+<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</li>
+<li>rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</li>
 <li>emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</li>
 <li>accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</li>
 <li>confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {"amorous": 90, "love": 80}.</li>
@@ -306,89 +322,249 @@
 <h3>إرشادات:</h3>
 <ul>
 <li>صنّف بناءً على النص نفسه لا على شهرة الشاعر.</li>
-<li>لا تخترع رموزاً خارج القوائم. إن لم تنطبق صورة حسية، اترك motifs فارغة.</li>
-<li>كن انتقائياً: اختر أقوى التصنيفات لا كل ما هو محتمل.</li>
-<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء واللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرد وصف طبيعة.</li>
+<li>لا تخترع رموزاً خارج القوائم.</li>
+<li>سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</li>
+<li>لا تُدرج أي رمز درجة ثقتك فيه دون 65.</li>
+<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</li>
 </ul>
-<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح:</h3>
-<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}
+<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</h3>
+<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}
 </code></pre>
-<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div><div class='pbmd en' dir='ltr'><p>You are an experienced Arab literary critic specializing in classical and modern poetry. Your task is to classify the poem presented to you across several dimensions to enable the reader to filter and discover according to mood, topic, and imagery.</p>
-<p>For each poem, choose classifications only from the following closed lists. Use the English key in your answer, not the Arabic name.</p>
-<h3>mood — Choose 1 to 4 dominant moods in the poem:</h3>
+<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div><div class='pbmd en' dir='ltr'><p class='noen'>(English translation unavailable — showing Arabic source)</p><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن <strong>جوهر</strong> القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</p>
+<p>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</p>
+<h3>المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</h3>
 <ul>
-<li>melancholy (Melancholy)</li>
-<li>nostalgia (Nostalgia)</li>
-<li>joy (Joy)</li>
-<li>amorous (Amorous)</li>
-<li>passion (Passion)</li>
-<li>contemplation (Contemplation)</li>
-<li>serenity (Serenity)</li>
-<li>defiance (Defiance)</li>
-<li>pride (Pride)</li>
-<li>grief (Grief)</li>
-<li>hope (Hope)</li>
-<li>despair (Despair)</li>
-<li>satire (Satire)</li>
-<li>reverence (Reverence)</li>
-<li>bittersweet (Bittersweet)</li>
-<li>yearning (Yearning)</li>
+<li>melancholy  (حزن / Melancholy)</li>
+<li>nostalgia  (حنين / Nostalgia)</li>
+<li>joy  (فرح / Joy)</li>
+<li>amorous  (غزل / Amorous)</li>
+<li>passion  (وجد / Passion)</li>
+<li>contemplation  (تأمّل / Contemplation)</li>
+<li>serenity  (سكينة / Serenity)</li>
+<li>defiance  (تحدٍّ / Defiance)</li>
+<li>pride  (اعتزاز / Pride)</li>
+<li>grief  (أسى / Grief)</li>
+<li>hope  (أمل / Hope)</li>
+<li>despair  (يأس / Despair)</li>
+<li>satire  (سخرية / Satire)</li>
+<li>reverence  (خشوع / Reverence)</li>
+<li>bittersweet  (حلوٌ مرّ / Bittersweet)</li>
+<li>yearning  (شوق / Yearning)</li>
 </ul>
-<h3>topic — Choose 1 to 4 topics:</h3>
+<h3>الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</h3>
 <ul>
-<li>love (Love)</li>
-<li>loss-death (Loss &amp; Death)</li>
-<li>exile-longing (Exile &amp; Longing)</li>
-<li>homeland (Homeland)</li>
-<li>nature (Nature)</li>
-<li>war-conflict (War &amp; Conflict)</li>
-<li>faith-spirit (Faith &amp; Spirituality)</li>
-<li>wine-pleasure (Wine &amp; Pleasure)</li>
-<li>friendship (Friendship &amp; Loyalty)</li>
-<li>time-mortality (Time &amp; Mortality)</li>
-<li>wisdom-ethics (Wisdom &amp; Ethics)</li>
-<li>justice-oppression (Justice &amp; Oppression)</li>
-<li>freedom (Freedom)</li>
-<li>beauty (Beauty)</li>
-<li>honor-pride (Honor &amp; Pride)</li>
-<li>women-feminine (Women &amp; the Feminine)</li>
+<li>love  (الحب / Love)</li>
+<li>loss-death  (الفقد والموت / Loss &amp; Death)</li>
+<li>exile-longing  (الغربة والحنين / Exile &amp; Longing)</li>
+<li>homeland  (الوطن / Homeland)</li>
+<li>nature  (الطبيعة / Nature)</li>
+<li>war-conflict  (الحرب والصراع / War &amp; Conflict)</li>
+<li>faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</li>
+<li>wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</li>
+<li>friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</li>
+<li>time-mortality  (الزمن والفناء / Time &amp; Mortality)</li>
+<li>wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</li>
+<li>justice-oppression  (العدل والظلم / Justice &amp; Oppression)</li>
+<li>freedom  (الحرية / Freedom)</li>
+<li>beauty  (الجمال / Beauty)</li>
+<li>honor-pride  (الفخر والشرف / Honor &amp; Pride)</li>
+<li>women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</li>
 </ul>
-<h3>motif — Choose 0 to 5 sensory images actually present in the text:</h3>
+<h3>الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</h3>
 <ul>
-<li>night (Night)</li>
-<li>desert-ruins (Desert &amp; Ruins)</li>
-<li>moon-stars (Moon &amp; Stars)</li>
-<li>sea-water (Sea &amp; Water)</li>
-<li>garden-flowers (Garden &amp; Flowers)</li>
-<li>wine-cup (The Wine Cup)</li>
-<li>sword-battle (Sword &amp; Battle)</li>
-<li>birds (Birds)</li>
-<li>fire-light (Fire &amp; Light)</li>
-<li>tears (Tears)</li>
-<li>journey (Journey &amp; Mount)</li>
-<li>dawn (Dawn)</li>
+<li>night  (الليل / Night)</li>
+<li>desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</li>
+<li>moon-stars  (القمر والنجوم / Moon &amp; Stars)</li>
+<li>sea-water  (البحر والماء / Sea &amp; Water)</li>
+<li>garden-flowers  (الروض والزهر / Garden &amp; Flowers)</li>
+<li>wine-cup  (الكأس والخمر / The Wine Cup)</li>
+<li>sword-battle  (السيف والمعركة / Sword &amp; Battle)</li>
+<li>birds  (الطير / Birds)</li>
+<li>fire-light  (النار والضوء / Fire &amp; Light)</li>
+<li>tears  (الدموع / Tears)</li>
+<li>journey  (الرحلة والراحلة / Journey &amp; Mount)</li>
+<li>dawn  (الفجر والصبح / Dawn)</li>
 </ul>
-<h3>You also produce the following fields:</h3>
+<p>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:
+- اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)
+- اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</p>
+<h3>كما تنتج الحقول التالية:</h3>
 <ul>
-<li>mood_primary: The single most dominant mood (one key from the mood list).</li>
-<li>emotional_intensity: The intensity of the emotional charge from 0 to 100. Use the full range and do not cluster values: most poems are between 30 and 70, below 30 for calm description, wisdom, and teaching, and above 80 for overwhelming emotion (intense grief, infatuation, severe indignation).</li>
-<li>accessibility_factors: Estimate five factors for readability by an Arabic learner, each factor from 1 (easiest) to 5 (hardest): lexical (word commonality: 1 modern familiar ← 5 archaic obscure), syntax (clarity of structure: 1 direct ← 5 fronting, postpositioning, ellipsis, and complexity), imagery_abstraction (image abstraction: 1 direct sensory ← 5 extended metaphor requiring deciphering), allusion (referential load: 1 independent ← 5 intertextuality and dense heritage references), narrativity (narrative: 1 instantaneous image ← 5 extended story requiring follow-up; narrative is harder than imagery). Vary your estimates and use the full range.</li>
-<li>confidences: An object linking each key you selected (from any dimension) to your confidence level in it from 0 to 100, such as {"amorous": 90, "love": 80}.</li>
+<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</li>
+<li>rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</li>
+<li>emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</li>
+<li>accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</li>
+<li>confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {"amorous": 90, "love": 80}.</li>
 </ul>
-<h3>Instructions:</h3>
+<h3>إرشادات:</h3>
 <ul>
-<li>Classify based on the text itself, not the poet's fame.</li>
-<li>Do not invent keys outside the lists. If a sensory image does not apply, leave motifs empty.</li>
-<li>Be selective: choose the strongest classifications, not every possibility.</li>
-<li>Fine distinctions: yearning is a longing for a person, while nostalgia is a longing for one's homeland or dwellings; satire means biting sarcasm and denigration, not gentle humor; and garden-flowers often refer to the beloved's garden, not just a description of nature.</li>
+<li>صنّف بناءً على النص نفسه لا على شهرة الشاعر.</li>
+<li>لا تخترع رموزاً خارج القوائم.</li>
+<li>سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</li>
+<li>لا تُدرج أي رمز درجة ثقتك فيه دون 65.</li>
+<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</li>
 </ul>
-<h3>Respond in JSON format only for each poem, without any explanation:</h3>
-<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}
+<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</h3>
+<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}
 </code></pre>
-<p>If multiple poems are presented, respond with a JSON array ordered in the same sequence as the poems.</p></div></div></div><div class='pmode pmode-diff'><div class='pvsel'><span class='pvl'>A</span><span class='pseg' id='diffA'><button data-vid='v2baseline' class='on'>v2 · baseline</button><button data-vid='v4rubric' class=''>v4 · calibrated intensity + accessibility rubric</button></span><span class='pvl'>B</span><span class='pseg' id='diffB'><button data-vid='v2baseline' class=''>v2 · baseline</button><button data-vid='v4rubric' class='on'>v4 · calibrated intensity + accessibility rubric</button></span></div><div class='diffbox'><div class='diffwrap' data-pair='v2baseline|v4rubric'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v2 · baseline<div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div><div class='dm b'><span class='tag add'>B +</span> v4 · calibrated intensity + accessibility rubric<div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر عدة أبعاد لتمكين القارئ من التصفية والاكتشاف حسب المزاج والموضوع والصورة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>لكل قصيدة، اختر التصنيفات من القوائم المغلقة التالية فقط. استخدم الرمز الإنجليزي (key) في إجابتك، لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 4 مزاجاً يغلب على القصيدة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 4 موضوعاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 5 من الصور الحسية الحاضرة فعلاً في النص:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج).</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم. إن لم تنطبق صورة حسية، اترك motifs فارغة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- كن انتقائياً: اختر أقوى التصنيفات لا كل ما هو محتمل.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء واللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح:</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div><div class='diffwrap' data-pair='v4rubric|v2baseline'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v4 · calibrated intensity + accessibility rubric<div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div><div class='dm b'><span class='tag add'>B +</span> v2 · baseline<div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر عدة أبعاد لتمكين القارئ من التصفية والاكتشاف حسب المزاج والموضوع والصورة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>لكل قصيدة، اختر التصنيفات من القوائم المغلقة التالية فقط. استخدم الرمز الإنجليزي (key) في إجابتك، لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 4 مزاجاً يغلب على القصيدة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 4 موضوعاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 5 من الصور الحسية الحاضرة فعلاً في النص:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج).</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم. إن لم تنطبق صورة حسية، اترك motifs فارغة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- كن انتقائياً: اختر أقوى التصنيفات لا كل ما هو محتمل.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء واللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح:</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div></div></div><div class='pbfb'><div class='pfl'>Prompt feedback (saved + included in export)</div><textarea id='promptfb' placeholder='what would you change about the prompt? wording, missing guidance, label definitions…'></textarea></div></aside>
+<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div></div><div class='pbody pbody-distill1'><div class='vmeta'><div class='vname'>v5 · distillation (caps 2/2/2, floor 65)</div><div class='vchg'>Distillation pass: pick the DOMINANT concept, not everything plausible. Hard caps of &lt;=2 labels per dimension (mood/topic/motif), a confidence floor of 65 (drop anything the model is less than 65% sure of), and no synonym-stacking (one label per idea, no near-duplicate shades). Taxonomy v3. Single-model production run on gemini-3.6-flash (no judge / 2.5-flash columns). Accessibility back to a holistic 1-5 level.</div></div><div class='pbmd ar' dir='rtl'><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن <strong>جوهر</strong> القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</p>
+<p>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</p>
+<h3>المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</h3>
+<ul>
+<li>melancholy  (حزن / Melancholy)</li>
+<li>nostalgia  (حنين / Nostalgia)</li>
+<li>joy  (فرح / Joy)</li>
+<li>amorous  (غزل / Amorous)</li>
+<li>passion  (وجد / Passion)</li>
+<li>contemplation  (تأمّل / Contemplation)</li>
+<li>serenity  (سكينة / Serenity)</li>
+<li>defiance  (تحدٍّ / Defiance)</li>
+<li>pride  (اعتزاز / Pride)</li>
+<li>grief  (أسى / Grief)</li>
+<li>hope  (أمل / Hope)</li>
+<li>despair  (يأس / Despair)</li>
+<li>satire  (سخرية / Satire)</li>
+<li>reverence  (خشوع / Reverence)</li>
+<li>bittersweet  (حلوٌ مرّ / Bittersweet)</li>
+<li>yearning  (شوق / Yearning)</li>
+</ul>
+<h3>الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</h3>
+<ul>
+<li>love  (الحب / Love)</li>
+<li>loss-death  (الفقد والموت / Loss &amp; Death)</li>
+<li>exile-longing  (الغربة والحنين / Exile &amp; Longing)</li>
+<li>homeland  (الوطن / Homeland)</li>
+<li>nature  (الطبيعة / Nature)</li>
+<li>war-conflict  (الحرب والصراع / War &amp; Conflict)</li>
+<li>faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</li>
+<li>wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</li>
+<li>friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</li>
+<li>time-mortality  (الزمن والفناء / Time &amp; Mortality)</li>
+<li>wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</li>
+<li>justice-oppression  (العدل والظلم / Justice &amp; Oppression)</li>
+<li>freedom  (الحرية / Freedom)</li>
+<li>beauty  (الجمال / Beauty)</li>
+<li>honor-pride  (الفخر والشرف / Honor &amp; Pride)</li>
+<li>women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</li>
+</ul>
+<h3>الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</h3>
+<ul>
+<li>night  (الليل / Night)</li>
+<li>desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</li>
+<li>moon-stars  (القمر والنجوم / Moon &amp; Stars)</li>
+<li>sea-water  (البحر والماء / Sea &amp; Water)</li>
+<li>garden-flowers  (الروض والزهر / Garden &amp; Flowers)</li>
+<li>wine-cup  (الكأس والخمر / The Wine Cup)</li>
+<li>sword-battle  (السيف والمعركة / Sword &amp; Battle)</li>
+<li>birds  (الطير / Birds)</li>
+<li>fire-light  (النار والضوء / Fire &amp; Light)</li>
+<li>tears  (الدموع / Tears)</li>
+<li>journey  (الرحلة والراحلة / Journey &amp; Mount)</li>
+<li>dawn  (الفجر والصبح / Dawn)</li>
+</ul>
+<p>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:
+- اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)
+- اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</p>
+<h3>كما تنتج الحقول التالية:</h3>
+<ul>
+<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</li>
+<li>rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</li>
+<li>emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</li>
+<li>accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</li>
+<li>confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {"amorous": 90, "love": 80}.</li>
+</ul>
+<h3>إرشادات:</h3>
+<ul>
+<li>صنّف بناءً على النص نفسه لا على شهرة الشاعر.</li>
+<li>لا تخترع رموزاً خارج القوائم.</li>
+<li>سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</li>
+<li>لا تُدرج أي رمز درجة ثقتك فيه دون 65.</li>
+<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</li>
+</ul>
+<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</h3>
+<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}
+</code></pre>
+<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div><div class='pbmd en' dir='ltr'><p class='noen'>(English translation unavailable — showing Arabic source)</p><p>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن <strong>جوهر</strong> القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</p>
+<p>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</p>
+<h3>المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</h3>
+<ul>
+<li>melancholy  (حزن / Melancholy)</li>
+<li>nostalgia  (حنين / Nostalgia)</li>
+<li>joy  (فرح / Joy)</li>
+<li>amorous  (غزل / Amorous)</li>
+<li>passion  (وجد / Passion)</li>
+<li>contemplation  (تأمّل / Contemplation)</li>
+<li>serenity  (سكينة / Serenity)</li>
+<li>defiance  (تحدٍّ / Defiance)</li>
+<li>pride  (اعتزاز / Pride)</li>
+<li>grief  (أسى / Grief)</li>
+<li>hope  (أمل / Hope)</li>
+<li>despair  (يأس / Despair)</li>
+<li>satire  (سخرية / Satire)</li>
+<li>reverence  (خشوع / Reverence)</li>
+<li>bittersweet  (حلوٌ مرّ / Bittersweet)</li>
+<li>yearning  (شوق / Yearning)</li>
+</ul>
+<h3>الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</h3>
+<ul>
+<li>love  (الحب / Love)</li>
+<li>loss-death  (الفقد والموت / Loss &amp; Death)</li>
+<li>exile-longing  (الغربة والحنين / Exile &amp; Longing)</li>
+<li>homeland  (الوطن / Homeland)</li>
+<li>nature  (الطبيعة / Nature)</li>
+<li>war-conflict  (الحرب والصراع / War &amp; Conflict)</li>
+<li>faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</li>
+<li>wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</li>
+<li>friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</li>
+<li>time-mortality  (الزمن والفناء / Time &amp; Mortality)</li>
+<li>wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</li>
+<li>justice-oppression  (العدل والظلم / Justice &amp; Oppression)</li>
+<li>freedom  (الحرية / Freedom)</li>
+<li>beauty  (الجمال / Beauty)</li>
+<li>honor-pride  (الفخر والشرف / Honor &amp; Pride)</li>
+<li>women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</li>
+</ul>
+<h3>الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</h3>
+<ul>
+<li>night  (الليل / Night)</li>
+<li>desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</li>
+<li>moon-stars  (القمر والنجوم / Moon &amp; Stars)</li>
+<li>sea-water  (البحر والماء / Sea &amp; Water)</li>
+<li>garden-flowers  (الروض والزهر / Garden &amp; Flowers)</li>
+<li>wine-cup  (الكأس والخمر / The Wine Cup)</li>
+<li>sword-battle  (السيف والمعركة / Sword &amp; Battle)</li>
+<li>birds  (الطير / Birds)</li>
+<li>fire-light  (النار والضوء / Fire &amp; Light)</li>
+<li>tears  (الدموع / Tears)</li>
+<li>journey  (الرحلة والراحلة / Journey &amp; Mount)</li>
+<li>dawn  (الفجر والصبح / Dawn)</li>
+</ul>
+<p>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:
+- اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)
+- اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</p>
+<h3>كما تنتج الحقول التالية:</h3>
+<ul>
+<li>mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</li>
+<li>rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</li>
+<li>emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</li>
+<li>accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</li>
+<li>confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {"amorous": 90, "love": 80}.</li>
+</ul>
+<h3>إرشادات:</h3>
+<ul>
+<li>صنّف بناءً على النص نفسه لا على شهرة الشاعر.</li>
+<li>لا تخترع رموزاً خارج القوائم.</li>
+<li>سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</li>
+<li>لا تُدرج أي رمز درجة ثقتك فيه دون 65.</li>
+<li>تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</li>
+</ul>
+<h3>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</h3>
+<pre><code class="language-json">{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}
+</code></pre>
+<p>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</p></div></div></div><div class='pmode pmode-diff'><div class='pvsel'><span class='pvl'>A</span><span class='pseg' id='diffA'><button data-vid='v2baseline' class='on'>v2 · baseline</button><button data-vid='v4rubric' class=''>v4 · calibrated intensity + accessibility rubric</button><button data-vid='distill1' class=''>v5 · distillation (caps 2/2/2, floor 65)</button></span><span class='pvl'>B</span><span class='pseg' id='diffB'><button data-vid='v2baseline' class=''>v2 · baseline</button><button data-vid='v4rubric' class=''>v4 · calibrated intensity + accessibility rubric</button><button data-vid='distill1' class='on'>v5 · distillation (caps 2/2/2, floor 65)</button></span></div><div class='diffbox'><div class='diffwrap' data-pair='v2baseline|v4rubric'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v2 · baseline<div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div><div class='dm b'><span class='tag add'>B +</span> v4 · calibrated intensity + accessibility rubric<div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تُدرج أي رمز درجة ثقتك فيه دون 65.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div><div class='diffwrap' data-pair='v2baseline|distill1'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v2 · baseline<div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div><div class='dm b'><span class='tag add'>B +</span> v5 · distillation (caps 2/2/2, floor 65)<div class='vchg'>Distillation pass: pick the DOMINANT concept, not everything plausible. Hard caps of &lt;=2 labels per dimension (mood/topic/motif), a confidence floor of 65 (drop anything the model is less than 65% sure of), and no synonym-stacking (one label per idea, no near-duplicate shades). Taxonomy v3. Single-model production run on gemini-3.6-flash (no judge / 2.5-flash columns). Accessibility back to a holistic 1-5 level.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تُدرج أي رمز درجة ثقتك فيه دون 65.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div><div class='diffwrap' data-pair='v4rubric|v2baseline'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v4 · calibrated intensity + accessibility rubric<div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div><div class='dm b'><span class='tag add'>B +</span> v2 · baseline<div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تُدرج أي رمز درجة ثقتك فيه دون 65.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div><div class='diffwrap' data-pair='v4rubric|distill1'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v4 · calibrated intensity + accessibility rubric<div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div><div class='dm b'><span class='tag add'>B +</span> v5 · distillation (caps 2/2/2, floor 65)<div class='vchg'>Distillation pass: pick the DOMINANT concept, not everything plausible. Hard caps of &lt;=2 labels per dimension (mood/topic/motif), a confidence floor of 65 (drop anything the model is less than 65% sure of), and no synonym-stacking (one label per idea, no near-duplicate shades). Taxonomy v3. Single-model production run on gemini-3.6-flash (no judge / 2.5-flash columns). Accessibility back to a holistic 1-5 level.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تُدرج أي رمز درجة ثقتك فيه دون 65.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div><div class='diffwrap' data-pair='distill1|v2baseline'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v5 · distillation (caps 2/2/2, floor 65)<div class='vchg'>Distillation pass: pick the DOMINANT concept, not everything plausible. Hard caps of &lt;=2 labels per dimension (mood/topic/motif), a confidence floor of 65 (drop anything the model is less than 65% sure of), and no synonym-stacking (one label per idea, no near-duplicate shades). Taxonomy v3. Single-model production run on gemini-3.6-flash (no judge / 2.5-flash columns). Accessibility back to a holistic 1-5 level.</div></div><div class='dm b'><span class='tag add'>B +</span> v2 · baseline<div class='vchg'>Original taxonomy prompt. Intensity 0-100 (no calibration, tends to cluster high). Accessibility a single holistic 1-5 score.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تُدرج أي رمز درجة ثقتك فيه دون 65.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div><div class='diffwrap' data-pair='distill1|v4rubric'><div class='diffmeta'><div class='dm a'><span class='tag del'>A −</span> v5 · distillation (caps 2/2/2, floor 65)<div class='vchg'>Distillation pass: pick the DOMINANT concept, not everything plausible. Hard caps of &lt;=2 labels per dimension (mood/topic/motif), a confidence floor of 65 (drop anything the model is less than 65% sure of), and no synonym-stacking (one label per idea, no near-duplicate shades). Taxonomy v3. Single-model production run on gemini-3.6-flash (no judge / 2.5-flash columns). Accessibility back to a holistic 1-5 level.</div></div><div class='dm b'><span class='tag add'>B +</span> v4 · calibrated intensity + accessibility rubric<div class='vchg'>Intensity 0-100 with anti-clustering calibration (use the full range; most poems 30-70, reserve 80+ for overwhelming emotion). Accessibility decomposed into 5 scored sub-factors (lexical, syntax, imagery_abstraction, allusion, narrativity) -&gt; derived 0-10 score, weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1. Storytelling counts as harder than imagery.</div></div></div><div class='difflines'><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أنت ناقد أدبي عربي خبير بالشعر الكلاسيكي والحديث. مهمتك تصنيف القصيدة المعروضة عليك عبر أبعاد المزاج والموضوع والصورة، بأقلّ عدد من التصنيفات التي تعبّر عن **جوهر** القصيدة، لا كلّ ما هو محتمل. الهدف تمكين القارئ من التصفية والاكتشاف بتصنيفات حادّة مميِّزة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>اختر التصنيفات من القوائم المغلقة التالية فقط، واستخدم الرمز الإنجليزي (key) في إجابتك لا الاسم العربي.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ المزاج (mood) — اختر من 1 إلى 2: مزاجاً مهيمناً واحداً، وأضف ثانوياً واحداً فقط إن كان مختلفاً جوهرياً لا مجرّد ظلٍّ للأول:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - melancholy  (حزن / Melancholy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nostalgia  (حنين / Nostalgia)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - joy  (فرح / Joy)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - amorous  (غزل / Amorous)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - passion  (وجد / Passion)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - contemplation  (تأمّل / Contemplation)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - serenity  (سكينة / Serenity)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - defiance  (تحدٍّ / Defiance)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - pride  (اعتزاز / Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - grief  (أسى / Grief)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - hope  (أمل / Hope)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - despair  (يأس / Despair)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - satire  (سخرية / Satire)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - reverence  (خشوع / Reverence)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - bittersweet  (حلوٌ مرّ / Bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - yearning  (شوق / Yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الموضوع (topic) — اختر من 1 إلى 2: موضوعاً واحداً، أو اثنين إن حمل النصّ موضوعين متمايزين حقاً:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - love  (الحب / Love)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - loss-death  (الفقد والموت / Loss &amp; Death)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - exile-longing  (الغربة والحنين / Exile &amp; Longing)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - homeland  (الوطن / Homeland)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - nature  (الطبيعة / Nature)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - war-conflict  (الحرب والصراع / War &amp; Conflict)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - faith-spirit  (الإيمان والروحانية / Faith &amp; Spirituality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-pleasure  (الخمر واللذّة / Wine &amp; Pleasure)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - friendship  (الصداقة والوفاء / Friendship &amp; Loyalty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - time-mortality  (الزمن والفناء / Time &amp; Mortality)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wisdom-ethics  (الحكمة والأخلاق / Wisdom &amp; Ethics)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - justice-oppression  (العدل والظلم / Justice &amp; Oppression)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - freedom  (الحرية / Freedom)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - beauty  (الجمال / Beauty)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - honor-pride  (الفخر والشرف / Honor &amp; Pride)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - women-feminine  (المرأة والأنوثة / Women &amp; the Feminine)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>■ الصورة والرموز (motif) — اختر من 0 إلى 2 من الصور الحسّية الحاضرة فعلاً وبقوة في النص. إن لم تبرز صورة، اترك القائمة فارغة:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - night  (الليل / Night)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - desert-ruins  (الصحراء والطلل / Desert &amp; Ruins)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - moon-stars  (القمر والنجوم / Moon &amp; Stars)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sea-water  (البحر والماء / Sea &amp; Water)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - garden-flowers  (الروض والزهر / Garden &amp; Flowers)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - wine-cup  (الكأس والخمر / The Wine Cup)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - sword-battle  (السيف والمعركة / Sword &amp; Battle)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - birds  (الطير / Birds)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - fire-light  (النار والضوء / Fire &amp; Light)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - tears  (الدموع / Tears)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - journey  (الرحلة والراحلة / Journey &amp; Mount)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - dawn  (الفجر والصبح / Dawn)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>قاعدة عدم تكديس المرادفات (مهمّة) — من كلّ مجموعة تالية اختر الأدقّ واحداً فقط:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: حزن (melancholy)، أسى (grief)، يأس (despair)، حلوٌ مرّ (bittersweet)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>  - اختر رمزاً واحداً على الأكثر من: غزل (amorous)، وجد (passion)، شوق (yearning)</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>كما تنتج الحقول التالية:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- mood_primary: المزاج الأوحد الأكثر هيمنة (رمز واحد من قائمة المزاج، ويجب أن يكون ضمن moods).</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- rationale: جملة عربية قصيرة تسمّي المفهوم الجوهري للقصيدة وتبرّر اختيارك.</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- emotional_intensity: عدد من 0 إلى 100 يقيس شدة الشحنة العاطفية.</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>- accessibility_level: عدد من 1 إلى 5 (1 = سهلة على متعلّم العربية، 5 = تتطلب معرفة كلاسيكية عميقة).</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- emotional_intensity: شدة الشحنة العاطفية من 0 إلى 100. استعمل المدى كاملاً ولا تكدّس القيم: أغلب القصائد بين 30 و70، ما دون 30 للوصف الهادئ والحكمة والتعليم، وما فوق 80 للعاطفة الطاغية (فجيعة عارمة، هيام، سخط شديد).</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>- accessibility_factors: قدّر خمسة عوامل لسهولة القراءة على متعلّم العربية، كل عامل من 1 (أيسر) إلى 5 (أصعب): lexical (شيوع الألفاظ: 1 حديثة مألوفة ← 5 غريبة أرشيفية)، syntax (وضوح التركيب: 1 مباشر ← 5 تقديم وتأخير وحذف وتعقيد)، imagery_abstraction (تجريد الصورة: 1 حسّية مباشرة ← 5 استعارة ممتدة تحتاج فكّاً)، allusion (الحمل المرجعي: 1 مستقل ← 5 تناص وإشارات تراثية كثيفة)، narrativity (السرد: 1 صورة آنيّة ← 5 حكاية مُطوَّلة تحتاج متابعة؛ فالسرد أصعب من الصورة). نوّع تقديراتك واستعمل المدى كاملاً.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- confidences: كائن يربط كل رمز اخترته (من أي بُعد) بدرجة ثقتك فيه من 0 إلى 100، مثل {&quot;amorous&quot;: 90, &quot;love&quot;: 80}.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إرشادات:</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- صنّف بناءً على النص نفسه لا على شهرة الشاعر.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تخترع رموزاً خارج القوائم.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- سمِّ المفهوم المهيمن أولاً ثم صنّف؛ لا تُدرج تصنيفاً هامشياً لمجرّد وروده.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- لا تُدرج أي رمز درجة ثقتك فيه دون 65.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>- تمييزات دقيقة: شوق (yearning) حنينٌ نحو شخص، أما حنين (nostalgia) فحنينٌ نحو الوطن أو الديار؛ سخرية (satire) تعني الهجاء اللاذع لا الفكاهة اللطيفة؛ والروض والزهر (garden-flowers) غالباً روض المحبوب لا مجرّد وصف طبيعة.</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>أجب بصيغة JSON فقط لكل قصيدة، بلا أي شرح خارج الكائن:</span></div><div class='dl del'><span class='gut'>−</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_level&quot;: N, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl add'><span class='gut'>+</span><span class='dtx' dir='rtl'>{&quot;id&quot;: &quot;...&quot;, &quot;moods&quot;: [&quot;...&quot;], &quot;mood_primary&quot;: &quot;...&quot;, &quot;topics&quot;: [&quot;...&quot;], &quot;motifs&quot;: [&quot;...&quot;], &quot;emotional_intensity&quot;: N, &quot;accessibility_factors&quot;: {&quot;lexical&quot;: N, &quot;syntax&quot;: N, &quot;imagery_abstraction&quot;: N, &quot;allusion&quot;: N, &quot;narrativity&quot;: N}, &quot;confidences&quot;: {&quot;&lt;key&gt;&quot;: N}, &quot;rationale&quot;: &quot;...&quot;}</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>&nbsp;</span></div><div class='dl ctx'><span class='gut'> </span><span class='dtx' dir='rtl'>إذا عُرضت عدة قصائد، أجب بمصفوفة JSON مرتبة بنفس ترتيب القصائد.</span></div></div></div></div></div><div class='pbfb'><div class='pfl'>Prompt feedback (saved + included in export)</div><textarea id='promptfb' placeholder='what would you change about the prompt? wording, missing guidance, label definitions…'></textarea></div></aside>
 <main id='list'>
     <section class='card' data-num='1' data-pid='85646'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 67, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 2.5, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 67, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 2.5, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>1</span> <span class='ttl'>ابتسامة كأس الرضاب</span>
         <span class='poet'>أبو فراس الحمداني</span> <span class='pid'>#85646</span>
         <span class='ag'></span></div>
@@ -915,11 +1091,88 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:25.0%"></div></div><b>2.5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:10.0%"></div></div><b>1</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-1.5</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 1 (1 easy → 5 hard)">syn<b>1</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:25.0%"></div></div><b>2.5</b><span class="ref10">/10</span><span class="dlt zero" title="vs judge">0</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:25.0%"></div></div><b>2.5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:10.0%"></div></div><b>1</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-1.5</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 1 (1 easy → 5 hard)">syn<b>1</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:25.0%"></div></div><b>2.5</b><span class="ref10">/10</span><span class="dlt zero" title="vs judge">0</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Amorous · غزل ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Amorous · غزل ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Wine &amp; Pleasure · الخمر واللذّة</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">The Wine Cup · الكأس والخمر</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Garden &amp; Flowers · الروض والزهر</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:75%"></div></div><b>75</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='2' data-pid='82043'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;joy&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 89}, &quot;v4rubric&quot;: {&quot;int&quot;: 65, &quot;acc&quot;: 5.6, &quot;prim&quot;: &quot;joy&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 89}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;joy&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 89}, &quot;v4rubric&quot;: {&quot;int&quot;: 65, &quot;acc&quot;: 5.6, &quot;prim&quot;: &quot;joy&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 89}, &quot;distill1&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;joy&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>2</span> <span class='ttl'>آذار والربيع والفرح</span>
         <span class='poet'>أحمد شوقي</span> <span class='pid'>#82043</span>
         <span class='ag'></span></div>
@@ -1579,11 +1832,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:56.0%"></div></div><b>5.6</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:35.0%"></div></div><b>3.5</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-2.1</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.2</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:56.0%"></div></div><b>5.6</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:35.0%"></div></div><b>3.5</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-2.1</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.2</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Joy · فرح ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Joy · فرح ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Serenity · سكينة</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Nature · الطبيعة</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Beauty · الجمال</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Garden &amp; Flowers · الروض والزهر</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Birds · الطير</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:80%"></div></div><b>80</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='3' data-pid='85504'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 2.9, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 57, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 2.9, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 57, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 65, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>3</span> <span class='ttl'>سحابة العاشق</span>
         <span class='poet'>ابن رشيق القيرواني</span> <span class='pid'>#85504</span>
         <span class='ag'></span></div>
@@ -2131,11 +2470,79 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:29.0%"></div></div><b>2.9</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:42.0%"></div></div><b>4.2</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.3</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:23.0%"></div></div><b>2.3</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.6</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:29.0%"></div></div><b>2.9</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:42.0%"></div></div><b>4.2</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.3</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:23.0%"></div></div><b>2.3</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.6</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Contemplation · تأمّل ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Contemplation · تأمّل ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Nature · الطبيعة</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Garden &amp; Flowers · الروض والزهر</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Tears · الدموع</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill mid" style="width:65%"></div></div><b>65</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='4' data-pid='64583'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 88, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 4.2, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 88, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 88, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 4.2, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 88, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>4</span> <span class='ttl'>سلامٌ على الأطلالِ والعهد</span>
         <span class='poet'>ذو الرمة</span> <span class='pid'>#64583</span>
         <span class='ag'></span></div>
@@ -2679,11 +3086,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:42.0%"></div></div><b>4.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:54.0%"></div></div><b>5.4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.2</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:56.0%"></div></div><b>5.6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.4</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:42.0%"></div></div><b>4.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:54.0%"></div></div><b>5.4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.2</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:56.0%"></div></div><b>5.6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.4</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Nostalgia · حنين ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Nostalgia · حنين ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Melancholy · حزن</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Exile &amp; Longing · الغربة والحنين</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Desert &amp; Ruins · الصحراء والطلل</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Tears · الدموع</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:80%"></div></div><b>80</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='5' data-pid='72494'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;melancholy&quot;, &quot;a25&quot;: 91, &quot;a36&quot;: 73}, &quot;v4rubric&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 5.0, &quot;prim&quot;: &quot;melancholy&quot;, &quot;a25&quot;: 77, &quot;a36&quot;: 77}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;melancholy&quot;, &quot;a25&quot;: 91, &quot;a36&quot;: 73}, &quot;v4rubric&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 5.0, &quot;prim&quot;: &quot;melancholy&quot;, &quot;a25&quot;: 77, &quot;a36&quot;: 77}, &quot;distill1&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>5</span> <span class='ttl'>بكاءُ الوَرْقاءِ ولوعةُ الزمان</span>
         <span class='poet'>ابن حمديس</span> <span class='pid'>#72494</span>
         <span class='ag'></span></div>
@@ -3446,11 +3939,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:50.0%"></div></div><b>5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:44.0%"></div></div><b>4.4</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.6</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:50.0%"></div></div><b>5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:44.0%"></div></div><b>4.4</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.6</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Nostalgia · حنين ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Nostalgia · حنين ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Pride · اعتزاز</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Time &amp; Mortality · الزمن والفناء</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">War &amp; Conflict · الحرب والصراع</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Night · الليل</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Moon &amp; Stars · القمر والنجوم</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:75%"></div></div><b>75</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips hard"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i></span><b>4</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='6' data-pid='79379'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 65, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 75, &quot;a36&quot;: 62}, &quot;v4rubric&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 5.2, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 67, &quot;a36&quot;: 67}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 65, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 75, &quot;a36&quot;: 62}, &quot;v4rubric&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 5.2, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 67, &quot;a36&quot;: 67}, &quot;distill1&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>6</span> <span class='ttl'>ثابت والنساء والبنات</span>
         <span class='poet'>تأبط شرا</span> <span class='pid'>#79379</span>
         <span class='ag'></span></div>
@@ -3997,11 +4576,88 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:52.0%"></div></div><b>5.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:67.0%"></div></div><b>6.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.5</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:69.0%"></div></div><b>6.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:52.0%"></div></div><b>5.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:67.0%"></div></div><b>6.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.5</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:69.0%"></div></div><b>6.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Pride · اعتزاز ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Pride · اعتزاز ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Defiance · تحدٍّ</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Honor &amp; Pride · الفخر والشرف</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Night · الليل</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Sword &amp; Battle · السيف والمعركة</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:85%"></div></div><b>85</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips hard"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i></span><b>5</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='7' data-pid='63361'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 60, &quot;a36&quot;: 70}, &quot;v4rubric&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 2.1, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 80, &quot;a36&quot;: 80}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 60, &quot;a36&quot;: 70}, &quot;v4rubric&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 2.1, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 80, &quot;a36&quot;: 80}, &quot;distill1&quot;: {&quot;int&quot;: 82, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>7</span> <span class='ttl'>وقفة على الأطلال</span>
         <span class='poet'>ابن الفارض</span> <span class='pid'>#63361</span>
         <span class='ag'></span></div>
@@ -4704,11 +5360,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:21.0%"></div></div><b>2.1</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.9</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:29.0%"></div></div><b>2.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:21.0%"></div></div><b>2.1</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.9</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:29.0%"></div></div><b>2.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Nostalgia · حنين ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Nostalgia · حنين ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Bittersweet · حلوٌ مرّ</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Exile &amp; Longing · الغربة والحنين</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Desert &amp; Ruins · الصحراء والطلل</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Night · الليل</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:82%"></div></div><b>82</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='8' data-pid='65749'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 95, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 78, &quot;a36&quot;: 89}, &quot;v4rubric&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 2.3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 67, &quot;a36&quot;: 78}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 95, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 78, &quot;a36&quot;: 89}, &quot;v4rubric&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 2.3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 67, &quot;a36&quot;: 78}, &quot;distill1&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>8</span> <span class='ttl'>مَآثِرُ الرّسول</span>
         <span class='poet'>حسان بن ثابت</span> <span class='pid'>#65749</span>
         <span class='ag'></span></div>
@@ -5288,11 +6030,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:23.0%"></div></div><b>2.3</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 1 (1 easy → 5 hard)">img<b>1</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:44.0%"></div></div><b>4.4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+2.1</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:48.0%"></div></div><b>4.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+2.5</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:23.0%"></div></div><b>2.3</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 1 (1 easy → 5 hard)">img<b>1</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:44.0%"></div></div><b>4.4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+2.1</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:48.0%"></div></div><b>4.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+2.5</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Grief · أسى ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Grief · أسى ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Reverence · خشوع</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Loss &amp; Death · الفقد والموت</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Faith &amp; Spirituality · الإيمان والروحانية</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Tears · الدموع</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Desert &amp; Ruins · الصحراء والطلل</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:90%"></div></div><b>90</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='9' data-pid='73129'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 86}, &quot;v4rubric&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4.0, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 71}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 86}, &quot;v4rubric&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4.0, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 71}, &quot;distill1&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>9</span> <span class='ttl'>بكاء على فُقدان الأعزة</span>
         <span class='poet'>ابن معصوم</span> <span class='pid'>#73129</span>
         <span class='ag'></span></div>
@@ -5799,11 +6627,72 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:46.0%"></div></div><b>4.6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.6</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt zero" title="vs judge">0</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:46.0%"></div></div><b>4.6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.6</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt zero" title="vs judge">0</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Grief · أسى ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Grief · أسى ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Loss &amp; Death · الفقد والموت</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Tears · الدموع</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:90%"></div></div><b>90</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='10' data-pid='80047'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 2.5, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 86, &quot;a36&quot;: 86}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 2.5, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 86, &quot;a36&quot;: 86}, &quot;distill1&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;passion&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>10</span> <span class='ttl'>خوف الفراق</span>
         <span class='poet'>عروة بن حزام</span> <span class='pid'>#80047</span>
         <span class='ag'></span></div>
@@ -6282,11 +7171,81 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:25.0%"></div></div><b>2.5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:50.0%"></div></div><b>5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+2.5</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:27.0%"></div></div><b>2.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.2</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:25.0%"></div></div><b>2.5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:50.0%"></div></div><b>5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+2.5</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:27.0%"></div></div><b>2.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.2</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Passion · وجد ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Passion · وجد ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Despair · يأس</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Journey &amp; Mount · الرحلة والراحلة</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:85%"></div></div><b>85</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='11' data-pid='89575'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 50, &quot;a36&quot;: 83}, &quot;v4rubric&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 5.2, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 50, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 50, &quot;a36&quot;: 83}, &quot;v4rubric&quot;: {&quot;int&quot;: 60, &quot;acc&quot;: 5.2, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 50, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>11</span> <span class='ttl'>وصف الجود</span>
         <span class='poet'>المتنبي</span> <span class='pid'>#89575</span>
         <span class='ag'></span></div>
@@ -6703,11 +7662,72 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:52.0%"></div></div><b>5.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:54.0%"></div></div><b>5.4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.2</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:60.0%"></div></div><b>6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:52.0%"></div></div><b>5.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:54.0%"></div></div><b>5.4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.2</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:60.0%"></div></div><b>6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Pride · اعتزاز ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Pride · اعتزاز ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Honor &amp; Pride · الفخر والشرف</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Sword &amp; Battle · السيف والمعركة</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:85%"></div></div><b>85</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips hard"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i></span><b>4</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='12' data-pid='81599'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 95, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 89, &quot;a36&quot;: 89}, &quot;v4rubric&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 5.2, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 90, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 95, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 89, &quot;a36&quot;: 89}, &quot;v4rubric&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 5.2, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 90, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 88, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>12</span> <span class='ttl'>جراحات دمشق</span>
         <span class='poet'>أحمد شوقي</span> <span class='pid'>#81599</span>
         <span class='ag'></span></div>
@@ -7378,11 +8398,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:52.0%"></div></div><b>5.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:56.0%"></div></div><b>5.6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.4</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:38.0%"></div></div><b>3.8</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-1.4</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:52.0%"></div></div><b>5.2</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:56.0%"></div></div><b>5.6</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.4</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:38.0%"></div></div><b>3.8</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-1.4</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Grief · أسى ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Grief · أسى ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Defiance · تحدٍّ</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Homeland · الوطن</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">War &amp; Conflict · الحرب والصراع</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Tears · الدموع</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Fire &amp; Light · النار والضوء</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:88%"></div></div><b>88</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='13' data-pid='85684'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 2, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 80}, &quot;v4rubric&quot;: {&quot;int&quot;: 65, &quot;acc&quot;: 2.1, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 80, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 2, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 80}, &quot;v4rubric&quot;: {&quot;int&quot;: 65, &quot;acc&quot;: 2.1, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 80, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>13</span> <span class='ttl'>زيارة الحبيب في الروضة</span>
         <span class='poet'>صفي الدين الحلي</span> <span class='pid'>#85684</span>
         <span class='ag'></span></div>
@@ -7833,11 +8939,90 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:21.0%"></div></div><b>2.1</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:17.0%"></div></div><b>1.7</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.4</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:29.0%"></div></div><b>2.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:21.0%"></div></div><b>2.1</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:17.0%"></div></div><b>1.7</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.4</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:29.0%"></div></div><b>2.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.8</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Amorous · غزل ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Amorous · غزل ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Nostalgia · حنين</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Nature · الطبيعة</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Garden &amp; Flowers · الروض والزهر</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:75%"></div></div><b>75</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='14' data-pid='77541'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 95, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3.8, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 75, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 95, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 71, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3.8, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: 75, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;grief&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>14</span> <span class='ttl'>حسرة الفراق وفقد الحبيب</span>
         <span class='poet'>قيس بن ذريح</span> <span class='pid'>#77541</span>
         <span class='ag'></span></div>
@@ -8368,11 +9553,79 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:38.0%"></div></div><b>3.8</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:50.0%"></div></div><b>5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.2</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:48.0%"></div></div><b>4.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:38.0%"></div></div><b>3.8</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:50.0%"></div></div><b>5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.2</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:48.0%"></div></div><b>4.8</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Grief · أسى ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Grief · أسى ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Journey &amp; Mount · الرحلة والراحلة</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Tears · الدموع</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:90%"></div></div><b>90</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips hard"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i></span><b>4</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='15' data-pid='36877'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 86, &quot;a36&quot;: 86}, &quot;v4rubric&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 3.5, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 56, &quot;a36&quot;: 89}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 86, &quot;a36&quot;: 86}, &quot;v4rubric&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 3.5, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: 56, &quot;a36&quot;: 89}, &quot;distill1&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;amorous&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>15</span> <span class='ttl'>ليلة الظبي ودمع الحياء</span>
         <span class='poet'>ابن خفاجة</span> <span class='pid'>#36877</span>
         <span class='ag'></span></div>
@@ -8937,11 +10190,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:35.0%"></div></div><b>3.5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:31.0%"></div></div><b>3.1</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.4</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.5</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:35.0%"></div></div><b>3.5</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:31.0%"></div></div><b>3.1</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.4</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.5</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Amorous · غزل ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Amorous · غزل ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Nostalgia · حنين</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Women &amp; the Feminine · المرأة والأنوثة</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Night · الليل</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Moon &amp; Stars · القمر والنجوم</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:70%"></div></div><b>70</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='16' data-pid='76769'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 83, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 55, &quot;acc&quot;: 6.0, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 78, &quot;a36&quot;: 78}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 83, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 55, &quot;acc&quot;: 6.0, &quot;prim&quot;: &quot;pride&quot;, &quot;a25&quot;: 78, &quot;a36&quot;: 78}, &quot;distill1&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;reverence&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>16</span> <span class='ttl'>ذكريات روضة نعمي</span>
         <span class='poet'>النابغة الذبياني</span> <span class='pid'>#76769</span>
         <span class='ag'></span></div>
@@ -9511,11 +10850,88 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:60.0%"></div></div><b>6</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:69.0%"></div></div><b>6.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.9</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:77.0%"></div></div><b>7.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:60.0%"></div></div><b>6</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:69.0%"></div></div><b>6.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.9</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:77.0%"></div></div><b>7.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Reverence · خشوع ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Reverence · خشوع ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Nostalgia · حنين</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Honor &amp; Pride · الفخر والشرف</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Desert &amp; Ruins · الصحراء والطلل</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Journey &amp; Mount · الرحلة والراحلة</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:75%"></div></div><b>75</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips hard"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i></span><b>4</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='17' data-pid='87837'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 50, &quot;acc&quot;: 5.8, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 100}, &quot;v4rubric&quot;: {&quot;int&quot;: 50, &quot;acc&quot;: 5.8, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 70, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;contemplation&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>17</span> <span class='ttl'>التجلي الإلهي في كل شيء</span>
         <span class='poet'>محيي الدين بن عربي</span> <span class='pid'>#87837</span>
         <span class='ag'></span></div>
@@ -9870,11 +11286,65 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 5 (1 easy → 5 hard)">img<b>5</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:65.0%"></div></div><b>6.5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 5 (1 easy → 5 hard)">img<b>5</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:67.0%"></div></div><b>6.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.9</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 5 (1 easy → 5 hard)">img<b>5</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 5 (1 easy → 5 hard)">img<b>5</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:65.0%"></div></div><b>6.5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 4 (1 easy → 5 hard)">lex<b>4</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 5 (1 easy → 5 hard)">img<b>5</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:67.0%"></div></div><b>6.7</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+0.9</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 5 (1 easy → 5 hard)">img<b>5</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Contemplation · تأمّل ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Contemplation · تأمّل ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Reverence · خشوع</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class='none'>—</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class='none'>—</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:70%"></div></div><b>70</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips hard"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i></span><b>4</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='18' data-pid='33304'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 83, &quot;a36&quot;: 92}, &quot;v4rubric&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 5.8, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 75, &quot;a36&quot;: 92}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 83, &quot;a36&quot;: 92}, &quot;v4rubric&quot;: {&quot;int&quot;: 75, &quot;acc&quot;: 5.8, &quot;prim&quot;: &quot;nostalgia&quot;, &quot;a25&quot;: 75, &quot;a36&quot;: 92}, &quot;distill1&quot;: {&quot;int&quot;: 80, &quot;acc&quot;: 5, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>18</span> <span class='ttl'>خيال ليلي عن اليمن</span>
         <span class='poet'>تميم بن أبي بن مقبل</span> <span class='pid'>#33304</span>
         <span class='ag'></span></div>
@@ -10634,11 +12104,97 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:75.0%"></div></div><b>7.5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:69.0%"></div></div><b>6.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.1</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:58.0%"></div></div><b>5.8</b><span class="ref10">/10</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:75.0%"></div></div><b>7.5</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.7</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf hard" title="allusion / referential load = 4 (1 easy → 5 hard)">all<b>4</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill hard" style="width:69.0%"></div></div><b>6.9</b><span class="ref10">/10</span><span class="dlt up" title="vs judge">+1.1</span></div><div class="subs"><span class="subf hard" title="lexical rarity = 5 (1 easy → 5 hard)">lex<b>5</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf med" title="allusion / referential load = 3 (1 easy → 5 hard)">all<b>3</b></span><span class="subf hard" title="narrativity (storytelling) = 4 (1 easy → 5 hard)">narr<b>4</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Yearning · شوق ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Yearning · شوق ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Pride · اعتزاز</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span> <span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Honor &amp; Pride · الفخر والشرف</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Night · الليل</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Desert &amp; Ruins · الصحراء والطلل</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:80%"></div></div><b>80</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips hard"><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i><i class="on"></i></span><b>5</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='19' data-pid='42127'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 89, &quot;a36&quot;: 78}, &quot;v4rubric&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4.6, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 100}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 89, &quot;a36&quot;: 78}, &quot;v4rubric&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 4.6, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: 100, &quot;a36&quot;: 100}, &quot;distill1&quot;: {&quot;int&quot;: 82, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>19</span> <span class='ttl'>شوق سكان القلب</span>
         <span class='poet'>أبو بحر الخطي</span> <span class='pid'>#42127</span>
         <span class='ag'></span></div>
@@ -11253,11 +12809,88 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:46.0%"></div></div><b>4.6</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:44.0%"></div></div><b>4.4</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.2</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.6</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:46.0%"></div></div><b>4.6</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf hard" title="syntax complexity = 4 (1 easy → 5 hard)">syn<b>4</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 1 (1 easy → 5 hard)">narr<b>1</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:44.0%"></div></div><b>4.4</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.2</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf hard" title="imagery abstraction = 4 (1 easy → 5 hard)">img<b>4</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill med" style="width:40.0%"></div></div><b>4</b><span class="ref10">/10</span><span class="dlt down" title="vs judge">-0.6</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf med" title="syntax complexity = 3 (1 easy → 5 hard)">syn<b>3</b></span><span class="subf med" title="imagery abstraction = 3 (1 easy → 5 hard)">img<b>3</b></span><span class="subf easy" title="allusion / referential load = 2 (1 easy → 5 hard)">all<b>2</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Yearning · شوق ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Yearning · شوق ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Nostalgia · حنين</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Exile &amp; Longing · الغربة والحنين</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Tears · الدموع</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Birds · الطير</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:82%"></div></div><b>82</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section>
     <section class='card' data-num='20' data-pid='80050'
-             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;despair&quot;, &quot;a25&quot;: 83, &quot;a36&quot;: 83}, &quot;v4rubric&quot;: {&quot;int&quot;: 0, &quot;acc&quot;: 0, &quot;prim&quot;: &quot;&quot;, &quot;a25&quot;: 0, &quot;a36&quot;: 0}}'>
+             data-sort='{&quot;v2baseline&quot;: {&quot;int&quot;: 90, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;despair&quot;, &quot;a25&quot;: 83, &quot;a36&quot;: 83}, &quot;v4rubric&quot;: {&quot;int&quot;: 0, &quot;acc&quot;: 0, &quot;prim&quot;: &quot;&quot;, &quot;a25&quot;: 0, &quot;a36&quot;: 0}, &quot;distill1&quot;: {&quot;int&quot;: 85, &quot;acc&quot;: 3, &quot;prim&quot;: &quot;yearning&quot;, &quot;a25&quot;: null, &quot;a36&quot;: null}}'>
       <div class='hd'><span class='num'>20</span> <span class='ttl'>أمنية البُعْد</span>
         <span class='poet'>عروة بن حزام</span> <span class='pid'>#80050</span>
         <span class='ag'></span></div>
@@ -11719,14 +13352,91 @@ from 5 sub-factors (each 1 easy → 5 hard):
 lex lexical rarity · syn syntax complexity · img imagery abstraction
 all allusion / referential load · narr narrativity (storytelling)
 weights allusion=4, lexical=3, syntax=2, imagery=2, narrativity=1
-green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:0%"></div></div><b>—</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = ? (1 easy → 5 hard)">lex<b>?</b></span><span class="subf easy" title="syntax complexity = ? (1 easy → 5 hard)">syn<b>?</b></span><span class="subf easy" title="imagery abstraction = ? (1 easy → 5 hard)">img<b>?</b></span><span class="subf easy" title="allusion / referential load = ? (1 easy → 5 hard)">all<b>?</b></span><span class="subf easy" title="narrativity (storytelling) = ? (1 easy → 5 hard)">narr<b>?</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:23.0%"></div></div><b>2.3</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:19.0%"></div></div><b>1.9</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div>
+green &lt;3.5 easy · amber 3.5-6.5 · red &gt;6.5 hard">access</td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:0%"></div></div><b>—</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = ? (1 easy → 5 hard)">lex<b>?</b></span><span class="subf easy" title="syntax complexity = ? (1 easy → 5 hard)">syn<b>?</b></span><span class="subf easy" title="imagery abstraction = ? (1 easy → 5 hard)">img<b>?</b></span><span class="subf easy" title="allusion / referential load = ? (1 easy → 5 hard)">all<b>?</b></span><span class="subf easy" title="narrativity (storytelling) = ? (1 easy → 5 hard)">narr<b>?</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:23.0%"></div></div><b>2.3</b><span class="ref10">/10</span></div><div class="subs"><span class="subf med" title="lexical rarity = 3 (1 easy → 5 hard)">lex<b>3</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf easy" title="narrativity (storytelling) = 2 (1 easy → 5 hard)">narr<b>2</b></span></div></div></td><td><div class="accwrap"><div class="accrow"><div class="bar acc"><div class="afill easy" style="width:19.0%"></div></div><b>1.9</b><span class="ref10">/10</span></div><div class="subs"><span class="subf easy" title="lexical rarity = 2 (1 easy → 5 hard)">lex<b>2</b></span><span class="subf easy" title="syntax complexity = 2 (1 easy → 5 hard)">syn<b>2</b></span><span class="subf easy" title="imagery abstraction = 2 (1 easy → 5 hard)">img<b>2</b></span><span class="subf easy" title="allusion / referential load = 1 (1 easy → 5 hard)">all<b>1</b></span><span class="subf med" title="narrativity (storytelling) = 3 (1 easy → 5 hard)">narr<b>3</b></span></div></div></td></tr></tbody></table></div><div class='cmpwrap cmp-distill1'><table class='cmp'><thead><tr><th></th><th>3.6-flash <span class='ref'>(sole run)</span></th></tr></thead><tbody><tr class=''><td class='rl tip' data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">primary</td><td><span class="chip tip agree" data-tip="Primary mood
+the single dominant mood
+(one of the mood options)">Yearning · شوق ★</span></td></tr><tr class=''><td class='rl tip' data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">mood</td><td><span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Yearning · شوق ★</span> <span class="chip tip agree" data-tip="Mood (multi-label, up to 4).
+Options:
+Melancholy · حزن  ·  Nostalgia · حنين
+Joy · فرح  ·  Amorous · غزل
+Passion · وجد  ·  Contemplation · تأمّل
+Serenity · سكينة  ·  Defiance · تحدٍّ
+Pride · اعتزاز  ·  Grief · أسى
+Hope · أمل  ·  Despair · يأس
+Satire · سخرية  ·  Reverence · خشوع
+Bittersweet · حلوٌ مرّ  ·  Yearning · شوق">Melancholy · حزن</span></td></tr><tr class=''><td class='rl tip' data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">topic</td><td><span class="chip tip agree" data-tip="Topic (multi-label, up to 4).
+Options:
+Love · الحب  ·  Loss &amp; Death · الفقد والموت
+Exile &amp; Longing · الغربة والحنين  ·  Homeland · الوطن
+Nature · الطبيعة  ·  War &amp; Conflict · الحرب والصراع
+Faith &amp; Spirituality · الإيمان والروحانية  ·  Wine &amp; Pleasure · الخمر واللذّة
+Friendship &amp; Loyalty · الصداقة والوفاء  ·  Time &amp; Mortality · الزمن والفناء
+Wisdom &amp; Ethics · الحكمة والأخلاق  ·  Justice &amp; Oppression · العدل والظلم
+Freedom · الحرية  ·  Beauty · الجمال
+Honor &amp; Pride · الفخر والشرف  ·  Women &amp; the Feminine · المرأة والأنوثة">Love · الحب</span></td></tr><tr class=''><td class='rl tip' data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">motif</td><td><span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Journey &amp; Mount · الرحلة والراحلة</span> <span class="chip tip agree" data-tip="Motif (multi-label, up to 5).
+Options:
+Night · الليل  ·  Desert &amp; Ruins · الصحراء والطلل
+Moon &amp; Stars · القمر والنجوم  ·  Sea &amp; Water · البحر والماء
+Garden &amp; Flowers · الروض والزهر  ·  The Wine Cup · الكأس والخمر
+Sword &amp; Battle · السيف والمعركة  ·  Birds · الطير
+Fire &amp; Light · النار والضوء  ·  Tears · الدموع
+Journey &amp; Mount · الرحلة والراحلة  ·  Dawn · الفجر والصبح">Desert &amp; Ruins · الصحراء والطلل</span></td></tr><tr class='mtr'><td class='rl tip' data-tip="Emotional intensity (0-100)
+how emotionally charged the poem is
+blue &lt;40 calm
+amber 40-70
+red &gt;70 intense">intensity</td><td><div class="bar"><div class="fill hi" style="width:85%"></div></div><b>85</b></td></tr><tr class='mtr'><td class='rl tip' data-tip="Accessibility (1-5)
+1 = easy for Arabic learners
+5 = requires deep classical knowledge
+green (1-2) easy · amber (3) · red (4-5) hard">access</td><td><span class="pips med"><i class="on"></i><i class="on"></i><i class="on"></i><i class="off"></i><i class="off"></i></span><b>3</b></td></tr></tbody></table></div>
       </div>
     </section></main>
 <footer style='padding:20px;text-align:center;color:#565c66;font-size:12px'>feedback saved in your browser (localStorage) · export writes spotcheck_feedback.json to Downloads · active prompt version is recorded in the export</footer>
 <script>
-const ACCESS={"v2baseline": "level_1_5", "v4rubric": "factors_0_10"};
-const VNAMES={"v2baseline": "v2 \u00b7 baseline", "v4rubric": "v4 \u00b7 calibrated intensity + accessibility rubric"};
-let VER="v4rubric";
+const ACCESS={"v2baseline": "level_1_5", "v4rubric": "factors_0_10", "distill1": "level_1_5"};
+const VNAMES={"v2baseline": "v2 \u00b7 baseline", "v4rubric": "v4 \u00b7 calibrated intensity + accessibility rubric", "distill1": "v5 \u00b7 distillation (caps 2/2/2, floor 65)"};
+let VER="distill1";
 
 // ---- per-poem feedback (localStorage) ----
 const KEY='spotcheck_fb_v2';
@@ -11816,7 +13526,7 @@ function setPromptView(v){
   document.querySelectorAll('#pver button').forEach(x=>x.classList.toggle('on',x.dataset.vid===v));
 }
 document.querySelectorAll('#pver button').forEach(b=>b.addEventListener('click',()=>setPromptView(b.dataset.vid)));
-let diffA="v2baseline", diffB="v4rubric";
+let diffA="v2baseline", diffB="distill1";
 function refreshDiff(){
   const pair=diffA+'|'+diffB;
   document.querySelectorAll('.diffwrap').forEach(d=>d.classList.toggle('on',d.dataset.pair===pair));
@@ -11843,6 +13553,6 @@ document.getElementById('export').addEventListener('click',()=>{
 });
 
 // ---- init ----
-bar.classList.add('tab-view','pv-'+"v4rubric");
+bar.classList.add('tab-view','pv-'+"distill1");
 setVersion(VER); refreshDiff();
 </script></body></html>

--- a/poetry_quality_and_curation/categorization/import_categories.py
+++ b/poetry_quality_and_curation/categorization/import_categories.py
@@ -142,12 +142,23 @@ def import_rows(conn, df: pd.DataFrame, lookup: dict, batch_size: int) -> tuple[
             confidences = _as_conf_dict(row.get("confidences"))
             taxonomy_version = row.get("taxonomy_version")
             taxonomy_version = str(taxonomy_version) if pd.notna(taxonomy_version) else None
+            prompt_version = row.get("prompt_version")
+            prompt_version = str(prompt_version) if pd.notna(prompt_version) else None
+            rationale = row.get("rationale")
+            rationale = str(rationale) if pd.notna(rationale) and str(rationale).strip() else None
+            mood_primary = row.get("mood_primary") or None
 
-            dim_lists = {
+            raw_dim_lists = {
                 "mood": _as_list(row.get("moods")),
                 "topic": _as_list(row.get("topics")),
                 "motif": _as_list(row.get("motifs")),
             }
+            # Distillation (v3): drop labels below the confidence floor before
+            # writing anything, so the table and the JSONB agree. mood_primary is
+            # always kept. Old (v2) parquets have full-confidence tags, so this is
+            # a no-op for them; it only bites weak tags going forward.
+            dim_lists = config.apply_confidence_floor(
+                raw_dim_lists, confidences, mood_primary, config.CONFIDENCE_FLOOR)
 
             # Resolve (value_id, value_key) so we can attach each value's confidence.
             value_entries = []
@@ -159,7 +170,7 @@ def import_rows(conn, df: pd.DataFrame, lookup: dict, batch_size: int) -> tuple[
 
             # JSONB provenance mirrors the shape promised in the migration:
             #   {"moods":[...], "topics":[...], "motifs":[...], "confidences":{...}}
-            # plus a taxonomy_version stamp so we know which taxonomy tagged it.
+            # plus taxonomy/prompt version stamps and the distilled rationale.
             categories_payload = {
                 "moods": dim_lists["mood"],
                 "topics": dim_lists["topic"],
@@ -168,6 +179,10 @@ def import_rows(conn, df: pd.DataFrame, lookup: dict, batch_size: int) -> tuple[
             }
             if taxonomy_version is not None:
                 categories_payload["taxonomy_version"] = taxonomy_version
+            if prompt_version is not None:
+                categories_payload["prompt_version"] = prompt_version
+            if rationale is not None:
+                categories_payload["rationale"] = rationale
             categories_json = json.dumps(categories_payload, ensure_ascii=False)
 
             def _num(v):

--- a/poetry_quality_and_curation/categorization/spotcheck_viewer.py
+++ b/poetry_quality_and_curation/categorization/spotcheck_viewer.py
@@ -37,6 +37,7 @@ import difflib
 import hashlib
 import html
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -59,11 +60,34 @@ JUDGE_MODEL = data.get("judge_model", "judge")
 POEMS = list(data["poems"].values())
 
 VIDS = list(PROMPT_VERSIONS.keys())
-DEFAULT_VID = VIDS[-1]                              # last version (v4-rubric)
+DEFAULT_VID = VIDS[-1]                              # last version (newest)
 CAND_MODELS = [m for m in MODELS if m != "judge"]  # candidates in order
+
+# A version is "judge-less" when no poem carries judge labels for it — e.g. a
+# single-model production run (distill-1 ran only gemini-3.6-flash). Such a
+# version has no judge baseline, so its table/sort/agreement fall back to the
+# one model that has data instead of diffing against an (absent) judge.
+JUDGELESS = {vid for vid in VIDS
+             if not any((p.get("labels", {}).get(vid, {}) or {}).get("judge") for p in POEMS)}
+
+
+def _base_model(labels):
+    """First candidate model with data (the baseline for a judge-less version)."""
+    return next((m for m in CAND_MODELS if labels.get(m)), CAND_MODELS[-1])
+
 
 esc = lambda s: html.escape(s or "", quote=True)
 slug = lambda vid: re.sub(r"[^a-z0-9]", "", vid.lower())
+
+
+def _prompt_text(vid):
+    """Prompt source for a version. Versions run through the prompt library live
+    in prompts.py; versions produced by a standalone run (e.g. distill-1) carry
+    their prompt inline in spotcheck_versions.json under ``prompt_text``."""
+    inline = PROMPT_VERSIONS.get(vid, {}).get("prompt_text")
+    if inline:
+        return inline
+    return prompts.get_text(vid)
 
 # ---------------------------------------------------------------------------
 # English label glosses + dimension tooltips (shared across versions).
@@ -152,7 +176,7 @@ def _load_encache():
         return c["versions"]
     if "hash" in c:  # legacy flat cache — belongs to whichever version matches.
         for vid in VIDS:
-            if hashlib.sha1(prompts.get_text(vid).encode()).hexdigest()[:12] == c["hash"]:
+            if hashlib.sha1(_prompt_text(vid).encode()).hexdigest()[:12] == c["hash"]:
                 return {vid: {"hash": c["hash"], "en": c.get("en", "")}}
     return {}
 
@@ -189,11 +213,14 @@ _encache = _load_encache()
 _encache_dirty = False
 PROMPT_META = {}   # vid -> {name, changed, access, text, ar_html, en_html, has_en}
 for vid in VIDS:
-    text = prompts.get_text(vid)
+    text = _prompt_text(vid)
     h = hashlib.sha1(text.encode()).hexdigest()[:12]
     ce = _encache.get(vid)
     en = ce.get("en") if ce and ce.get("hash") == h else None
-    if en is None:
+    # Live EN translation hits an LLM API; it stays opt-in (SPOTCHECK_TRANSLATE=1)
+    # so a plain rebuild is offline. On a cache miss without it, the version
+    # renders its Arabic source (the sidebar shows a "translation unavailable" note).
+    if en is None and os.environ.get("SPOTCHECK_TRANSLATE") == "1":
         en = _translate_prompt_en(text)
         if en:
             _encache[vid] = {"hash": h, "en": en}
@@ -329,12 +356,43 @@ def _th(access_kind):
             f"<th>2.5-flash</th><th>3.6-flash</th></tr></thead><tbody>")
 
 
+_MODEL_HDR = {"gemini-3.6-flash": "3.6-flash", "gemini-2.5-flash": "2.5-flash", "judge": "judge · 3.1-pro"}
+
+
+def _th_single(model, note):
+    return (f"<table class='cmp'><thead><tr><th></th>"
+            f"<th>{html.escape(_MODEL_HDR.get(model, model))} "
+            f"<span class='ref'>({html.escape(note)})</span></th></tr></thead><tbody>")
+
+
 def _row(label, tip, cells, cls=""):
     tds = "".join(f"<td>{c}</td>" for c in cells)
     return (f"<tr class='{cls}'><td class='rl tip' data-tip=\"{esc(tip)}\">{label}</td>{tds}</tr>")
 
 
+def build_table_single(poem, vid):
+    """Judge-less version (single-model run): show the one model that has data as
+    its own baseline — its labels in green, primary starred, scalar meters with no
+    delta (nothing to diff against). Ordered by that model's own labels."""
+    labels = poem["labels"][vid]
+    model = _base_model(labels)
+    r = labels.get(model, {})
+    kind = PROMPT_META[vid]["access"]
+    acc_tip = ACC_TIP_FACTORS if kind == "factors_0_10" else ACC_TIP_LEVEL
+    prim = r.get("mood_primary")
+    return (_th_single(model, "sole run")
+            + _row("primary", PRIM_TIP, [judge_prim(prim)])
+            + _row("mood", DIM_TIP["mood"], [judge_labels(r.get("moods"), "mood", prim)])
+            + _row("topic", DIM_TIP["topic"], [judge_labels(r.get("topics"), "topic")])
+            + _row("motif", DIM_TIP["motif"], [judge_labels(r.get("motifs"), "motif")])
+            + _row("intensity", INT_TIP, [bar_cell(r.get("emotional_intensity"))], "mtr")
+            + _row("access", acc_tip, [access_cell(kind, r, None)], "mtr")
+            + "</tbody></table>")
+
+
 def build_table(poem, vid):
+    if vid in JUDGELESS:
+        return build_table_single(poem, vid)
     labels = poem["labels"][vid]
     j = labels.get("judge", {})
     cands = [labels.get(m, {}) for m in CAND_MODELS]
@@ -375,16 +433,19 @@ def sort_data(poem):
     out = {}
     for vid in VIDS:
         labels = poem["labels"][vid]
-        j = labels.get("judge", {})
+        judgeless = vid in JUDGELESS
+        # Judge-less versions have no baseline: order by the sole model's own
+        # values, and blank the agreement badge (nothing to agree against).
+        base = labels.get(_base_model(labels), {}) if judgeless else labels.get("judge", {})
         kind = PROMPT_META[vid]["access"]
-        acc = (j.get("accessibility_score") if kind == "factors_0_10"
-               else j.get("accessibility_level"))
-        row = {"int": j.get("emotional_intensity") or 0,
+        acc = (base.get("accessibility_score") if kind == "factors_0_10"
+               else base.get("accessibility_level"))
+        row = {"int": base.get("emotional_intensity") or 0,
                "acc": acc if isinstance(acc, (int, float)) else 0,
-               "prim": j.get("mood_primary") or ""}
+               "prim": base.get("mood_primary") or ""}
         for m in CAND_MODELS:
             key = "a25" if "2.5" in m else "a36"
-            row[key] = agree_pct(labels.get(m, {}), j)
+            row[key] = None if judgeless else agree_pct(labels.get(m, {}), base)
         out[slug(vid)] = row
     return out
 

--- a/poetry_quality_and_curation/categorization/test_distillation.py
+++ b/poetry_quality_and_curation/categorization/test_distillation.py
@@ -1,0 +1,168 @@
+"""Unit tests for the v3 distillation changes to the categorization pipeline.
+
+Covers the three things the distillation actually changed:
+  * caps tightened to <= 2 per dimension (config),
+  * the confidence-floor filter (config.apply_confidence_floor, used by import),
+  * prompt / seed consistency with the taxonomy.
+
+Import-light on purpose: everything under test lives in `config`, which imports
+no pandas / psycopg / litellm at module load, so this runs anywhere Python does.
+
+Run with pytest:      pytest poetry_quality_and_curation/categorization/test_distillation.py
+or standalone:        python poetry_quality_and_curation/categorization/test_distillation.py
+"""
+import io
+import contextlib
+import sys
+from pathlib import Path
+
+# Allow `python path/to/test_distillation.py` (script dir, not repo root, is on
+# sys.path in that mode). pytest / `python -m` don't need this, but it's cheap.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from poetry_quality_and_curation.categorization import config as c
+
+
+# -- caps + required/optional contract --------------------------------------
+
+def test_caps_are_two_per_dimension():
+    for dim in ("mood", "topic", "motif"):
+        assert c.MAX_LABELS_PER_DIM[dim] == 2, f"{dim} cap should be 2"
+    # a hypothetical new dimension also defaults to 2, not the old 4
+    assert c.MAX_LABELS_PER_DIM["___new___"] == 2
+
+
+def test_required_optional_contract():
+    assert c.DIMENSION_MIN_LABELS["mood"] >= 1
+    assert c.DIMENSION_MIN_LABELS["topic"] >= 1
+    assert c.DIMENSION_MIN_LABELS["motif"] == 0  # motif is optional by design
+
+
+def test_ceiling_is_six_total():
+    total = sum(c.MAX_LABELS_PER_DIM[d] for d in ("mood", "topic", "motif"))
+    assert total == 6, "distilled poem should cap at 6 labels total"
+
+
+# -- confidence floor --------------------------------------------------------
+
+def test_confidence_floor_in_range():
+    assert 0 < c.CONFIDENCE_FLOOR <= 100
+
+
+def test_floor_drops_weak_labels():
+    dim_lists = {
+        "mood": ["nostalgia", "amorous"],
+        "topic": ["love", "honor-pride"],
+        "motif": ["desert-ruins", "sword-battle"],
+    }
+    conf = {"nostalgia": 90, "amorous": 50, "love": 90,
+            "honor-pride": 55, "desert-ruins": 92, "sword-battle": 60}
+    out = c.apply_confidence_floor(dim_lists, conf, "nostalgia", floor=65)
+    assert out == {"mood": ["nostalgia"], "topic": ["love"], "motif": ["desert-ruins"]}
+
+
+def test_floor_keeps_mood_primary_even_if_below():
+    out = c.apply_confidence_floor({"mood": ["grief"]}, {"grief": 40}, "grief", floor=65)
+    assert out["mood"] == ["grief"], "mood_primary must survive the floor"
+
+
+def test_floor_keeps_missing_confidence():
+    # a label with no confidence is ambiguous -> kept, not dropped
+    out = c.apply_confidence_floor({"topic": ["love"]}, {}, None, floor=65)
+    assert out["topic"] == ["love"]
+
+
+def test_floor_does_not_mutate_input():
+    dim_lists = {"mood": ["grief", "joy"]}
+    conf = {"grief": 90, "joy": 10}
+    c.apply_confidence_floor(dim_lists, conf, "grief", floor=65)
+    assert dim_lists == {"mood": ["grief", "joy"]}, "input must be untouched"
+
+
+# -- prompt reflects the distillation ---------------------------------------
+
+def test_prompt_mentions_rationale_and_floor():
+    p = c.CLASSIFICATION_PROMPT
+    assert "rationale" in p
+    assert str(c.CONFIDENCE_FLOOR) in p
+
+
+def test_prompt_lists_every_synonym_group_member():
+    p = c.CLASSIFICATION_PROMPT
+    for dim, groups in c.SYNONYM_GROUPS.items():
+        for group in groups:
+            for key in group:
+                assert key in p, f"synonym key {key} missing from prompt"
+
+
+def test_prompt_is_taxonomy_driven():
+    # every vocab key should appear (prompt is built from DIMENSIONS, not hand-typed)
+    p = c.CLASSIFICATION_PROMPT
+    for dim, spec in c.DIMENSIONS.items():
+        for key, _ar, _en in spec["values"]:
+            assert key in p, f"{dim}/{key} missing from prompt"
+
+
+# -- taxonomy + seed consistency --------------------------------------------
+
+def test_validate_taxonomy_passes():
+    c.validate_taxonomy()  # raises on drift
+
+
+def test_versions_bumped():
+    assert c.TAXONOMY_VERSION == "3"
+    assert c.PROMPT_VERSION and isinstance(c.PROMPT_VERSION, str)
+
+
+def test_default_model_is_3_6_flash():
+    assert c.DEFAULT_GEMINI_MODEL.endswith("gemini-3.6-flash")
+
+
+def _seed_text():
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        c.print_seed_sql()
+    return buf.getvalue()
+
+
+def test_seed_covers_full_taxonomy():
+    seed = _seed_text()
+    # 3 dimensions, 44 values, 7 families all present
+    for dim in c.DIMENSIONS:
+        assert f"'{dim}'" in seed
+    n_values = sum(len(s["values"]) for s in c.DIMENSIONS.values())
+    assert n_values == 44
+    for dim, spec in c.DIMENSIONS.items():
+        for key, _ar, _en in spec["values"]:
+            assert f"'{key}'" in seed, f"value {key} missing from seed"
+    assert seed.count("INSERT INTO category_families") == len(c.FAMILIES) == 7
+
+
+def test_seed_sets_min_max_matching_config():
+    seed = _seed_text()
+    for dim in ("mood", "topic", "motif"):
+        line = (f"UPDATE category_dimensions SET "
+                f"min_labels = {c.DIMENSION_MIN_LABELS.get(dim, 0)}, "
+                f"max_labels = {c.MAX_LABELS_PER_DIM[dim]} WHERE key = '{dim}';")
+        assert line in seed, f"seed missing min/max line for {dim}"
+
+
+if __name__ == "__main__":
+    # Standalone runner so this works without pytest installed.
+    fns = [(n, f) for n, f in sorted(globals().items())
+           if n.startswith("test_") and callable(f)]
+    failed = 0
+    for name, fn in fns:
+        try:
+            fn()
+            print(f"  PASS  {name}")
+        except AssertionError as e:
+            failed += 1
+            print(f"  FAIL  {name}: {e}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"  ERROR {name}: {type(e).__name__}: {e}")
+    print(f"\n{'OK' if failed == 0 else 'FAILED'} — {len(fns) - failed}/{len(fns)} passed.")
+    raise SystemExit(1 if failed else 0)

--- a/supabase/migrations/20260727000000_categorization_v3_distillation.sql
+++ b/supabase/migrations/20260727000000_categorization_v3_distillation.sql
@@ -1,0 +1,60 @@
+-- Categorization v3 (distillation) — schema support.
+--
+-- Pairs with the pipeline change in
+--   poetry_quality_and_curation/categorization/config.py        (distilled prompt, caps 2/2/2, floor)
+--   poetry_quality_and_curation/categorization/import_categories.py (confidence floor at import)
+--
+-- This migration is ADDITIVE and safe to apply before or after re-tagging:
+--   * it adds the required-vs-optional contract (min_labels/max_labels) to
+--     category_dimensions, encoding in the DB what previously lived only in the
+--     classifier prompt (mood/topic required >=1, motif optional 0);
+--   * it documents (does NOT drop) the redundant accessibility_level column.
+--
+-- HELD: apply only after user approval. Nothing here rewrites poem_categories or
+-- poems.categories — the distilled re-tag is a separate, approval-gated step
+-- (see poetry_quality_and_curation/categorization/audit/README.md).
+
+-- ============================================================
+-- 1. Required-vs-optional contract on dimensions
+-- ============================================================
+-- cardinality ('single'|'multi') says whether a dimension takes one or many
+-- labels; it does NOT say whether a label is required. That distinction (mood is
+-- required, motif is optional) previously existed only as prose in the prompt,
+-- so 16% of poems legitimately having no motif looked like a coverage bug. These
+-- columns make the contract explicit, machine-checkable, and renderable in the UI
+-- ("motif — optional").
+ALTER TABLE category_dimensions
+  ADD COLUMN IF NOT EXISTS min_labels SMALLINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS max_labels SMALLINT;
+
+-- Mirrors config.DIMENSION_MIN_LABELS / config.MAX_LABELS_PER_DIM. Keep these in
+-- sync with config.py (its --print-seed emits the same UPDATEs). min=0 => the
+-- dimension may be empty (optional); min>=1 => required.
+UPDATE category_dimensions SET min_labels = 1, max_labels = 2 WHERE key = 'mood';
+UPDATE category_dimensions SET min_labels = 1, max_labels = 2 WHERE key = 'topic';
+UPDATE category_dimensions SET min_labels = 0, max_labels = 2 WHERE key = 'motif';
+
+COMMENT ON COLUMN category_dimensions.min_labels IS
+  'Minimum labels a poem must carry in this dimension. 0 = optional (e.g. motif); >=1 = required (mood, topic).';
+COMMENT ON COLUMN category_dimensions.max_labels IS
+  'Maximum labels accepted per poem in this dimension (distillation cap; NULL = unbounded).';
+
+-- ============================================================
+-- 2. accessibility_level — reconciliation (documented, not dropped)
+-- ============================================================
+-- The classifier produces accessibility_level (1-5). In production it is NULL on
+-- every categorized poem, while accessibility_score (REAL, 0-10, higher = harder)
+-- is populated for all of them by the separate quality-curation pipeline. So
+-- accessibility_score is the canonical, queryable facet; accessibility_level is
+-- raw model provenance only.
+--
+-- We deliberately DO NOT drop accessibility_level in this migration:
+--   * import_categories.py still writes it, so dropping the column would break
+--     the importer without a coordinated code change;
+--   * it is harmless (NULL) and cheap to keep as provenance.
+-- If a later cleanup wants it gone, do it together with removing the write in
+-- import_categories.py. For now we just document the intent.
+COMMENT ON COLUMN poems.accessibility_level IS
+  'Raw model 1-5 ease estimate (provenance only; currently unused). Canonical difficulty facet is accessibility_score (0-10). Retained, not dropped — see migration 20260727000000.';
+COMMENT ON COLUMN poems.accessibility_score IS
+  'Canonical difficulty facet, 0-10 (higher = harder), populated by the quality-curation pipeline. Prefer this over accessibility_level.';


### PR DESCRIPTION
## Categorization distillation (v3) — implementation, audit & eval

This PR is the **feature-development record** for the categorization distillation. The v2 taxonomy over-tagged poems (avg **7.59** mood/topic/motif labels each; broad values like "love" on 46% of poems, synonym stacks like grief+melancholy+despair piled together), which made filters barely discriminate. This work distills each poem to the **few sharp labels that capture its core**.

### What distillation changes
- **Caps tightened** 4/4/5 → **mood 2 / topic 2 / motif 2** (ceiling 13 → 6).
- **Dominant-concept prompt**: name the poem's core first, then classify; no marginal tags.
- **No-synonym-stacking rule**: at most one of {melancholy, grief, despair, bittersweet}; at most one of {amorous, passion, yearning}.
- **Confidence floor 65** enforced at import (weak labels dropped).
- **`taxonomy_version = 3` / `prompt_version = distill-1`**; provider-agnostic pipeline unchanged.
- Migration adds `category_dimensions.min_labels/max_labels` (mood 1/2, topic 1/2, motif 0/2) to DB-encode required-vs-optional, and reconciles the dead `accessibility_level` column.

### Results (full corpus, 9,073 poems)
- avg labels/poem **7.59 → 4.41** (−42%); poems with ≥8 labels **62% → 0%**.
- synonym stacks collapsed (passion 24.7%→8.2%, amorous 25.5%→17.4%); broad "love" **46.4% → 38.9%**.
- 0 orphaned/duplicate rows, JSONB matches the table, every poem keeps its primary mood.

### What's in this PR
- Pipeline: `config.py` (distilled prompt + caps + floor + version), `import_categories.py` (floor enforcement), `classify_poems.py`, `classify_new.sh` (auto-classify new inserts).
- Migration: `supabase/migrations/20260727000000_categorization_v3_distillation.sql` (idempotent).
- Audit: `ideas/categorization-audit.md`, `poetry_quality_and_curation/categorization/audit/` (current vs distilled prompts, reproducible SQL, before/after sample), `test_distillation.py` (16 unit tests).
- Spot-check viewer: distillation added as the **v5 · distillation** comparable version in `spotcheck_viewer.{py,html}` so v2 / v4 / distilled tags sit side by side.

### Lineage / status (traceability)
- **Code is already live on `main`** — it shipped via #652 (commits `f6a1552` + `744c6e8`). This PR remains as the distillation feature-dev record and carries the audit/eval artifacts.
- **DB re-tagged to v3 on 2026-07-28** — full-corpus distilled re-classification applied to the shared Supabase DB (verified; pre-change backup retained).
- **Migration tracking:** the schema migration is idempotent and belongs in `supabase/migrations/`; it should be applied/recorded via `supabase db push` on deploy (it was applied directly to unblock the re-tag and will be re-recorded harmlessly by `db push`). Do not apply schema via direct `pg`.
- Base is `claude/poem-categorization-standalone` (not `main`), since `main` already has the code via #652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
