### PR TITLE
fix(tour): stop auto-opening the walkthrough; move its entry into the account menu

### DIFF
--- a/feature-manifest.json
+++ b/feature-manifest.json
@@ -679,16 +679,18 @@
       "id": "guided-tour",
       "name": "Guided walkthrough / spotlight tour",
       "tier": "important",
-      "userFacing": "Bespoke on-brand walkthrough that spotlights nav elements; launchable via ?tour=1; resumes and adapts to the redesigned reader.",
+      "userFacing": "Bespoke on-brand walkthrough that spotlights nav elements. Never opens itself: started from the account menu ('Take the tour' / 'Resume tour', label follows saved progress), from ?tour=1, or from the corner restart compass once completed.",
       "entrypoints": [
         "src/components/tour/SpotlightTour.jsx",
         "src/components/tour/TourLauncher.jsx",
+        "src/components/AccountMenu.jsx",
+        "src/utils/tourProgress.js",
         "src/constants/routes.js",
         "src/hooks/useIsFullScreenRoute.js"
       ],
       "endpoints": [],
       "tests": {
-        "unit": ["src/test/fullscreen-route-gate.test.jsx"],
+        "unit": ["src/test/fullscreen-route-gate.test.jsx", "src/test/tour.test.jsx"],
         "e2e": ["e2e/tour.spec.js"]
       },
       "deviceOnly": false,

--- a/src/components/AccountMenu.jsx
+++ b/src/components/AccountMenu.jsx
@@ -11,12 +11,14 @@ import {
   SlidersHorizontal,
   Compass,
   Sparkles,
+  Footprints,
 } from 'lucide-react';
 import { THEME } from '../constants/theme.js';
 import { FEATURES } from '../constants/features.js';
 import { useUIStore } from '../stores/uiStore';
 import { useModalStore } from '../stores/modalStore';
 import { voiceDisplayName, voiceGender } from '../constants/voices';
+import { tourEntryLabel } from '../utils/tourProgress.js';
 
 /**
  * AccountMenu — the rightmost bottom-nav item. A person icon that opens an expandable menu holding
@@ -30,9 +32,13 @@ export default function AccountMenu({ user, onSignIn, onSignOut, liveVoice, onCy
   const darkMode = useUIStore((s) => s.darkMode);
   const curated = useUIStore((s) => s.curated);
   const openDisplaySettings = useModalStore((s) => s.openDisplaySettings);
+  const openTour = useModalStore((s) => s.openTour);
   const [, navigate] = useLocation();
   // Controlled so tapping "Display Settings" closes this menu as it opens the panel.
   const [open, setOpen] = useState(false);
+  // Read on every open (the menu re-renders when `open` flips), so the label tracks
+  // progress the reader made since last time instead of going stale.
+  const tourLabel = tourEntryLabel();
   const theme = darkMode ? THEME.dark : THEME.light;
   const initial = (user?.email ?? user?.user_metadata?.full_name ?? 'U').charAt(0).toUpperCase();
   const voiceName = voiceDisplayName(liveVoice);
@@ -87,6 +93,23 @@ export default function AccountMenu({ user, onSignIn, onSignOut, liveVoice, onCy
               <Compass size={16} style={{ color: ink }} />
               <span>Explore Poems</span>
             </button>
+
+            {/* Guided walkthrough — the only entry point. It never opens itself, so a reader
+                who wants the tour comes and gets it. Label reflects saved progress. */}
+            {FEATURES.tour && (
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  openTour();
+                }}
+                aria-label={tourLabel}
+                className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-brand-en hover:bg-gold/10 transition-colors"
+                style={{ color: ink }}
+              >
+                <Footprints size={16} style={{ color: ink }} />
+                <span>{tourLabel}</span>
+              </button>
+            )}
 
             <div className="my-1 h-px" style={{ background: 'rgba(197,160,89,0.18)' }} />
 

--- a/src/components/tour/TourLauncher.jsx
+++ b/src/components/tour/TourLauncher.jsx
@@ -2,18 +2,11 @@ import { Suspense, lazy, useCallback, useMemo, useState } from 'react';
 import { Compass } from 'lucide-react';
 import { THEME } from '../../constants/theme.js';
 import { useUIStore } from '../../stores/uiStore';
+import { useModalStore } from '../../stores/modalStore';
 import { TOUR_STEPS } from '../../constants/tourSteps.js';
+import { readTourProgress } from '../../utils/tourProgress.js';
 
 const SpotlightTour = lazy(() => import('./SpotlightTour.jsx'));
-
-// Deep-link launch: ?tour=1 | ?tour=spotlight
-const launchedFromURL = () => {
-  try {
-    return !!new URLSearchParams(window.location.search).get('tour');
-  } catch {
-    return false;
-  }
-};
 
 // Predicates for conditional steps. `hasLibrary` keeps the library step out of a
 // brand-new visitor's tour, but shows it to anyone signed in or with saved poems.
@@ -21,26 +14,17 @@ const WHEN = {
   hasLibrary: (ctx) => !!ctx.user || ctx.savedCount > 0,
 };
 
-function readPersisted() {
-  try {
-    return {
-      completed: localStorage.getItem('tourCompleted') === 'true',
-      step: parseInt(localStorage.getItem('tourStep') ?? '', 10),
-    };
-  } catch {
-    return { completed: false, step: NaN };
-  }
-}
-
 /**
- * TourLauncher — owns the walkthrough lifecycle:
- *  - Auto-opens on landing and resumes at the saved step, until the tour is
- *    completed. The reader can always dismiss it.
- *  - While dismissed (and not yet completed) a bottom-left "Resume tour" chip
- *    reopens it where they left off.
- *  - Once completed, the entry point becomes a small restart icon in the
- *    top-right (below the Aa text-settings pill); the final tour step highlights
- *    that icon so readers know where to find a refresher.
+ * TourLauncher — owns the walkthrough lifecycle, but never starts it.
+ *
+ * The reader asks for the tour from the account menu ("Take the tour" / "Resume
+ * tour"); modalStore.tour is the single open/closed flag, and it only starts
+ * true for an explicit `?tour=…` deep link or the dev-only FEATURES.forceTour.
+ * A first-time visitor gets a poem, not a seven-step modal over it.
+ *
+ * Resuming still works: the step index is persisted, so reopening picks up where
+ * they stopped. Once completed, a small restart icon appears in the top-right
+ * (below the Aa pill) — the final tour step spotlights that icon.
  */
 export default function TourLauncher({ user = null, savedCount = 0, onDemoRecite }) {
   const darkMode = useUIStore((s) => s.darkMode);
@@ -53,20 +37,19 @@ export default function TourLauncher({ user = null, savedCount = 0, onDemoRecite
     [user, savedCount]
   );
 
-  const [completed, setCompleted] = useState(() => readPersisted().completed);
-  const [started, setStarted] = useState(() => Number.isFinite(readPersisted().step));
+  const [completed, setCompleted] = useState(() => readTourProgress().completed);
   const [resumeStep, setResumeStep] = useState(() => {
-    const { step } = readPersisted();
-    return Number.isFinite(step) ? Math.max(0, step) : 0;
+    const { completed: done, step } = readTourProgress();
+    // A finished tour reopens from the top; an abandoned one resumes in place.
+    return !done && Number.isFinite(step) ? Math.max(0, step) : 0;
   });
-  // Shown on landing until completed; ?tour=… forces it open. (Under browser automation the whole
-  // launcher is suppressed by the guard below, so this state is moot there.)
-  const [open, setOpen] = useState(() => !readPersisted().completed || launchedFromURL());
+  const open = useModalStore((s) => s.tour);
+  const closeTour = useModalStore((s) => s.closeTour);
+  const openTour = useModalStore((s) => s.openTour);
   const [currentKey, setCurrentKey] = useState(null);
 
   const persistStep = useCallback(
     (i) => {
-      setStarted(true);
       setResumeStep(i);
       setCurrentKey(steps[i]?.key ?? null);
       try {
@@ -79,14 +62,14 @@ export default function TourLauncher({ user = null, savedCount = 0, onDemoRecite
   );
 
   const handleComplete = useCallback(() => {
-    setOpen(false);
+    closeTour();
     setCompleted(true);
     try {
       localStorage.setItem('tourCompleted', 'true');
     } catch {
       /* ignore */
     }
-  }, []);
+  }, [closeTour]);
 
   // Reaching the finish step IS completion. If the reader closes the tour from
   // that step by ANY path (×, Esc, or a Done tap a lingering auth overlay might
@@ -97,24 +80,21 @@ export default function TourLauncher({ user = null, savedCount = 0, onDemoRecite
       handleComplete();
       return;
     }
-    setOpen(false);
-  }, [currentKey, handleComplete]);
+    closeTour();
+  }, [currentKey, handleComplete, closeTour]);
 
   const restart = useCallback(() => {
     setResumeStep(0);
-    setOpen(true);
-  }, []);
+    openTour();
+  }, [openTour]);
 
   const safeResume = Math.min(Math.max(0, resumeStep), Math.max(0, steps.length - 1));
   // The corner icon is permanent once completed; it also appears on the final
   // step (so that step can spotlight it) before completion.
   const showCornerIcon = completed || (open && currentKey === 'finish');
 
-  // Under browser automation (Playwright e2e), render nothing — no coachmark/tap-catcher, no
-  // "Take a tour" chip, no restart icon — so the walkthrough can never block a flow spec. The
-  // tour's own e2e opts back in explicitly via ?tour=1 (launchedFromURL).
-  if (typeof navigator !== 'undefined' && navigator.webdriver && !launchedFromURL()) return null;
-
+  // No automation guard is needed any more: nothing opens the tour on its own, so it
+  // cannot block an e2e flow. The tour's own spec still opts in with ?tour=1.
   return (
     <>
       {open && (
@@ -131,27 +111,8 @@ export default function TourLauncher({ user = null, savedCount = 0, onDemoRecite
         </Suspense>
       )}
 
-      {/* Top-left chip — only while the tour is closed and not yet completed. */}
-      {!open && !completed && (
-        <button
-          onClick={() => setOpen(true)}
-          aria-label={started ? 'Resume tour' : 'Take a tour'}
-          className="fixed top-4 left-4 z-[60] flex items-center gap-2 rounded-full pl-3 pr-4 py-2 border transition-transform hover:scale-105"
-          style={{
-            background: 'rgba(12,12,14,0.9)',
-            backdropFilter: 'blur(20px) saturate(150%)',
-            WebkitBackdropFilter: 'blur(20px) saturate(150%)',
-            borderColor: 'rgba(197,160,89,0.35)',
-            color: 'var(--gold)',
-            fontFamily: "'Forum', serif",
-            fontSize: '0.85rem',
-            boxShadow: '0 8px 28px rgba(0,0,0,0.45)',
-          }}
-        >
-          <Compass size={15} />
-          {started ? 'Resume tour' : 'Take a tour'}
-        </button>
-      )}
+      {/* The floating "Resume tour" pill is gone — the entry point lives in the
+          account menu now, beside Explore Poems, instead of floating over the poem. */}
 
       {/* Top-right restart icon — below the Aa text-settings pill. Matches the
           theme toggle / text-settings button format exactly. */}

--- a/src/constants/features.js
+++ b/src/constants/features.js
@@ -13,6 +13,7 @@ export const FEATURES = {
   drawInspector: true, // الميزان — floating inspector for the last scored discovery draw. A verification tool, not a reader feature: it also requires showDebugLogs (seeded from FEATURES.debug), so turning debug off clears it with the rest of the dev surfaces. Set false to remove it outright.
   designReview: false, // Show design review shortcut icon (still accessible via /design-review URL)
   categoryExplorer: true, // Category Explorer — taxonomy browser + filter playground (Account menu "Explore Poems")
+  forceTour: false, // Dev-only: open the walkthrough at boot (mirrors forceOnboarding) so it stays testable without clearing storage
   tour: true, // Guided walkthrough — re-wired to the redesigned reader nav (ReaderActions Listen/Poem Insights + bottom-nav Save/Library/Discover); insights are inline so the 'explain' step is a plain spotlight (no drawer)
 
   verticalFeed: true, // Vertical swipe feed + tap-to-reveal stanza blooms (replaces horizontal carousel)

--- a/src/stores/modalStore.js
+++ b/src/stores/modalStore.js
@@ -20,6 +20,19 @@ function computeSplash() {
   }
 }
 
+// The walkthrough never opens itself on landing — the reader asks for it from the
+// account menu. The only boot-time openers are an explicit `?tour=…` deep link and
+// the dev-only forceTour flag.
+function computeTour() {
+  if (!FEATURES.tour) return false;
+  if (FEATURES.forceTour) return true;
+  try {
+    return !!new URLSearchParams(window.location.search).get('tour');
+  } catch {
+    return false;
+  }
+}
+
 const initialState = {
   authModal: false,
   authMessage: '',
@@ -37,6 +50,7 @@ const initialState = {
   shareCard: false,
   displaySettings: false,
   onboarding: computeOnboarding(),
+  tour: computeTour(),
 };
 
 const TOAST_MAP = {
@@ -82,6 +96,12 @@ export const useModalStore = create((set) => ({
   closeDisplaySettings: () => set({ displaySettings: false }),
   setDisplaySettings: (open) => set({ displaySettings: open }),
 
+  // Guided walkthrough — opened from the account menu ("Take the tour" / "Resume tour"),
+  // restarted from the corner compass, never on its own.
+  openTour: () => set({ tour: true }),
+  closeTour: () => set({ tour: false }),
+  setTour: (open) => set({ tour: open }),
+
   showToast: (type) => set({ [TOAST_MAP[type]]: true }),
   hideToast: (type) => set({ [TOAST_MAP[type]]: false }),
   showToastTimed: (type, ms = 2000) => {
@@ -111,5 +131,11 @@ export const useModalStore = create((set) => ({
       displaySettings: false,
     }),
 
-  reset: () => set({ ...initialState, splash: computeSplash(), onboarding: computeOnboarding() }),
+  reset: () =>
+    set({
+      ...initialState,
+      splash: computeSplash(),
+      onboarding: computeOnboarding(),
+      tour: computeTour(),
+    }),
 }));

--- a/src/test/tour.test.jsx
+++ b/src/test/tour.test.jsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { forwardRef } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TOUR_STEPS, anchoredSteps } from '../constants/tourSteps.js';
+import { useModalStore } from '../stores/modalStore';
+import { tourEntryLabel, hasTourProgress } from '../utils/tourProgress.js';
 
 // framer-motion → plain elements so the portal/animation machinery doesn't
 // interfere with assertions. We only render the lightweight motion.div.
@@ -168,23 +170,72 @@ describe('SpotlightTour engine', () => {
 
 describe('TourLauncher', () => {
   beforeEach(() => {
-    try {
-      localStorage.clear();
-    } catch {
-      /* ignore */
-    }
+    // In-memory storage stub — this environment doesn't reliably provide one.
+    const store = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      clear: () => store.clear(),
+    });
+    useModalStore.getState().closeTour();
   });
 
-  it('auto-opens the tour on landing (no chip while open)', async () => {
+  it('never opens itself on landing, and floats no chip over the reader', async () => {
     render(<TourLauncher />);
-    expect(await screen.findByText('Welcome to Poetry بالعربي')).toBeInTheDocument();
+    // Give the lazy SpotlightTour chunk a chance to appear — it must not.
+    await waitFor(() => expect(useModalStore.getState().tour).toBe(false));
+    expect(screen.queryByText('Welcome to Poetry بالعربي')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /tour/i })).not.toBeInTheDocument();
   });
 
-  it('shows a "Resume tour" chip after the tour is dismissed', async () => {
+  it('opens when the account menu asks for it, and closes back to nothing', async () => {
     render(<TourLauncher />);
-    await screen.findByText('Welcome to Poetry بالعربي');
+    act(() => useModalStore.getState().openTour());
+    expect(await screen.findByText('Welcome to Poetry بالعربي')).toBeInTheDocument();
+
     await userEvent.click(screen.getByRole('button', { name: 'Close walkthrough' }));
-    expect(await screen.findByRole('button', { name: 'Resume tour' })).toBeInTheDocument();
+    expect(screen.queryByText('Welcome to Poetry بالعربي')).not.toBeInTheDocument();
+    // No chip takes its place.
+    expect(screen.queryByRole('button', { name: /resume|take the tour/i })).not.toBeInTheDocument();
+  });
+
+  it('resumes at the persisted step when reopened', async () => {
+    localStorage.setItem('tourStep', '1');
+    render(<TourLauncher />);
+    act(() => useModalStore.getState().openTour());
+    expect(await screen.findByText('Listen to the poem')).toBeInTheDocument();
+  });
+});
+
+describe('tour entry label', () => {
+  // This environment doesn't always provide a real localStorage (see the guarded
+  // clear in src/test/setup.js), so drive the helper against an in-memory stub.
+  let store;
+  beforeEach(() => {
+    store = new Map();
+    vi.stubGlobal('localStorage', {
+      getItem: (k) => (store.has(k) ? store.get(k) : null),
+      setItem: (k, v) => store.set(k, String(v)),
+      removeItem: (k) => store.delete(k),
+      clear: () => store.clear(),
+    });
+  });
+
+  it('reads "Take the tour" for a first-timer', () => {
+    expect(tourEntryLabel()).toBe('Take the tour');
+    expect(hasTourProgress()).toBe(false);
+  });
+
+  it('reads "Resume tour" once a step past the first is saved', () => {
+    localStorage.setItem('tourStep', '2');
+    expect(tourEntryLabel()).toBe('Resume tour');
+    expect(hasTourProgress()).toBe(true);
+  });
+
+  it('goes back to "Take the tour" once completed — a finished tour restarts', () => {
+    localStorage.setItem('tourStep', '4');
+    localStorage.setItem('tourCompleted', 'true');
+    expect(tourEntryLabel()).toBe('Take the tour');
   });
 });

--- a/src/utils/tourProgress.js
+++ b/src/utils/tourProgress.js
@@ -1,0 +1,40 @@
+/**
+ * Guided-walkthrough progress, read straight from localStorage.
+ *
+ * Two consumers need the same answer and must not disagree: TourLauncher (which
+ * step to resume at) and AccountMenu (whether the entry reads "Take the tour" or
+ * "Resume tour"). Keeping the keys in one place stops the label from drifting
+ * away from what the tour actually does when you tap it.
+ *
+ * Keys: `tourCompleted` ('true' once finished), `tourStep` (last step index).
+ */
+
+/** @returns {{completed: boolean, step: number}} step is NaN when never started. */
+export function readTourProgress() {
+  try {
+    return {
+      completed: localStorage.getItem('tourCompleted') === 'true',
+      step: parseInt(localStorage.getItem('tourStep') ?? '', 10),
+    };
+  } catch {
+    // Private mode / storage disabled — treat as a first-timer.
+    return { completed: false, step: NaN };
+  }
+}
+
+/**
+ * True when the reader left the tour partway through: they started it and never
+ * reached the end. A completed tour has no progress to resume — tapping it
+ * restarts from the top, so it reads "Take the tour" again.
+ *
+ * @returns {boolean}
+ */
+export function hasTourProgress() {
+  const { completed, step } = readTourProgress();
+  return !completed && Number.isFinite(step) && step > 0;
+}
+
+/** Menu label that matches what the entry will actually do. */
+export function tourEntryLabel() {
+  return hasTourProgress() ? 'Resume tour' : 'Take the tour';
+}


### PR DESCRIPTION
## What's wrong

`TourLauncher` auto-opened the walkthrough on load. A reader arrived and got a seven-step modal before seeing a poem, and it fired again right after someone completed onboarding. A floating "Resume tour" pill sat at the top-left of the reader, competing with the poem.

## What changed

**No auto-open.** `modalStore` now owns a single `tour` flag, and it starts `true` only for an explicit `?tour=…` deep link or the new dev-only `FEATURES.forceTour` (mirrors `forceOnboarding`, so the tour stays testable without clearing storage). `TourLauncher` mounts and waits.

**Entry point in the account menu**, beside Explore Poems, gated on `FEATURES.tour`. The floating pill is gone.

**Honest label.** `src/utils/tourProgress.js` is the one place that reads `tourStep` / `tourCompleted`, so the menu label and the resume step can't drift apart:

| State | Label | Behavior |
|---|---|---|
| Never run | Take the tour | Starts at step 0 |
| Left partway (step > 0, not completed) | Resume tour | Reopens at the saved step |
| Completed | Take the tour | Restarts, because "Resume" would be a lie |

**Dropped the `navigator.webdriver` suppression** in `TourLauncher`. It existed to keep the auto-open from blocking e2e flows; nothing auto-opens now, so the guard only made the tour unreachable under automation.

Unchanged: tour steps and content, the `isFullScreenRoute` mount gate from #681, `?tour=1`, and the corner restart compass that the final step spotlights.

## Verified in a browser

- Cold load: poem, no tour, no pill.
- Account menu opens the tour; advancing a step and reopening flips the label to "Resume tour", and it resumes at that step rather than the top.
- `/?tour=1` still opens it.
- Landing on the reader after onboarding: nothing pops over it.

## Gates

`npm run lint` 0 errors · `npm run test:run` 1001 passed, only the 5 known `utils-extracted.test.js` localStorage failures · `npm run manifest:check` no drift · `npm run build` clean.

`src/app.jsx` is untouched: the pill lived in `TourLauncher`, so there was nothing to change at the mount site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
