### PR TITLE
fix(tour): don't mount the walkthrough on full-screen routes

### DIFF
--- a/feature-manifest.json
+++ b/feature-manifest.json
@@ -630,16 +630,18 @@
       "userFacing": "Bespoke on-brand walkthrough that spotlights nav elements; launchable via ?tour=1; resumes and adapts to the redesigned reader.",
       "entrypoints": [
         "src/components/tour/SpotlightTour.jsx",
-        "src/components/tour/TourLauncher.jsx"
+        "src/components/tour/TourLauncher.jsx",
+        "src/constants/routes.js",
+        "src/hooks/useIsFullScreenRoute.js"
       ],
       "endpoints": [],
       "tests": {
-        "unit": [],
+        "unit": ["src/test/fullscreen-route-gate.test.jsx"],
         "e2e": ["e2e/tour.spec.js"]
       },
       "deviceOnly": false,
       "coverage": "mocked",
-      "gap": "#582/#602. e2e exercises step flow; conditional-step + resume-lifecycle branches only partly asserted."
+      "gap": "#582/#602. e2e exercises step flow; conditional-step + resume-lifecycle branches only partly asserted. Unit test covers the full-screen-route mount gate only."
     },
     {
       "id": "enjoyability-lab",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -86,10 +86,7 @@ import { updateOGMetaTags } from './utils/ogMetaTags.js';
 import { computeWordTimings } from './utils/wordTiming.js';
 import { computeWordTimingsFromAudio } from './utils/audioWordTiming.js';
 import { alignTranscriptTimings } from './utils/alignTranscriptTimings.js';
-import {
-  applyLiveTimingProfile,
-  DEFAULT_LIVE_TIMING_PROFILE,
-} from './utils/liveTimingProfiles.js';
+import { applyLiveTimingProfile, DEFAULT_LIVE_TIMING_PROFILE } from './utils/liveTimingProfiles.js';
 import {
   useTTSHighlight,
   startPlayer,
@@ -100,6 +97,7 @@ import {
   applyHighlightsOnce,
 } from './hooks/useTTSHighlight.js';
 import { useIdleTimer } from './hooks/useIdleTimer.js';
+import { useIsFullScreenRoute } from './hooks/useIsFullScreenRoute.js';
 import DebugPanel from './components/DebugPanel.jsx';
 import MysticalConsultationEffect from './components/MysticalConsultationEffect.jsx';
 import SquoctogonBackground from './components/SquoctogonBackground.jsx';
@@ -282,6 +280,9 @@ export default function DiwanApp() {
   const setShowSavedPoems = useModalStore((s) => s.setSavedPoemsOpen);
   const showSplash = useModalStore((s) => s.splash);
   const showOnboarding = useModalStore((s) => s.onboarding);
+  // True on routes that own the whole viewport (see src/constants/routes.js).
+  // Reader-scoped floating chrome must stay unmounted while one is active.
+  const isFullScreenRoute = useIsFullScreenRoute();
   const showTranslation = useUIStore((s) => s.showTranslation);
   const setShowTranslation = useUIStore((s) => s.setShowTranslation);
   const textSizeLevel = useUIStore((s) => s.textSize);
@@ -2217,10 +2218,12 @@ export default function DiwanApp() {
         )}
       </AnimatePresence>
 
-      {/* Interactive walkthrough launcher — only once the splash is dismissed.
-          Disabled (FEATURES.tour = false) until the tour steps are re-wired to the
-          redesigned reader nav; the code is kept so the follow-up can re-enable it. */}
-      {FEATURES.tour && !showSplash && (
+      {/* Interactive walkthrough launcher — reader-scoped, so it mounts only once the
+          splash is dismissed AND no full-screen route is active. The spotlight paints at
+          z-index 9999, well above every route surface, so mounting it on a routed
+          full-screen view (e.g. /explore) buries that view under the tour. The route list
+          lives in src/constants/routes.js so new full-screen routes are covered there. */}
+      {FEATURES.tour && !showSplash && !isFullScreenRoute && (
         <TourLauncher user={user} savedCount={savedPoems.length} onDemoRecite={togglePlay} />
       )}
 

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,0 +1,30 @@
+/**
+ * Routes that take over the whole viewport.
+ *
+ * These render *instead of* the reader, not on top of it, so any reader-scoped
+ * chrome that floats above the page (the guided walkthrough, coachmarks, and
+ * anything else that paints a full-screen scrim) must not mount while one is
+ * active. The walkthrough in particular paints at z-index 9999, far above every
+ * route surface, so without a gate it swallows the whole screen.
+ *
+ * Add a new full-screen route here the moment you add it to the router. Keeping
+ * the list in one place is the point: the alternative — a hardcoded
+ * `&& !isSomeRoute` at each floating-chrome mount — silently regresses every
+ * time someone adds a route and forgets to update all the call sites.
+ */
+export const FULL_SCREEN_ROUTES = [
+  '/explore', // Category Explorer (FEATURES.categoryExplorer)
+  '/onboarding', // Kinetic onboarding pickers (FEATURES.onboarding)
+];
+
+/**
+ * True when `pathname` is a full-screen route, or nested beneath one
+ * (so a future `/explore/:slug` detail view is covered without another edit).
+ *
+ * @param {string} [pathname] - Location pathname, e.g. `/explore`
+ * @returns {boolean}
+ */
+export function isFullScreenPath(pathname) {
+  if (typeof pathname !== 'string' || pathname === '') return false;
+  return FULL_SCREEN_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`));
+}

--- a/src/hooks/useIsFullScreenRoute.js
+++ b/src/hooks/useIsFullScreenRoute.js
@@ -1,0 +1,16 @@
+import { useLocation } from 'wouter';
+import { isFullScreenPath } from '../constants/routes.js';
+
+/**
+ * True while a full-screen route (see `FULL_SCREEN_ROUTES`) is active.
+ *
+ * Use it to suppress reader-scoped floating chrome — the guided walkthrough and
+ * anything else that paints over the whole viewport — so a routed full-screen
+ * view isn't buried under it.
+ *
+ * @returns {boolean}
+ */
+export function useIsFullScreenRoute() {
+  const [location] = useLocation();
+  return isFullScreenPath(location);
+}

--- a/src/test/fullscreen-route-gate.test.jsx
+++ b/src/test/fullscreen-route-gate.test.jsx
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { Router } from 'wouter';
+import { memoryLocation } from 'wouter/memory-location';
+import { FULL_SCREEN_ROUTES, isFullScreenPath } from '../constants/routes.js';
+import { useIsFullScreenRoute } from '../hooks/useIsFullScreenRoute.js';
+
+/**
+ * Full-screen route gate.
+ *
+ * The guided walkthrough paints a scrim at z-index 9999 — above every route
+ * surface in the app. Mounting it while a routed full-screen view is active
+ * (e.g. /explore) buries that view: the user lands on the route and sees the
+ * tour instead. These tests pin both halves of the fix — the predicate, and the
+ * gate actually being wired into the TourLauncher mount.
+ */
+
+const appSource = readFileSync(path.join(process.cwd(), 'src/app.jsx'), 'utf8');
+
+const renderAt = (path) =>
+  renderHook(() => useIsFullScreenRoute(), {
+    wrapper: ({ children }) => <Router hook={memoryLocation({ path }).hook}>{children}</Router>,
+  });
+
+describe('isFullScreenPath', () => {
+  it.each(FULL_SCREEN_ROUTES)('matches the declared route %s', (route) => {
+    expect(isFullScreenPath(route)).toBe(true);
+  });
+
+  it.each(FULL_SCREEN_ROUTES)('matches paths nested under %s', (route) => {
+    expect(isFullScreenPath(`${route}/some-detail-view`)).toBe(true);
+  });
+
+  it('does not match the reader routes the tour belongs on', () => {
+    expect(isFullScreenPath('/')).toBe(false);
+    expect(isFullScreenPath('/poem/12345')).toBe(false);
+  });
+
+  it('does not match a route that merely shares a prefix', () => {
+    // `/explorer` is a different route from `/explore` — no accidental capture.
+    expect(isFullScreenPath('/explorez')).toBe(false);
+    expect(isFullScreenPath('/exploration')).toBe(false);
+  });
+
+  it('is safe on missing / non-string input', () => {
+    expect(isFullScreenPath(undefined)).toBe(false);
+    expect(isFullScreenPath('')).toBe(false);
+    expect(isFullScreenPath(null)).toBe(false);
+  });
+});
+
+describe('useIsFullScreenRoute', () => {
+  it('is true on a full-screen route', () => {
+    expect(renderAt('/explore').result.current).toBe(true);
+  });
+
+  it('is false on the reader', () => {
+    expect(renderAt('/').result.current).toBe(false);
+    expect(renderAt('/poem/12345').result.current).toBe(false);
+  });
+});
+
+describe('TourLauncher mount gate', () => {
+  it('gates the walkthrough on !isFullScreenRoute', () => {
+    // Regression guard for the overlay-covers-the-route bug. A hardcoded
+    // `!isExploreRoute` here would pass a route-specific test but regress the
+    // next time a full-screen route is added, so assert on the derived boolean.
+    expect(appSource).toMatch(/\{FEATURES\.tour &&[^}]*!isFullScreenRoute[^}]*&& \(/);
+  });
+
+  it('derives that boolean from the shared hook', () => {
+    expect(appSource).toContain('const isFullScreenRoute = useIsFullScreenRoute();');
+  });
+});


### PR DESCRIPTION
## The bug

`TourLauncher` mounted on every route once the splash was dismissed:

```jsx
{FEATURES.tour && !showSplash && (
```

`SpotlightTour.jsx` paints its scrim at `z-index: 9999`, far above every route surface. So landing on `/explore` buried the Category Explorer under the tour.

Confirmed by hit-testing the explorer's taxonomy tab before the fix — the element on top was the tour scrim, not the tab:

```
{"tag":"DIV","cls":"absolute inset-0","z":"9999"}
```

Not a visual-only issue: the explorer was unreachable.

## The fix

Gate the mount on a derived `isFullScreenRoute`, not a hardcoded `!isExploreRoute`.

A per-route check fixes today and regresses the next time someone adds a full-screen route and forgets this call site. The pending `/onboarding` pickers (z-index 60) would hit it immediately. So:

- `src/constants/routes.js` declares `FULL_SCREEN_ROUTES` plus an `isFullScreenPath()` predicate. Adding a route is a one-line edit in one place.
- `src/hooks/useIsFullScreenRoute.js` derives the boolean from wouter's location.
- Nested paths are covered too, so a future `/explore/:slug` needs no further edit.
- `/onboarding` is listed pre-emptively (no-op today) so that branch lands clean.

Also rewrote the comment above the mount. It claimed the tour was disabled via `FEATURES.tour = false`; `src/constants/features.js` has had `tour: true` since the steps were re-wired to the redesigned reader nav.

`FEATURES.tour` is unchanged and `SpotlightTour.jsx` is untouched. The overlay's z-index is correct *for the reader* — the bug was where it mounted.

## Verification

| Route | Before | After |
| --- | --- | --- |
| `/explore` | tour scrim on top, explorer unreachable | 0 elements at `z-index: 9999`, explorer tabs receive clicks |
| `/` | tour shows | tour shows, advances to step 2 (Listen spotlight) |
| `/poem/:id` | tour shows | tour shows, resumes at persisted step |

Checked in a real browser with `?tour=1` (the launcher self-suppresses under `navigator.webdriver`, so the opt-in is required for automated repro).

## Tests

`src/test/fullscreen-route-gate.test.jsx` (11 tests): the predicate (declared routes, nested paths, reader routes, prefix collisions like `/exploration`, non-string input), the hook under a memory router, and a regression guard asserting the mount is gated on the *derived* boolean rather than a route-specific one.

## Gates

- `npm run lint` — 0 errors
- `npm run test:run` — 787 passed; only the 5 pre-existing `utils-extracted.test.js` failures (unguarded `localStorage.clear()`, present on clean `main`)
- `npm run manifest:check` — exit 0
- `npm run build` — clean

`docs/APP-STATE.md` deliberately left untouched; per its own header the reconcile bot regenerates it once changes land on `main`.

## Note on diff scope

The pre-commit prettier hook collapsed one pre-existing multi-line import at `src/app.jsx:86` (`liveTimingProfiles.js`). Unrelated to this change, but left in rather than bypassing the repo's hook — it's deterministic, so a concurrent branch's hook produces the identical hunk.