### PR TITLE
fix(dev): stop the watch-ignore glob from disabling HMR in this repo

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -102,7 +102,15 @@ export default defineConfig({
   ],
   server: {
     watch: {
-      ignored: ['**/poetry-*/**'],
+      // Match the specific sibling checkouts below, NOT a bare `poetry-*` glob.
+      // `**/poetry-*/**` also matches this repo's own path
+      // (…/github/poetry-bil-araby/…), which silently disabled HMR for every
+      // git worktree under the project directory.
+      ignored: [
+        '**/poetry-innovative-*/**',
+        '**/poetry-splash-ci-fixes/**',
+        '**/poetry-database/**',
+      ],
     },
     fs: {
       deny: ['poetry-innovative-78ab', 'poetry-innovative-c0cf', 'poetry-splash-ci-fixes', 'poetry-database'],


### PR DESCRIPTION
## The bug

`vite.config.js` had:

```js
server: {
  watch: { ignored: ['**/poetry-*/**'] },
  fs: { deny: ['poetry-innovative-78ab', 'poetry-innovative-c0cf', 'poetry-splash-ci-fixes', 'poetry-database'] },
}
```

The intent is clear from `fs.deny`: skip those four sibling checkouts. But `poetry-*` also matches **`poetry-bil-araby`**, so the glob matched this repository's own path and silently turned off file watching.

Most visible inside git worktrees under the project directory — several agent sessions lost real time to "my edit isn't taking effect" before someone traced it here.

## The fix

Narrowed the patterns to the directories `fs.deny` already names. Verified with picomatch:

| path | before | after |
|---|---|---|
| `…/poetry-bil-araby/src/app.jsx` | **IGNORED** | watched |
| `…/poetry-database/dump.sql` | IGNORED | IGNORED |
| `…/poetry-innovative-78ab/a.js` | IGNORED | IGNORED |

`npm run build` passes. Dev-server config only — no runtime or bundle impact.