### PR TITLE
feat(tts): passionate recitation prompt + default temp 0.35

### DIFF
--- a/src/prompts.js
+++ b/src/prompts.js
@@ -137,10 +137,10 @@ export const getTTSContent = (poem) => `${TTS_DELIVERY}\n${poem.arabic}`;
 
 /**
  * System instruction for Gemini Live API recitation.
- * Masculine Arabic poet persona — authoritative, audible breaths, heavy delivery.
+ * Passionate Arabic poet persona — authoritative, audible breaths, heavy delivery.
  */
 export const LIVE_SYSTEM_INSTRUCTION =
-  'You are a masculine Arabic speaker, reciting Arabic poetry. You don\'t slow down unnecessarily ' +
+  'You are a passionate Arabic speaker, reciting Arabic poetry. You don\'t slow down unnecessarily ' +
   'and do this with the authority of a poet that is well practiced. It flows, and sounds serious. ' +
   'Even when you read this quicker, you take breaths that are audible. It\'s like you\'re pausing ' +
   'to think about what you\'re going to say, then it comes out heavy and hard.\n\n' +

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -60,7 +60,7 @@ const initialState = {
   ratchetMode: false, // Ratchet Mode: explains poems in Gen Z / gangster slang
   ttsMode: loadTtsMode(), // 'rest' | 'live' — defaults to 'live' (streaming)
   liveVoice: loadLiveVoice(), // selected speaking voice, persisted (default DEFAULT_VOICE)
-  liveTemperature: 0,
+  liveTemperature: 0.35,
   highlightStyle: 'pill', // 'none' | 'glow' | 'underline' | 'pill' | 'focus-blur'
   actionWeight: 'bold', // reader action buttons: 'quiet' | 'balanced' | 'bold' (molten) — visual intensity
   insightsMode: 'inline', // 'inline' = end-of-poem expand | 'drawer' = Vaul InsightOverlay (A/B test)


### PR DESCRIPTION
Brings two listening-experience tweaks from the (now-closed) categorization branch #646 to main, so they aren't lost:

- `prompts.js`: `LIVE_SYSTEM_INSTRUCTION` persona **masculine → passionate** (delivery text otherwise unchanged).
- `uiStore.js`: default `liveTemperature` **0 → 0.35** (expressive but stable).

The third tweak (trim 9 reciters: Fenrir/Umbriel/Gacrux/Sadachbia/Sadaltager/Kore/Erinome/Achird/Schedar) is **already on main** — those are archived in `voices.js` as "poet-curation exclusion" — so no voices change is needed.

Two-line semantic change; ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)