### PR TITLE
fix(api): strip angle brackets, not tag-shaped runs

### DIFF
--- a/server.js
+++ b/server.js
@@ -1758,8 +1758,18 @@ app.post(
         return res.status(400).json({ error: 'Content exceeds maximum length' });
       }
 
-      // Strip HTML tags (XSS prevention)
-      const clean = (s) => s?.replace(/<[^>]*>/g, '') || null;
+      // Drop the ANGLE BRACKETS, not tag-shaped runs. The previous
+      // `/<[^>]*>/g` required a closing `>`, so an unterminated tag passed
+      // through whole:
+      //   "<img src=x onerror=alert(1)"  ->  unchanged
+      // This body is client-supplied, so that mattered more here than on the
+      // rationale route. Removing the characters has no bypass: once every `<`
+      // is gone nothing downstream can reassemble one.
+      //
+      // Stripping rather than escaping because the app renders these as React
+      // text children (no dangerouslySetInnerHTML reaches them), so `&lt;`
+      // would be shown to the reader literally.
+      const clean = (s) => s?.replace(/[<>]/g, '') || null;
 
       // Only write if not already translated (write-once guard)
       const result = await pool.query(
@@ -1910,7 +1920,14 @@ app.post(
         .replace(/\s+/g, ' ')
         // Models like to wrap a bare sentence in quotes despite being told not to.
         .replace(/^["'“”]+|["'“”]+$/g, '')
-        .replace(/<[^>]*>/g, '')
+        // Drop the ANGLE BRACKETS, not tag-shaped runs. `/<[^>]*>/g` needs a
+        // closing `>`, so an unterminated tag passes through whole:
+        //   "<img src=x onerror=alert(1)"  ->  unchanged
+        // Removing the characters themselves has no bypass — once every `<` is
+        // gone, nothing downstream can reassemble one. This is a sentence we
+        // generated from our own prompt and it has no business containing
+        // markup, so there is nothing legitimate to preserve here.
+        .replace(/[<>]/g, '')
         .slice(0, RATIONALE_EN_MAX)
         .trim();
 


### PR DESCRIPTION
CodeQL flags both sanitization sites in `server.js` as `js/incomplete-multi-character-sanitization` **[high]**, and it is right.

```js
/<[^>]*>/g   // requires a closing `>`
```

An unterminated tag passes through untouched:

```
in    <img src=x onerror=alert(1)
out   <img src=x onerror=alert(1)      ← unchanged
```

Nesting payloads (`<scr<x>ipt>`, `<<a>script>`) are handled correctly by the old regex — I tested those first and they are **not** the hole. The unclosed tag is.

## Two sites

| route | source of the text |
|---|---|
| `POST /api/poems/:id/translation` | **client-supplied** — translation, explanation, author bio from the request body |
| `POST /api/poems/:id/rationale-translation` | generated from our own prompt, **written once** |

The first is the one that matters. The second matters differently: it is write-once, so a bad value would be that poem's English permanently.

## The fix

Remove the characters, not tag-shaped runs. Once every `<` is gone nothing downstream can reassemble one — including the whitespace collapse that runs alongside on the rationale route, which was what CodeQL flagged there.

Stripping rather than escaping because the app renders these as React text children. The only `dangerouslySetInnerHTML` in the tree is `SplashScreen` with a hardcoded `''`, so `&lt;` would be shown to the reader literally.

## Scope

Not exploitable in the app today. Filed as a fix rather than an issue because both fields are persisted and served over the API, and one of them can never be rewritten.

The rationale-route site arrived with #691; the translation-route site is older and was inherited. Both go away with the same one-line change.