### PR TITLE
fix(onboarding): era rail names the 21st century now that it exists

### DIFF
--- a/src/components/onboarding/steps/EraStep.jsx
+++ b/src/components/onboarding/steps/EraStep.jsx
@@ -64,20 +64,22 @@ import {
 const GOLD = '#c5a059';
 
 /**
- * The rail head for a band: "6th–8th", "9th–10th", "11th–14th", "15th–Today".
+ * The rail head for a band: "6th–8th", "9th–10th", "11th–14th", "15th–21st".
  *
- * These were bare numerals with an open dash on the last band — "15–" rather
- * than "15–21", on the argument that the closed number claims a precision the
- * corpus does not have, since that band also absorbs the undated poems. The
- * owner was asked directly and chose their own phrasing instead: ordinals on
- * both ends, and the word "Today" where the dash trailed off. Recorded rather
- * than deleted because the precision worry was not wrong, it was outvoted — if
- * anyone later wonders why the last band names a year-less endpoint while the
- * others name numbers, this is why.
+ * The last band used to read "15th–Today", and before that a bare "15–". Both
+ * were working around the same hole: `poems.century` was derived from `era_id`,
+ * so no poem carried a century past the 14th and naming the 21st would have
+ * claimed data that did not exist. "Today" was the honest way to say "and
+ * onward" without asserting a number.
+ *
+ * That hole is closed (#721). Centuries now come from poet life dates, and the
+ * last band really does hold 15th- through 21st-century poems — Darwish (d.
+ * 2008), Qabbani (d. 1998), Ahmad Matar (b. 1954) among them. So the head names
+ * the number, like every other band, and the row of heads finally reads as one
+ * consistent scale rather than three numbers and a word.
  */
 const headFor = (band) => {
   if (band.century_from == null) return '—';
-  if (band.includesUndated) return `${ordinal(band.century_from)}–Today`;
   return band.century_from === band.century_to
     ? ordinal(band.century_from)
     : `${ordinal(band.century_from)}–${ordinal(band.century_to)}`;
@@ -211,14 +213,18 @@ const EraStep = ({
                 <span
                   dir="ltr"
                   style={{
-                    // Forum, not Amiri: the heads carry English ordinals and
-                    // the word "Today" now, and Latin set in a naskh face reads
-                    // as a fallback rather than a choice. All four heads share
-                    // one face and ONE SIZE — the size never encodes anything
-                    // here, same rule the difficulty step follows.
+                    // Forum, not Amiri: the heads carry English ordinals, and
+                    // Latin set in a naskh face reads as a fallback rather than
+                    // a choice. All four heads share one face and ONE SIZE —
+                    // the size never encodes anything here, same rule the
+                    // difficulty step follows.
                     fontFamily: "'Forum', serif",
-                    // Down a step from 1.55rem so "15th–Today" fits on one line
-                    // at 393px without the other three shrinking to match it.
+                    // Down a step from 1.55rem so the longest head fits on one
+                    // line at 393px without the other three shrinking to match.
+                    // "15th–21st" is a character shorter than the "15th–Today"
+                    // this was originally sized for, and ties "11th–14th" as the
+                    // longest, so there may be room to go back up — measure at
+                    // 393px before changing it rather than assuming.
                     fontSize: '1.28rem',
                     lineHeight: 1.1,
                     letterSpacing: '.01em',

--- a/src/services/categoryBands.js
+++ b/src/services/categoryBands.js
@@ -149,11 +149,22 @@ export const deriveDifficultyBands = (histogram, bandCount = DIFFICULTY_BAND_COU
  * one-century button, and "undated" was surfaced to the reader as a period
  * ("Late & Modern") when it is really a gap in the metadata.
  *
- * Fixed cuts trade balance for legibility, knowingly. The 9th-10th band is
- * still by far the largest, and that is now a stated choice rather than
- * something the algorithm was fighting. Undated poems ride with 15th-to-today,
- * which is where an undated poem most likely belongs and, more importantly,
- * stops them needing a button of their own.
+ * Fixed cuts trade balance for legibility, knowingly. Undated poems ride with
+ * the last band rather than getting a button of their own.
+ *
+ * That trade turned out cheaper than expected. Those notes were written when
+ * `poems.century` was derived from `era_id`, so the 9th "really is ~40% of the
+ * corpus" and 1173 poems were undated. Both were artefacts: every Abbasid poem
+ * carried century 9 whether the poet died in 814 or 1057, and three whole eras
+ * carried no century at all (#721).
+ *
+ * Measured against real centuries, the fixed cuts are close to even —
+ * 6-8 ~20%, 9-10 ~27%, 11-14 ~34%, 15-21 ~14%, undated ~5%. So the bounds are
+ * left exactly as the owner chose them; there is nothing to rebalance.
+ *
+ * The absorb rule also stopped being load-bearing: it now carries a few hundred
+ * poems rather than a quarter of the library. Worth remembering if anyone is
+ * tempted to build on it — it is a remainder now, not a category.
  */
 const FIXED_ERA_BANDS = [
   {
@@ -190,8 +201,8 @@ const FIXED_ERA_BANDS = [
     includesUndated: true,
     label_ar: 'المتأخر والحديث',
     label_en: 'Late & Modern',
-    hint_ar: 'من القرن 15 حتى اليوم',
-    hint_en: '15th c. to today',
+    hint_ar: 'القرون 15–21 م',
+    hint_en: '15th–21st c. CE',
   },
 ];
 


### PR DESCRIPTION
Follow-up to #721. Cosmetic on the surface, but it retires a workaround.

## The rail head

The last band read `15th–Today`, and before that a bare `15–`. Both were working around the same hole: `poems.century` was derived from `era_id`, so no poem carried a century past the 14th, and naming the 21st would have claimed data that did not exist. "Today" was the honest way to say "and onward" without asserting a number.

That hole is closed. The last band really does hold 15th–21st century poems now — Darwish (d. 2008), Qabbani (d. 1998), Ahmad Matar (b. 1954). So the head names the number like every other band:

```
6th–8th    9th–10th    11th–14th    15th–21st
```

Four numbers, one scale, instead of three numbers and a word.

## Two claims in categoryBands that stopped being true

The header said the 9th "really is ~40% of the corpus" and that undated poems were a large enough block to need absorbing. Both were artefacts of the old derivation — every Abbasid poem carried century 9 whether the poet died in 814 or 1057, and three entire eras carried no century at all.

**Measured against real centuries the fixed cuts are close to even:**

| band | share |
| --- | --- |
| 6th–8th | ~20% |
| 9th–10th | ~27% |
| 11th–14th | ~34% |
| 15th–21st | ~14% |
| undated | ~5% |

So the bounds are left exactly as chosen. **There was nothing to rebalance** — which was the open question from #721 and is now answered with numbers rather than assumed.

The undated absorb rule survives but is noted as a remainder rather than a category: it carries a few hundred poems now, not a quarter of the library.

## Not changed, deliberately

The rail font size stays at `1.28rem`. It was dropped from `1.55rem` to fit `15th–Today`; `15th–21st` is a character shorter and ties `11th–14th` as the longest head, so there may be room to go back up. I left a note to measure at 393px rather than guessing, since all four heads must move together — the size never encodes anything on this screen.

## Tests

1024 passing. The 5 failures in `utils-extracted.test.js` are the pre-existing localStorage ones, unchanged in count.