### PR TITLE
docs(categorization): refresh/re-run runbook for v3 distillation

### DIFF
--- a/poetry_quality_and_curation/categorization/README.md
+++ b/poetry_quality_and_curation/categorization/README.md
@@ -88,6 +88,50 @@ labels where it matters most.
 
 ---
 
+## Refreshing the categorization (v3 distillation)
+
+The live corpus (9,073 poems) is tagged under the **distilled v3** rubric — caps
+`mood 2 / topic 2 / motif 2`, confidence floor **65**, dominant-concept + no-synonym-stacking prompt,
+`taxonomy_version=3` / `prompt_version=distill-1`. `config.py` is the single source of truth (prompt,
+caps, floor, version). Re-run when: **new poems** were added, or the **taxonomy/prompt** in `config.py`
+changed (bump `TAXONOMY_VERSION`).
+
+```bash
+# 0. Prereqs: GEMINI_API_KEY + DATABASE_URL in .env. The v3 corpus was tagged with
+#    gemini-3.6-flash via the app's proxy. ALWAYS BACK UP FIRST (SELECT dump of
+#    poem_categories + the poems categorization columns) — the merge is destructive.
+
+# 1. Only-new poems (the common case — cheap, safe):
+bash poetry_quality_and_curation/categorization/classify_new.sh   # wraps --scope unclassified
+#    ^ NOT yet on a schedule; run it after bulk inserts (e.g. a newly added poem needs this).
+
+# 2. Full re-tag (taxonomy/prompt changed): classify --scope all, then import.
+python -m poetry_quality_and_curation.categorization.classify_poems \
+    --model gemini/gemini-3.6-flash --scope all --concurrency 6 --max-cost 20 --resume
+python -m poetry_quality_and_curation.categorization.import_categories \
+    --input data/categories_gemini_gemini-3.6-flash.parquet   # enforces floor 65 + caps
+
+# 3. Verify: coverage ~100%, avg labels/poem ~4.4, no orphan/dup poem_categories rows,
+#    JSONB matches the join table. (SQL spot-checks; every poem must keep >=1 mood + >=1 topic.)
+```
+
+**Gemini spend-cap gotcha (learned the hard way):** the proxy 429s a "monthly spending cap"; keep
+`--concurrency` low (~6, not 24 — 24 drained the budget mid-run). The run is **checkpoint-resumable**,
+so on a 429 raise the cap at https://ai.studio/spend and re-run the same command — done poems are skipped.
+
+**Migration tracking:** apply schema migrations with `supabase db push` (records them in
+`schema_migrations`). If one was ever applied via direct `pg`/`psql` and shows unrecorded in
+`supabase migration list --db-url "$DATABASE_URL"`, reconcile the ledger **without re-running** via
+`supabase migration repair --status applied <version...> --db-url "$DATABASE_URL"` (migrations are
+idempotent, so this is safe). Never leave a migration applied-but-unrecorded.
+
+**Motif gaps are expected:** ~23% of poems correctly have **no motif** (it's optional; abstract/wisdom
+poems have no concrete image). Do NOT "fix" this with a raw model pass — a stronger model over-reads
+metaphor as imagery and re-adds noise. Genuine motif recovery needs a tighter, metaphor-excluding rubric
+plus human spot-review.
+
+---
+
 ## Consuming it (already wired into the API)
 
 `server.js` gained two **backward-compatible** endpoints (they return empty


### PR DESCRIPTION
## Categorization distillation (v3) — record + refresh runbook

This is the **canonical record** of the categorization distillation (it supersedes the working
PR #649, whose code already shipped to `main` via #652). The file change here is the refresh
runbook; the sections below document the whole feature so the record lives in one place.

### The problem
v2 over-tagged: avg **7.59** mood/topic/motif labels per poem, "love" on **46%** of poems, synonym
stacks (grief+melancholy+despair piled together) — so filters barely discriminated.

### What distillation changed
- Caps **4/4/5 → mood 2 / topic 2 / motif 2** (ceiling 13 → 6).
- **Dominant-concept** prompt + **no-synonym-stacking** rule (≤1 of {melancholy,grief,despair,bittersweet}; ≤1 of {amorous,passion,yearning}).
- **Confidence floor 65** enforced at import.
- `taxonomy_version=3` / `prompt_version=distill-1`. Migration adds `category_dimensions.min_labels/max_labels` (mood 1/2, topic 1/2, motif 0/2) + reconciles the dead `accessibility_level` column.

### Results (full corpus, 9,073 poems — live in the DB)
- avg labels/poem **7.59 → 4.41** (−42%); poems with ≥8 labels **62% → 0%**.
- synonym stacks collapsed (passion 24.7%→8.2%, amorous 25.5%→17.4%); broad "love" **46.4% → 38.9%**.
- 0 orphaned/duplicate rows, JSONB matches the join table, every poem keeps its primary mood.
- Gap-fill: 2 no-topic poems fixed; **~23% correctly have no motif** (optional dimension — not forced).

### Where it all lives now
- **Code on `main` via #652**: distilled `config.py` + `import_categories.py` (floor) + `classify_poems.py` + `classify_new.sh`, the v3 migration, `test_distillation.py`, the audit (`ideas/categorization-audit.md`, `categorization/audit/`), and the spot-check viewer's **v5 · distillation** comparison column.
- **DB re-tagged to v3 on 2026-07-28** (shared Supabase corpus; pre-change backups retained).
- **Migration tracking reconciled 2026-07-31**: the v3 migration (and the two other applied-but-unrecorded categorization migrations) were recorded in `schema_migrations` via `supabase migration repair --status applied` (records without re-running — they're idempotent + already applied). Ledger now matches reality. Going forward, apply schema via `supabase db push`, never direct `pg`.

### This PR's change
Adds the **"Refreshing the categorization (v3 distillation)"** runbook to
`poetry_quality_and_curation/categorization/README.md`: when/how to re-run (`classify_new.sh` for new
inserts; full `--scope all` re-tag on taxonomy/prompt change), the **spend-cap concurrency gotcha**
(keep it low ~6, it's checkpoint-resumable — raise the cap and rerun on 429), verification counts, the
`supabase migration repair` reconcile recipe, and why motif gaps are expected (don't force them).
Docs-only; single file.

Closes the loop on #649 (that PR can be closed — its content is on `main`; this is the record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
