### PR TITLE
fix(dev): allow backend in lab CSP connect-src (proxied /enjoyability + /tts-lab)

### DIFF
--- a/server.js
+++ b/server.js
@@ -1702,7 +1702,7 @@ async function designTablesExist() {
 app.get('/tts-lab', (_req, res) => {
   res.setHeader(
     'Content-Security-Policy',
-    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'; media-src blob:"
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://poetry-bil-araby-2mb0.onrender.com; media-src blob:"
   );
   res.type('html').send(loadLabHtml());
 });
@@ -1715,7 +1715,7 @@ app.get('/enjoyability', (_req, res) => {
   if (!process.env.ENABLE_DEV_LAB) return res.status(404).send('Not found');
   res.setHeader(
     'Content-Security-Policy',
-    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'; media-src blob:"
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://poetry-bil-araby-2mb0.onrender.com; media-src blob:"
   );
   res.type('html').send(loadEnjoyabilityHtml());
 });


### PR DESCRIPTION
Follow-up to the app-domain proxy: the proxied lab pages (origin `vercel.app`) call the Render backend cross-origin, but the routes set `connect-src 'self'`, which blocked every API call (`Refused to connect … violates connect-src 'self'`). Add the backend origin to `connect-src` on both `/enjoyability` and `/tts-lab`. Direct/same-origin serving unaffected.

Confirmed the exact violation in the browser console; CORS was already fine (backend returns the ACAO header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)