### PR TITLE
feat(tts): default to transcript mora leader

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -86,7 +86,10 @@ import { updateOGMetaTags } from './utils/ogMetaTags.js';
 import { computeWordTimings } from './utils/wordTiming.js';
 import { computeWordTimingsFromAudio } from './utils/audioWordTiming.js';
 import { alignTranscriptTimings } from './utils/alignTranscriptTimings.js';
-import { applyLiveTimingProfile } from './utils/liveTimingProfiles.js';
+import {
+  applyLiveTimingProfile,
+  DEFAULT_LIVE_TIMING_PROFILE,
+} from './utils/liveTimingProfiles.js';
 import {
   useTTSHighlight,
   startPlayer,
@@ -862,7 +865,7 @@ export default function DiwanApp() {
       const aligned = alignTranscriptTimings(allWords, serverWordTimings);
       const transcriptMatchRatio = aligned ? aligned.matchedCount / serverWordTimings.length : 0;
       if (aligned && aligned.matchedCount >= 1 && transcriptMatchRatio >= 0.5) {
-        let timingProfile = 'transcript-moras-weighted-fallback';
+        let timingProfile = DEFAULT_LIVE_TIMING_PROFILE;
         try {
           timingProfile = localStorage.getItem('ttsTimingMode') || timingProfile;
         } catch {

--- a/src/test/liveTimingProfiles.test.js
+++ b/src/test/liveTimingProfiles.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyLiveTimingProfile,
+  DEFAULT_LIVE_TIMING_PROFILE,
   LIVE_TIMING_PROFILE_OPTIONS,
 } from '../utils/liveTimingProfiles.js';
 
@@ -16,9 +17,13 @@ const fallback = [
 ];
 
 describe('live timing profiles', () => {
-  it('exposes the seven retained candidates with the shipped winner first', () => {
-    expect(LIVE_TIMING_PROFILE_OPTIONS).toHaveLength(7);
-    expect(LIVE_TIMING_PROFILE_OPTIONS[0].value).toBe('transcript-moras-weighted-fallback');
+  it('defaults to the held-out transcript-mora leader and exposes its audited result', () => {
+    expect(DEFAULT_LIVE_TIMING_PROFILE).toBe('branch-transcript-moras');
+    expect(LIVE_TIMING_PROFILE_OPTIONS[0]).toMatchObject({
+      value: DEFAULT_LIVE_TIMING_PROFILE,
+      label: 'transcript + moras [64.9% exact word]',
+    });
+    expect(LIVE_TIMING_PROFILE_OPTIONS).toHaveLength(9);
   });
 
   it('keeps the weighted fallback until a transcript-anchored verse has boundaries', () => {
@@ -54,5 +59,16 @@ describe('live timing profiles', () => {
       directMatches: [true, false, true],
     });
     expect(result).toEqual(aligned);
+  });
+
+  it('keeps the global weighted control on its fallback clock', () => {
+    const result = applyLiveTimingProfile({
+      profile: 'weighted',
+      alignedTimings: aligned,
+      fallbackTimings: fallback,
+      wordOffsets: [0],
+      directMatches: [true, true, true],
+    });
+    expect(result).toEqual(fallback);
   });
 });

--- a/src/utils/liveTimingProfiles.js
+++ b/src/utils/liveTimingProfiles.js
@@ -1,37 +1,56 @@
 import { wordMoras } from './verseSyllableWeightedTimings.js';
 
 /**
- * The seven profiles retained from the low-latency word-sync investigation.
- * They all use the same Live transcript anchors and 250 ms visual lag. They
- * differ only in how a measured verse span is divided between its words and
- * what clock remains active before that verse has usable anchors.
+ * The production-safe profiles retained from the low-latency word-sync
+ * investigation. They all use the same Live transcript anchors and 250 ms
+ * visual lag. The selected default is the strongest held-out karaoke result:
+ * 64.9% exact single-word state at audited speech starts.
+ * Profiles differ only in how a measured verse span is divided between its
+ * words and what clock remains active before that verse has usable anchors.
  */
+export const DEFAULT_LIVE_TIMING_PROFILE = 'branch-transcript-moras';
+
 export const LIVE_TIMING_PROFILE_OPTIONS = [
   {
+    value: 'branch-transcript-moras',
+    label: 'transcript + moras [64.9% exact word]',
+    schedule: 'moras',
+  },
+  {
     value: 'transcript-moras-weighted-fallback',
-    label: 'moras + weighted fallback (shipped)',
+    label: 'moras + weighted fallback [56.3% exact word]',
     schedule: 'moras',
     fallback: 'weighted',
   },
   {
+    value: 'transcript-mora-blend-50',
+    label: '50% mora / 50% even [49.8% exact word]',
+    schedule: 'mora-blend',
+    moraBlend: 0.5,
+    requireFullSegment: true,
+  },
+  {
     value: 'transcript-mora-blend-75',
-    label: '75% mora / 25% even',
+    label: '75% mora / 25% even [50.9% exact word]',
     schedule: 'mora-blend',
     moraBlend: 0.75,
     requireFullSegment: true,
   },
-  { value: 'branch-transcript-moras', label: 'transcript + moras', schedule: 'moras' },
-  { value: 'branch-transcript-letters', label: 'transcript + letters', schedule: 'letters' },
+  {
+    value: 'branch-transcript-letters',
+    label: 'transcript + letters [24.1% exact word]',
+    schedule: 'letters',
+  },
   {
     value: 'transcript-mora-blend-25',
-    label: '25% mora / 75% even',
+    label: '25% mora / 75% even [54.2% exact word]',
     schedule: 'mora-blend',
     moraBlend: 0.25,
     requireFullSegment: true,
   },
   {
     value: 'transcript-mora-blend-50-weighted-fallback',
-    label: '50% mora / 50% even + fallback',
+    label: '50% mora / 50% even + fallback [43.6% exact word]',
     schedule: 'mora-blend',
     moraBlend: 0.5,
     fallback: 'weighted',
@@ -39,10 +58,16 @@ export const LIVE_TIMING_PROFILE_OPTIONS = [
   },
   {
     value: 'transcript-mora-final',
-    label: 'moras + final-word reserve',
+    label: 'moras + final-word reserve [37.1% exact word]',
     schedule: 'moras-final',
     finalWeight: 1.25,
     requireFullSegment: true,
+  },
+  {
+    value: 'weighted',
+    label: 'global character-weighted clock [23.5% exact word]',
+    fallback: 'weighted',
+    fallbackOnly: true,
   },
 ];
 
@@ -51,7 +76,7 @@ const PROFILES_BY_VALUE = new Map(
 );
 
 export function liveTimingProfile(value) {
-  return PROFILES_BY_VALUE.get(value) || LIVE_TIMING_PROFILE_OPTIONS[0];
+  return PROFILES_BY_VALUE.get(value) || PROFILES_BY_VALUE.get(DEFAULT_LIVE_TIMING_PROFILE);
 }
 
 /**
@@ -75,6 +100,7 @@ export function applyLiveTimingProfile({
       ...timing,
     })
   );
+  if (profile.fallbackOnly) return output;
   const offsets = Array.isArray(wordOffsets) && wordOffsets.length ? wordOffsets : [0];
 
   for (let verse = 0; verse < offsets.length; verse += 1) {


### PR DESCRIPTION
## What changed

- Defaults new Live recitations to `transcript + moras`, the held-out karaoke leader.
- Labels that Debug Panel option with its audited `64.9% exact word` result.
- Adds the missing raw Mora-50 experiment and explicit global character-weighted control to the Timing Mode selector.
- Keeps existing saved `ttsTimingMode` preferences unchanged.

## Why

The retained evidence ranks transcript + moras above the current shipped fallback for exact single-word highlighting. The additional choices make the comparable controls available for debugging without presenting POC-only VAD-slew or agreement-window algorithms as production-ready.

## Validation

- `npm run test:run -- src/test/liveTimingProfiles.test.js`
- `npm run lint` (passes with pre-existing warnings)
- `npx prettier --check src/utils/liveTimingProfiles.js src/test/liveTimingProfiles.test.js`
- `npm run build`
- `npm run manifest:check`
- `git diff --check`

Repository-wide `npm run format:check` remains red on 45 pre-existing files; this PR adds no formatting drift.