### PR TITLE
feat(onboarding): sync preferences to the account so they follow the reader

### DIFF
--- a/docs/APP-STATE.md
+++ b/docs/APP-STATE.md
@@ -74,7 +74,7 @@ _The Manifest Auto-Reconcile bot regenerates this block and commits it via a PR 
 - **Features tracked:** 41
 - **HTTP endpoints in code:** 37
 - **Components in code:** 42
-- **Test files in code:** 65
+- **Test files in code:** 66
 - **Behavioral coverage:** 8/41 (20%)
 
 | Tier | Features |
@@ -97,7 +97,7 @@ _The Manifest Auto-Reconcile bot regenerates this block and commits it via a PR 
 | Feature | Tier | Coverage | Device-only | Gap |
 |---------|------|----------|-------------|-----|
 | `poem-categorization` | important | mocked | - | server.test.js covers the enabled/disabled API paths with a mocked pool; no e2e yet for the Explore Poems UI (filter chips, in-place poem expand). |
-| `onboarding-preferences` | nice | behavioral | - | Unit tests cover band derivation against a real measured histogram (era grouping, NULL-century handling, quantile difficulty cuts), the categoryTags adapter, stepping all five steps to completion, mood ordering, and the empty pre-migration state. No e2e yet for the rendered flow. |
+| `onboarding-preferences` | nice | behavioral | - | Unit tests cover band derivation against a real measured histogram (era grouping, NULL-century handling, quantile difficulty cuts), the categoryTags adapter, stepping all five steps to completion, mood ordering, and the empty pre-migration state. Cross-device sync is unit-tested in both merge directions, plus write-through, read-back and version mismatch, against a stubbed Supabase client. No e2e yet for the rendered flow, and nothing exercises the JSONB column against a real Postgres row. |
 | `taxonomy-tag-ui` | nice | none | - | No automated coverage. Components are ported but unmounted; add tests when a surface routes to them. |
 | `poem-display` | critical | behavioral | - | Arabic font rendering (Amiri/Tajawal) differs prod vs CI; no visual regression. |
 | `discover-random` | critical | mocked | - | e2e routes /api/** to canned JSON; real server SERVING filters + exclude fallback only covered by server.test.js in isolation. |

--- a/feature-manifest.json
+++ b/feature-manifest.json
@@ -39,7 +39,7 @@
       "id": "onboarding-preferences",
       "name": "Onboarding preference flow (5 steps)",
       "tier": "nice",
-      "userFacing": "Full-screen five-step flow at /onboarding: family, mood, motif (optional), era, difficulty. Every option, bilingual label and poem count is read from the live categorization API; the era and difficulty bands are cut from the LIVE DISTRIBUTION (GET /api/categories -> distributions) rather than hardcoded. Answers save to localStorage.onboardingPrefs and are re-editable through PreferencesDrawer. They bias the feed as a weight, never a filter (see feed-preference-weighting). Salvaged from PR #517's visual work and rebuilt against the shipped taxonomy.",
+      "userFacing": "Full-screen five-step flow at /onboarding: family, mood, motif (optional), era, difficulty. Every option, bilingual label and poem count is read from the live categorization API; the era and difficulty bands are cut from the LIVE DISTRIBUTION (GET /api/categories -> distributions) rather than hardcoded. Answers save to localStorage.onboardingPrefs and are re-editable through PreferencesDrawer. Signed in, they also mirror to user_settings.onboarding_preferences (versioned JSONB) so they follow the reader across devices; on sign-in the two sides are reconciled whole by most-recent completedAt, and a payload whose version this build does not recognise is left untouched on both sides. They bias the feed as a weight, never a filter (see feed-preference-weighting). Salvaged from PR #517's visual work and rebuilt against the shipped taxonomy.",
       "entrypoints": [
         "src/components/onboarding/OnboardingFlow.jsx",
         "src/components/onboarding/PreferenceStep.jsx",
@@ -47,16 +47,21 @@
         "src/services/categoryBands.js",
         "src/services/preferences.js",
         "src/services/categoryTags.js",
-        "src/constants/eras.js"
+        "src/constants/eras.js",
+        "src/hooks/useOnboardingPrefs.js"
       ],
       "endpoints": ["GET /api/categories"],
       "tests": {
-        "unit": ["src/test/onboarding-preferences.test.jsx", "src/test/categoryBands.test.js"],
+        "unit": [
+          "src/test/onboarding-preferences.test.jsx",
+          "src/test/categoryBands.test.js",
+          "src/test/onboarding-prefs-sync.test.jsx"
+        ],
         "e2e": []
       },
       "deviceOnly": false,
       "coverage": "behavioral",
-      "gap": "Unit tests cover band derivation against a real measured histogram (era grouping, NULL-century handling, quantile difficulty cuts), the categoryTags adapter, stepping all five steps to completion, mood ordering, and the empty pre-migration state. No e2e yet for the rendered flow."
+      "gap": "Unit tests cover band derivation against a real measured histogram (era grouping, NULL-century handling, quantile difficulty cuts), the categoryTags adapter, stepping all five steps to completion, mood ordering, and the empty pre-migration state. Cross-device sync is unit-tested in both merge directions, plus write-through, read-back and version mismatch, against a stubbed Supabase client. No e2e yet for the rendered flow, and nothing exercises the JSONB column against a real Postgres row."
     },
     {
       "id": "taxonomy-tag-ui",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -25,6 +25,7 @@ import {
   useDownvotes,
   usePoemEvents,
 } from './hooks/useAuth';
+import { useOnboardingPrefs } from './hooks/useOnboardingPrefs';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useQueryParams } from './hooks/useQueryParams';
 import { useVolumeDetection, PulseGlowBars } from './hooks/useVolumeDetection.jsx';
@@ -279,6 +280,9 @@ export default function DiwanApp() {
   // Auth state
   const { user, loading: authLoading, signInWithGoogle, signInWithApple, signOut } = useAuth();
   const { settings, saveSettings } = useUserSettings(user);
+  // Reconciles the onboarding answers with the account on sign-in, and gives the
+  // flow a write-through on completion. Inert while signed out.
+  const { persist: persistOnboardingPrefs } = useOnboardingPrefs(user);
   const { savedPoems, savePoem, unsavePoem, isPoemSaved } = useSavedPoems(user);
   const { downvotedPoemIds, downvotePoem, undownvotePoem, isPoemDownvoted } = useDownvotes(user);
   const { emitEvent } = usePoemEvents(user);
@@ -2200,7 +2204,17 @@ export default function DiwanApp() {
           of the default boot path (the app boots straight into the feed). */}
       {FEATURES.onboardingPrefs && isOnboardingRoute && (
         <Suspense fallback={null}>
-          <OnboardingFlow key="onboarding-flow" onComplete={() => navigate('/')} />
+          <OnboardingFlow
+            key="onboarding-flow"
+            onComplete={(prefs) => {
+              // OnboardingFlow has already written localStorage; this mirrors the
+              // answers to the account when signed in and is a no-op when not.
+              // Not awaited — the reader should not wait on a network round-trip
+              // to leave the last step.
+              persistOnboardingPrefs(prefs);
+              navigate('/');
+            }}
+          />
         </Suspense>
       )}
 

--- a/src/hooks/useOnboardingPrefs.js
+++ b/src/hooks/useOnboardingPrefs.js
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { supabase, isSupabaseConfigured } from '../supabaseClient';
+import {
+  readPrefs,
+  writePrefs,
+  mergePrefs,
+  sanitizePrefs,
+  hasForeignPrefs,
+} from '../services/preferences.js';
+
+const log = {
+  info: (msg, data) => console.info('[Auth:Prefs]', msg, data ?? ''),
+  error: (msg, data) => console.error('[Auth:Prefs]', msg, data ?? ''),
+};
+
+/**
+ * useOnboardingPrefs — makes the five onboarding answers follow a signed-in
+ * reader across devices.
+ *
+ * SHAPE OF THE SYNC. localStorage stays the single source of truth for READS.
+ * The feed reads answers on every draw, synchronously, inside
+ * stores/actions/fetchPoem.js — deliberately outside the await so a reader who
+ * skipped onboarding reaches the fetch on the same microtask tick as before the
+ * weighting existed. Making that read async to consult the account would reorder
+ * it against the other requests a poet switch fires. So the account is a MIRROR:
+ * on login we reconcile and write the winner back into localStorage, and every
+ * later read is the same synchronous localStorage read it has always been.
+ *
+ * SIGNED OUT, THE FILE IS INERT. Every path below returns early when there is no
+ * user or Supabase is unconfigured, and `persist` still writes localStorage in
+ * that case — which OnboardingFlow has already done for itself by the time it
+ * calls onComplete. Nothing about the signed-out flow changes.
+ *
+ * It reads user_settings directly rather than going through useUserSettings.
+ * That hook cannot distinguish "row not loaded yet" from "user has no row" —
+ * `settings` is null for both, and its `loading` never resets to true when the
+ * user changes — and a merge that mistakes "still loading" for "the account has
+ * nothing" would push this device's answers over the account's. The two hooks
+ * write disjoint columns of the same row through ON CONFLICT upserts, so their
+ * writes compose rather than race.
+ *
+ * @param {Object|null} user Supabase auth user
+ */
+export function useOnboardingPrefs(user) {
+  const [syncing, setSyncing] = useState(false);
+  // Which user id we have already reconciled, so a re-render or an unrelated
+  // auth event does not re-run the merge and re-write storage.
+  const reconciledFor = useRef(null);
+
+  const writeRemote = useCallback(async (userId, prefs) => {
+    const { error } = await supabase
+      .from('user_settings')
+      .upsert({ user_id: userId, onboarding_preferences: prefs }, { onConflict: 'user_id' });
+    if (error) {
+      log.error('Failed to save preferences to account', error.message);
+      return { error };
+    }
+    log.info('Preferences saved to account');
+    return {};
+  }, []);
+
+  /**
+   * Persist a completed set of answers. Called by OnboardingFlow's onComplete.
+   * localStorage first and unconditionally — the account write is best-effort and
+   * must never be able to lose the answers a reader just gave.
+   */
+  const persist = useCallback(
+    async (prefs) => {
+      const { prefs: clean } = sanitizePrefs(prefs);
+      writePrefs(clean);
+      if (!user || !isSupabaseConfigured()) return {};
+      return writeRemote(user.id, clean);
+    },
+    [user, writeRemote]
+  );
+
+  useEffect(() => {
+    if (!user || !isSupabaseConfigured()) {
+      reconciledFor.current = null;
+      return undefined;
+    }
+    if (reconciledFor.current === user.id) return undefined;
+    reconciledFor.current = user.id;
+
+    let cancelled = false;
+
+    const reconcile = async () => {
+      setSyncing(true);
+      try {
+        const { data, error } = await supabase
+          .from('user_settings')
+          .select('onboarding_preferences')
+          .eq('user_id', user.id)
+          .single();
+
+        // PGRST116 = no row yet. That is a normal new user, not a failure.
+        if (error && error.code !== 'PGRST116') {
+          log.error('Failed to load preferences from account', error.message);
+          return;
+        }
+        if (cancelled) return;
+
+        // A payload this build cannot interpret (a newer client wrote it) is left
+        // strictly alone in BOTH directions: we neither adopt it nor overwrite it.
+        // Whichever client understands it still owns it.
+        const remoteRaw = data?.onboarding_preferences ?? null;
+        const { prefs: remote, versionMismatch: remoteForeign } = sanitizePrefs(remoteRaw);
+        const localForeign = hasForeignPrefs();
+        if (remoteForeign || localForeign) {
+          log.info('Preference version mismatch — leaving both sides untouched', {
+            remote: remoteForeign,
+            local: localForeign,
+          });
+          return;
+        }
+
+        const local = readPrefs();
+        const { winner, source } = mergePrefs(local, remoteRaw ? remote : null);
+        if (source === 'neither') {
+          log.info('No preferences on either side');
+          return;
+        }
+
+        log.info(`Preferences reconciled — ${source} wins`, { completedAt: winner.completedAt });
+
+        if (source === 'remote') {
+          // Bring the device up to date so the next synchronous feed read sees it.
+          writePrefs(winner);
+        } else if (JSON.stringify(remoteRaw) !== JSON.stringify(winner)) {
+          await writeRemote(user.id, winner);
+        }
+      } catch (err) {
+        log.error('Exception reconciling preferences', err?.message);
+      } finally {
+        if (!cancelled) setSyncing(false);
+      }
+    };
+
+    reconcile();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, writeRemote]);
+
+  return { persist, syncing };
+}
+
+export default useOnboardingPrefs;

--- a/src/services/preferences.js
+++ b/src/services/preferences.js
@@ -34,16 +34,71 @@ export const EMPTY_PREFS = {
   completedAt: null,
 };
 
+/**
+ * Coerce an arbitrary parsed object into a prefs object this build can use.
+ *
+ * Version mismatches return EMPTY_PREFS rather than throwing or half-applying:
+ *
+ *   version < 2  Written by the pre-taxonomy build. Those key lists were
+ *                authored against a schema that never shipped and are wrong in
+ *                almost every entry (`anger`, `wonder`, `sea` and `praise` do
+ *                not exist as taxonomy keys). The shape would survive a spread
+ *                but the CONTENT is garbage — it would weight the feed toward
+ *                keys that match no poem. Discarding is the honest read.
+ *
+ *   version > 2  Written by a newer client (another tab, another device that
+ *                already shipped the next flow). We cannot know what its fields
+ *                mean, so we do not guess. Note the caller must not WRITE over
+ *                such a payload either; see readPrefs.
+ *
+ * In both cases the reader gets an unbiased feed — `hasPreferences` is false for
+ * EMPTY_PREFS — which is the same degradation as a reader who skipped onboarding.
+ *
+ * @param {unknown} parsed
+ * @returns {{prefs: Object, versionMismatch: boolean}}
+ */
+export const sanitizePrefs = (parsed) => {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { prefs: { ...EMPTY_PREFS }, versionMismatch: false };
+  }
+  // A missing version is treated as version 1: the only build that ever wrote
+  // an unversioned object is the pre-taxonomy one.
+  const version = typeof parsed.version === 'number' ? parsed.version : 1;
+  if (version !== PREFS_VERSION) {
+    return { prefs: { ...EMPTY_PREFS }, versionMismatch: true };
+  }
+  return {
+    prefs: {
+      ...EMPTY_PREFS,
+      ...parsed,
+      version: PREFS_VERSION,
+      moods: Array.isArray(parsed.moods) ? parsed.moods : [],
+      motifs: Array.isArray(parsed.motifs) ? parsed.motifs : [],
+      completedAt: typeof parsed.completedAt === 'string' ? parsed.completedAt : null,
+    },
+    versionMismatch: false,
+  };
+};
+
+/**
+ * True when storage holds a payload this build refuses to interpret. The sync
+ * layer uses it to stay hands-off: a newer client's answers must not be
+ * overwritten by this build's empty ones.
+ */
+export const hasForeignPrefs = () => {
+  try {
+    const raw = globalThis.localStorage?.getItem(PREFS_STORAGE_KEY);
+    if (!raw) return false;
+    return sanitizePrefs(JSON.parse(raw)).versionMismatch;
+  } catch {
+    return false;
+  }
+};
+
 export const readPrefs = () => {
   try {
     const parsed = JSON.parse(globalThis.localStorage?.getItem(PREFS_STORAGE_KEY) || 'null');
-    if (!parsed || typeof parsed !== 'object') return { ...EMPTY_PREFS };
-    return {
-      ...EMPTY_PREFS,
-      ...parsed,
-      moods: Array.isArray(parsed.moods) ? parsed.moods : [],
-      motifs: Array.isArray(parsed.motifs) ? parsed.motifs : [],
-    };
+    return sanitizePrefs(parsed).prefs;
   } catch {
     // Unavailable storage (private mode) or corrupt JSON. An unanswered reader
     // gets an unbiased feed, which is the correct degradation.
@@ -57,6 +112,78 @@ export const writePrefs = (prefs) => {
   } catch {
     /* private mode — selections just aren't persisted */
   }
+};
+
+/** Answered at all? Mirrors preferenceWeighting.hasPreferences without importing it. */
+const isAnswered = (p) =>
+  Boolean(p && (p.family || p.era || p.difficulty || p.moods?.length || p.motifs?.length));
+
+/** Epoch ms for a completedAt, or null when absent/unparseable. */
+const completedMs = (p) => {
+  const t = Date.parse(p?.completedAt ?? '');
+  return Number.isNaN(t) ? null : t;
+};
+
+/**
+ * Reconcile the answers on this device with the answers on the account.
+ *
+ * MOST-RECENT `completedAt` WINS, and it wins WHOLE — never field by field.
+ *
+ * Why most-recent: both sides carry a `completedAt` that is stamped only when a
+ * reader actually finishes the flow, so it is a real answer to "when did this
+ * person last tell us what they like". Local-wins would defeat the point of the
+ * feature (a fresh device would fetch the account's answers and immediately
+ * clobber them with its own empty ones). Remote-wins would throw away the five
+ * answers a reader just gave while signed out and then signed in — which is
+ * precisely the flow this exists to support.
+ *
+ * Why whole-object and not per-field: the five answers are one statement of
+ * taste. Merging a family from March with moods from August produces a
+ * combination the reader never chose, and the feed would then be weighted toward
+ * a person who does not exist. A stale-but-coherent answer set beats a fresh
+ * incoherent one.
+ *
+ * Why not prompt: it buys a modal on the sign-in path — the worst place for
+ * one — to resolve a difference the reader cannot meaningfully evaluate ("night
+ * + pride from Tuesday" vs "dawn + grief from last month"). The answers are a
+ * WEIGHT on the feed, not a filter, so the cost of guessing wrong is a slightly
+ * different mix, and redoing the flow takes about thirty seconds. That is not
+ * worth an interstitial.
+ *
+ * Tie-breaks, in order:
+ *   1. Only one side answered at all -> that side.
+ *   2. Both answered, both timestamped -> newer timestamp; EXACT TIE goes remote,
+ *      because the overwhelmingly common tie is "remote is already a mirror of
+ *      local", and preferring remote makes the merge a no-op instead of a write.
+ *   3. Both answered, only one timestamped -> the timestamped side (a stamped
+ *      completion is evidence of a finished flow; an unstamped one is a partial
+ *      or hand-edited payload).
+ *   4. Neither timestamped -> local, the device in front of the reader.
+ *
+ * Callers pass already-sanitized objects, so a version-mismatched payload
+ * arrives here as EMPTY_PREFS and simply loses to any real answer set.
+ *
+ * @param {Object} local  prefs from localStorage (sanitized)
+ * @param {Object} remote prefs from user_settings.onboarding_preferences (sanitized), or null
+ * @returns {{winner: Object, source: 'local'|'remote'|'neither'}}
+ */
+export const mergePrefs = (local, remote) => {
+  const localAnswered = isAnswered(local);
+  const remoteAnswered = isAnswered(remote);
+
+  if (!localAnswered && !remoteAnswered) return { winner: { ...EMPTY_PREFS }, source: 'neither' };
+  if (!remoteAnswered) return { winner: local, source: 'local' };
+  if (!localAnswered) return { winner: remote, source: 'remote' };
+
+  const l = completedMs(local);
+  const r = completedMs(remote);
+
+  if (l !== null && r !== null) {
+    return l > r ? { winner: local, source: 'local' } : { winner: remote, source: 'remote' };
+  }
+  if (r !== null) return { winner: remote, source: 'remote' };
+  if (l !== null) return { winner: local, source: 'local' };
+  return { winner: local, source: 'local' };
 };
 
 export const clearPrefs = () => {

--- a/src/test/onboarding-prefs-sync.test.jsx
+++ b/src/test/onboarding-prefs-sync.test.jsx
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// Node's experimental `localStorage` global shadows happy-dom's and is undefined
+// unless the runner was started with --localstorage-file, so this suite installs
+// its own in-memory store rather than depending on the environment. Scoped to
+// this file; nothing shared is touched.
+const store = new Map();
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Supabase stub. `from('user_settings')` returns a builder whose select chain
+// resolves to whatever the current test set as the remote row, and whose upsert
+// records what was written. The real client returns a thenable builder, so the
+// select chain terminates in `.single()` and `upsert()` is awaited directly.
+// ---------------------------------------------------------------------------
+const remote = { row: null, error: null };
+const upsertSpy = vi.fn(() => Promise.resolve({ error: null }));
+const configured = { value: true };
+
+vi.mock('../supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: remote.row, error: remote.error }),
+        }),
+      }),
+      upsert: (...args) => upsertSpy(...args),
+    })),
+  },
+  isSupabaseConfigured: () => configured.value,
+}));
+
+import { useOnboardingPrefs } from '../hooks/useOnboardingPrefs';
+import {
+  readPrefs,
+  writePrefs,
+  mergePrefs,
+  sanitizePrefs,
+  PREFS_STORAGE_KEY,
+  PREFS_VERSION,
+  EMPTY_PREFS,
+} from '../services/preferences.js';
+import { hasPreferences } from '../services/preferenceWeighting.js';
+
+const USER = { id: 'user-1' };
+
+const prefsAt = (completedAt, overrides = {}) => ({
+  version: PREFS_VERSION,
+  family: 'love-desire',
+  moods: ['pride'],
+  motifs: ['night'],
+  era: 'c9-9',
+  difficulty: 'gentle',
+  completedAt,
+  ...overrides,
+});
+
+const storedPrefs = () => JSON.parse(localStorage.getItem(PREFS_STORAGE_KEY));
+
+beforeEach(() => {
+  localStorage.removeItem(PREFS_STORAGE_KEY);
+  remote.row = null;
+  remote.error = null;
+  configured.value = true;
+  upsertSpy.mockClear();
+  upsertSpy.mockImplementation(() => Promise.resolve({ error: null }));
+  vi.spyOn(console, 'info').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Signed out is untouched
+// ---------------------------------------------------------------------------
+describe('signed out', () => {
+  it('never reads or writes the account', async () => {
+    writePrefs(prefsAt('2026-08-01T00:00:00.000Z'));
+
+    const { result } = renderHook(() => useOnboardingPrefs(null));
+    await act(async () => {
+      await result.current.persist(prefsAt('2026-08-02T00:00:00.000Z'));
+    });
+
+    expect(upsertSpy).not.toHaveBeenCalled();
+    // localStorage remains the whole story, and persist still wrote it.
+    expect(storedPrefs().completedAt).toBe('2026-08-02T00:00:00.000Z');
+  });
+
+  it('leaves localStorage as the sole path when Supabase is unconfigured', async () => {
+    configured.value = false;
+    const { result } = renderHook(() => useOnboardingPrefs(USER));
+    await act(async () => {
+      await result.current.persist(prefsAt('2026-08-02T00:00:00.000Z'));
+    });
+
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(readPrefs().family).toBe('love-desire');
+  });
+
+  it('reads the same prefs the feed reads, synchronously, with no user present', () => {
+    writePrefs(prefsAt('2026-08-01T00:00:00.000Z'));
+    renderHook(() => useOnboardingPrefs(null));
+
+    // fetchPoem.js does exactly this, outside any await.
+    const prefs = readPrefs();
+    expect(hasPreferences(prefs)).toBe(true);
+    expect(prefs.moods).toEqual(['pride']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Write-through on completion
+// ---------------------------------------------------------------------------
+describe('write-through on completion', () => {
+  it('mirrors completed answers to the account and to localStorage', async () => {
+    const { result } = renderHook(() => useOnboardingPrefs(USER));
+    const answers = prefsAt('2026-08-03T14:01:45.000Z');
+
+    await act(async () => {
+      await result.current.persist(answers);
+    });
+
+    expect(storedPrefs()).toMatchObject({ family: 'love-desire', motifs: ['night'] });
+    const [payload, options] = upsertSpy.mock.calls.at(-1);
+    expect(payload.user_id).toBe('user-1');
+    expect(payload.onboarding_preferences).toMatchObject({
+      family: 'love-desire',
+      completedAt: '2026-08-03T14:01:45.000Z',
+    });
+    // Only the one column, so it composes with useUserSettings' theme/font write
+    // on the same row instead of clobbering it.
+    expect(Object.keys(payload).sort()).toEqual(['onboarding_preferences', 'user_id']);
+    expect(options).toEqual({ onConflict: 'user_id' });
+  });
+
+  it('keeps the local answers when the account write fails', async () => {
+    upsertSpy.mockImplementation(() => Promise.resolve({ error: { message: 'offline' } }));
+    const { result } = renderHook(() => useOnboardingPrefs(USER));
+
+    let outcome;
+    await act(async () => {
+      outcome = await result.current.persist(prefsAt('2026-08-03T00:00:00.000Z'));
+    });
+
+    expect(outcome.error).toBeTruthy();
+    expect(readPrefs().family).toBe('love-desire');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Read-back on login
+// ---------------------------------------------------------------------------
+describe('read-back on login', () => {
+  it('hydrates a fresh device from the account', async () => {
+    remote.row = { onboarding_preferences: prefsAt('2026-07-01T00:00:00.000Z') };
+
+    renderHook(() => useOnboardingPrefs(USER));
+
+    await waitFor(() => expect(storedPrefs()).not.toBeNull());
+    expect(readPrefs()).toMatchObject({ family: 'love-desire', era: 'c9-9' });
+    // Remote already matched; nothing to push back.
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('pushes local answers up when the account has none', async () => {
+    writePrefs(prefsAt('2026-08-02T00:00:00.000Z'));
+    remote.row = null; // PGRST116-equivalent: no row yet
+
+    renderHook(() => useOnboardingPrefs(USER));
+
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled());
+    expect(upsertSpy.mock.calls.at(-1)[0].onboarding_preferences.completedAt).toBe(
+      '2026-08-02T00:00:00.000Z'
+    );
+  });
+
+  it('does nothing when neither side has answers', async () => {
+    renderHook(() => useOnboardingPrefs(USER));
+    await waitFor(() => expect(upsertSpy).not.toHaveBeenCalled());
+    expect(localStorage.getItem(PREFS_STORAGE_KEY)).toBeNull();
+  });
+
+  it('leaves local answers alone when the account read errors', async () => {
+    writePrefs(prefsAt('2026-08-02T00:00:00.000Z'));
+    remote.error = { code: '500', message: 'boom' };
+
+    renderHook(() => useOnboardingPrefs(USER));
+
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
+    expect(readPrefs().completedAt).toBe('2026-08-02T00:00:00.000Z');
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. The merge rule, both directions
+// ---------------------------------------------------------------------------
+describe('mergePrefs — most recent completedAt wins, whole', () => {
+  it('local wins when local is newer', () => {
+    const local = prefsAt('2026-08-02T00:00:00.000Z');
+    const rem = prefsAt('2026-07-01T00:00:00.000Z', { family: 'grief-loss' });
+    expect(mergePrefs(local, rem)).toEqual({ winner: local, source: 'local' });
+  });
+
+  it('remote wins when remote is newer', () => {
+    const local = prefsAt('2026-07-01T00:00:00.000Z');
+    const rem = prefsAt('2026-08-02T00:00:00.000Z', { family: 'grief-loss' });
+    expect(mergePrefs(local, rem)).toEqual({ winner: rem, source: 'remote' });
+  });
+
+  it('takes the winner whole rather than blending fields', () => {
+    const local = prefsAt('2026-08-02T00:00:00.000Z', { family: 'valor-defiance', motifs: [] });
+    const rem = prefsAt('2026-07-01T00:00:00.000Z', { moods: ['grief'], motifs: ['sea'] });
+    const { winner } = mergePrefs(local, rem);
+    // Not a union: the older side's motifs do not survive into the newer answer.
+    expect(winner.motifs).toEqual([]);
+    expect(winner.moods).toEqual(['pride']);
+  });
+
+  it('prefers the answered side regardless of timestamps', () => {
+    const answered = prefsAt('2026-01-01T00:00:00.000Z');
+    expect(mergePrefs({ ...EMPTY_PREFS }, answered).source).toBe('remote');
+    expect(mergePrefs(answered, { ...EMPTY_PREFS }).source).toBe('local');
+    expect(mergePrefs({ ...EMPTY_PREFS }, null).source).toBe('neither');
+  });
+
+  it('breaks an exact tie toward remote so the common no-op stays a no-op', () => {
+    const at = '2026-08-02T00:00:00.000Z';
+    expect(mergePrefs(prefsAt(at), prefsAt(at)).source).toBe('remote');
+  });
+
+  it('prefers a stamped completion over an unstamped one, either direction', () => {
+    expect(mergePrefs(prefsAt(null), prefsAt('2026-01-01T00:00:00.000Z')).source).toBe('remote');
+    expect(mergePrefs(prefsAt('2026-01-01T00:00:00.000Z'), prefsAt(null)).source).toBe('local');
+  });
+
+  it('treats an unparseable completedAt as absent instead of throwing', () => {
+    expect(mergePrefs(prefsAt('not-a-date'), prefsAt('2026-01-01T00:00:00.000Z')).source).toBe(
+      'remote'
+    );
+    expect(mergePrefs(prefsAt('not-a-date'), prefsAt(null)).source).toBe('local');
+  });
+
+  it('resolves the signed-out-then-sign-in case in favour of the fresh answers', async () => {
+    // The flow this feature exists for: answered while signed out, then signs in
+    // to an account holding older answers.
+    writePrefs(prefsAt('2026-08-03T12:00:00.000Z', { family: 'nature-cosmos' }));
+    remote.row = { onboarding_preferences: prefsAt('2026-02-01T00:00:00.000Z') };
+
+    renderHook(() => useOnboardingPrefs(USER));
+
+    await waitFor(() => expect(upsertSpy).toHaveBeenCalled());
+    expect(upsertSpy.mock.calls.at(-1)[0].onboarding_preferences.family).toBe('nature-cosmos');
+    expect(readPrefs().family).toBe('nature-cosmos');
+  });
+
+  it('overwrites this device when the account is the newer side', async () => {
+    writePrefs(prefsAt('2026-02-01T00:00:00.000Z', { family: 'nature-cosmos' }));
+    remote.row = { onboarding_preferences: prefsAt('2026-08-03T12:00:00.000Z') };
+
+    renderHook(() => useOnboardingPrefs(USER));
+
+    await waitFor(() => expect(readPrefs().family).toBe('love-desire'));
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Version mismatch
+// ---------------------------------------------------------------------------
+describe('version mismatch', () => {
+  it('discards a v1 payload rather than half-applying it', () => {
+    // v1 keys were written against a schema that never shipped ('anger', 'sea').
+    const { prefs, versionMismatch } = sanitizePrefs({
+      version: 1,
+      family: 'love',
+      moods: ['anger'],
+    });
+    expect(versionMismatch).toBe(true);
+    expect(prefs).toEqual(EMPTY_PREFS);
+    expect(hasPreferences(prefs)).toBe(false);
+  });
+
+  it('treats an unversioned payload as v1', () => {
+    expect(sanitizePrefs({ family: 'love', moods: ['anger'] }).versionMismatch).toBe(true);
+  });
+
+  it('discards a future v3 payload without crashing', () => {
+    const { prefs, versionMismatch } = sanitizePrefs({
+      version: 3,
+      family: 'love-desire',
+      forms: ['ghazal'],
+    });
+    expect(versionMismatch).toBe(true);
+    expect(prefs).toEqual(EMPTY_PREFS);
+    expect(prefs.forms).toBeUndefined();
+  });
+
+  it('readPrefs returns empty prefs for a mismatched stored payload', () => {
+    localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify({ version: 3, family: 'x' }));
+    expect(readPrefs()).toEqual(EMPTY_PREFS);
+  });
+
+  it('survives corrupt JSON and non-object payloads', () => {
+    localStorage.setItem(PREFS_STORAGE_KEY, '{not json');
+    expect(readPrefs()).toEqual(EMPTY_PREFS);
+    expect(sanitizePrefs([1, 2, 3]).prefs).toEqual(EMPTY_PREFS);
+    expect(sanitizePrefs(null).prefs).toEqual(EMPTY_PREFS);
+    expect(sanitizePrefs('nope').prefs).toEqual(EMPTY_PREFS);
+  });
+
+  it("does not overwrite a newer client's remote payload", async () => {
+    writePrefs(prefsAt('2026-08-03T00:00:00.000Z'));
+    remote.row = { onboarding_preferences: { version: 3, family: 'unknown-shape' } };
+
+    renderHook(() => useOnboardingPrefs(USER));
+
+    await waitFor(() => expect(console.info).toHaveBeenCalled());
+    expect(upsertSpy).not.toHaveBeenCalled();
+    // And this device keeps its own answers.
+    expect(readPrefs().completedAt).toBe('2026-08-03T00:00:00.000Z');
+  });
+
+  it("does not overwrite a newer client's local payload", async () => {
+    localStorage.setItem(PREFS_STORAGE_KEY, JSON.stringify({ version: 3, family: 'unknown' }));
+    remote.row = { onboarding_preferences: prefsAt('2026-01-01T00:00:00.000Z') };
+
+    renderHook(() => useOnboardingPrefs(USER));
+
+    await waitFor(() => expect(console.info).toHaveBeenCalled());
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem(PREFS_STORAGE_KEY)).version).toBe(3);
+  });
+
+  it('normalises a mismatched payload on persist instead of storing it', async () => {
+    const { result } = renderHook(() => useOnboardingPrefs(USER));
+    await act(async () => {
+      await result.current.persist({ version: 99, family: 'love-desire' });
+    });
+    expect(upsertSpy.mock.calls.at(-1)[0].onboarding_preferences).toEqual(EMPTY_PREFS);
+  });
+});

--- a/supabase/migrations/20260803000000_add_onboarding_preferences.sql
+++ b/supabase/migrations/20260803000000_add_onboarding_preferences.sql
@@ -1,0 +1,41 @@
+-- Onboarding answers follow a signed-in reader across devices.
+--
+-- Until now the five onboarding answers (family, moods, motifs, era, difficulty)
+-- lived only in localStorage.onboardingPrefs, so clearing browser data or picking
+-- up a second device lost them.
+--
+-- ONE JSONB COLUMN, NOT FIVE TYPED ONES. The payload is already versioned
+-- (`"version": 2`) and the taxonomy it references is still growing: motif was
+-- added after the first cut, era and difficulty store DERIVED BAND KEYS whose
+-- banding is recomputed from the live distribution. Typed columns would need a
+-- migration every time the flow gains, drops or renames a question. The shape is
+-- read by exactly one consumer (src/services/preferences.js), which validates the
+-- version on the way in, so the database does not need to know the schema.
+--
+-- Stored shape (version 2):
+--   {"version":2,"family":"love-desire","moods":["pride"],"motifs":["night"],
+--    "era":"c9-9","difficulty":"gentle","completedAt":"2026-08-03T14:01:45Z"}
+--
+-- Named `onboarding_preferences` rather than `preferences`: user_settings already
+-- holds theme, font_id and voice_preference, which are all "preferences" too. The
+-- name matches the localStorage key it mirrors.
+--
+-- NULL means "this reader has never completed onboarding on any device", which is
+-- distinct from an all-null answer object. No DEFAULT, for that reason.
+
+ALTER TABLE public.user_settings
+  ADD COLUMN IF NOT EXISTS onboarding_preferences JSONB;
+
+COMMENT ON COLUMN public.user_settings.onboarding_preferences IS
+  'Versioned onboarding answers mirrored from localStorage.onboardingPrefs. Shape owned by src/services/preferences.js, see PREFS_VERSION. NULL means the reader has never completed onboarding.';
+
+-- No new RLS policy and no new GRANT are required:
+--   * The policies in 20260119000000_auth_and_user_features.sql are ROW level
+--     (`auth.uid() = user_id`) with no column lists, so they already cover every
+--     column on the table, present and future.
+--   * 20260219000000_postgrest_schema_grants.sql grants table-level
+--     SELECT/INSERT/UPDATE/DELETE on user_settings to `authenticated`; a
+--     table-level grant extends to columns added later. (A column-level grant
+--     would NOT have, which is why this is worth stating rather than assuming.)
+-- Re-asserted here anyway so this file is correct standalone and safely re-runnable.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.user_settings TO authenticated;


### PR DESCRIPTION
**Stacked on #691** (`feat/onboarding-flow-categorization`). Branched off that PR's head so the prefs shape exists. **Land #691 first.** Base is set to that branch, so the diff here is only this change.

Closes the gap where the five onboarding answers lived only in `localStorage.onboardingPrefs` — clearing browser data or switching device lost them.

## The migration is NOT applied

`supabase/migrations/20260803000000_add_onboarding_preferences.sql` adds one column:

```sql
ALTER TABLE public.user_settings
  ADD COLUMN IF NOT EXISTS onboarding_preferences JSONB;
```

`supabase db push` is the owner's call and has not been run. Verified against a scratch Postgres 17 container instead: applies clean, re-runs clean (the `IF NOT EXISTS` notice is the only output on the second pass), and a v2 payload round-trips through `->>`.

**RLS and grants need nothing new**, and that is worth stating rather than assuming:
- The policies from `20260119000000` are row-level (`auth.uid() = user_id`) with no column lists, so they already cover every column present and future.
- `20260219000000` grants **table-level** `SELECT, INSERT, UPDATE, DELETE` on `user_settings` to `authenticated`. A table-level grant extends to columns added later — confirmed empirically on the scratch DB. A *column*-level grant would not have. The migration re-asserts the grant anyway so the file is correct standalone.

Named `onboarding_preferences`, not `preferences`: `user_settings` already holds `theme`, `font_id` and `voice_preference`, which are all preferences too. The name matches the localStorage key it mirrors. NULL means "never completed onboarding on any device", so no DEFAULT.

## Merge rule: most-recent `completedAt` wins, and wins WHOLE

Both sides carry a timestamp stamped only when a reader actually finishes the flow, so it is a real answer to "when did this person last tell us what they like".

- **Local-wins** defeats the point: a fresh device would fetch the account's answers and immediately clobber them with its own empty ones.
- **Remote-wins** throws away the answers a reader just gave while signed out and then signed in — precisely the flow this exists to support.
- **Prompting** buys a modal on the sign-in path (the worst place for one) to resolve a difference the reader cannot meaningfully evaluate: "night + pride from Tuesday" vs "dawn + grief from last month". The answers are a **weight** on the feed, not a filter, so guessing wrong costs a slightly different mix and redoing the flow takes ~30 seconds. Not worth an interstitial, and not worth the UI I would then own.

**Whole-object, not field-by-field.** The five answers are one statement of taste. A family from March plus moods from August is a combination nobody chose, and the feed would then weight toward a person who does not exist. A stale-but-coherent answer set beats a fresh incoherent one.

Tie-breaks, in order: answered side beats unanswered → newer timestamp → **exact tie goes remote** (the overwhelmingly common tie is "remote already mirrors local", so preferring remote makes the merge a no-op instead of a pointless write) → a stamped completion beats an unstamped one → otherwise local. Unparseable `completedAt` counts as absent rather than throwing.

## Version mismatch is inert, never fatal

`sanitizePrefs` gates on `version` before anything is spread.

- **v1 / unversioned** → discarded. Those key lists were authored against a schema that never shipped (`anger`, `wonder`, `sea`, `praise` are not taxonomy keys). The *shape* would survive a spread, but the content would weight the feed toward keys matching no poem.
- **v3 or later** → discarded for use, and **left strictly alone in both directions**: not adopted, and not overwritten. If a newer client on another device wrote it, that client still owns it. This applies to the local payload too — the sync bails rather than pushing this build's empty answers over a newer one.

Either way the reader falls back to an unbiased feed, since `hasPreferences(EMPTY_PREFS)` is false. Same degradation as skipping onboarding.

## Signed out is unchanged

`localStorage` stays the single source of truth for **reads**. `fetchPoem.js` reads the answers on every draw, synchronously, deliberately outside the `await` (a reader who skipped onboarding must reach `fetchRandomPoem` on the same microtask tick). Consulting the network there would reorder it against the other requests a poet switch fires. So the account is a **mirror**: on sign-in the winner is written back into localStorage, and every later read is the same synchronous read it has always been.

Every path in the hook returns early when `!user || !isSupabaseConfigured()`, and `persist` still writes localStorage in that case. Three tests pin it: no account read or write with no user, the same with Supabase unconfigured, and a synchronous `readPrefs()` that `hasPreferences` still accepts.

## Tests

26 new in `src/test/onboarding-prefs-sync.test.jsx`: signed-out unchanged (3), write-through incl. a failed account write (2), read-back on login incl. no-row and read-error (4), the merge rule in both directions plus every tie-break (9), version mismatch incl. corrupt JSON and non-objects (8).

The suite installs its own in-memory `localStorage` — Node's experimental global shadows happy-dom's and is undefined without `--localstorage-file`. Scoped to the file; nothing shared is touched. (This is the same root cause as the 5 pre-existing `utils-extracted.test.js` failures.)

## Gates

| gate | result |
|---|---|
| `npm run lint` | 0 errors (187 pre-existing warnings) |
| `npm run test:run` | 890 passed, 5 failed — only the known unguarded `localStorage.clear()` in `utils-extracted.test.js` |
| `npm run manifest:check` | exit 0 |
| `npm run build` | clean |

## Note on `useUserSettings`

I did **not** route this through `useUserSettings`, deliberately. That hook cannot distinguish "row not loaded yet" from "user has no row" — `settings` is null for both, and its `loading` never resets to `true` when the user changes — and a merge that mistook "still loading" for "the account has nothing" would push this device's answers over the account's. `useOnboardingPrefs` reads the column itself. The two hooks write **disjoint columns** of the same row through `ON CONFLICT` upserts, so their writes compose rather than race.

`PreferencesDrawer` already takes `onSave`/`onReset` callbacks and is not mounted anywhere yet, so there was nothing to wire there; whoever mounts it can pass `persist`.
