### PR TITLE
fix(logging): stop painting a normal translation wait as a red FAIL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ storybook-static
 
 # Local DB backup dumps — never commit (large data + binaries)
 backups/
+
+# Transient request payloads from scripts/batch-translate.mjs
+.batch-translate-*.jsonl

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,4 +71,15 @@ export default [
       },
     },
   },
+
+  // Maintenance scripts run under Node, not in the browser. Without this they
+  // inherit the browser globals above and every console/process/fs reference
+  // reads as an undefined variable.
+  {
+    files: ['scripts/**/*.{js,mjs,cjs}'],
+    languageOptions: {
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+  },
 ];

--- a/scripts/batch-translate.mjs
+++ b/scripts/batch-translate.mjs
@@ -257,7 +257,7 @@ async function collect(job) {
 
 // ── write back ─────────────────────────────────────────────────────────────
 async function writeBack(results, poemsById) {
-  const stats = { written: 0, shortLines: 0, noPoem: 0, apiError: 0 };
+  const stats = { written: 0, shortLines: 0, extraLines: 0, noPoem: 0, apiError: 0 };
   const pending = [];
 
   for (const r of results) {
@@ -276,23 +276,34 @@ async function writeBack(results, poemsById) {
       continue;
     }
 
-    // Same guard the app applies before caching: a translation with fewer
-    // lines than the original is truncated, and caching it would freeze the
-    // truncation in place for every future reader.
+    // The line counts must match exactly, not merely reach the original's.
+    //
+    // Too few lines means a truncated translation, and caching it freezes the
+    // truncation in place for every future reader. Too many is the more
+    // surprising failure: the model recognises a classical poem and continues
+    // it past the corpus excerpt from memory. Poem 79376 came back with 40
+    // English lines for 20 Arabic — the first 20 correct, the rest verse with
+    // no source. The reader zips to max(ar, en), so those extra lines render
+    // beside empty Arabic.
     const arabicLines = toLines(poem.body).split('\n').filter((l) => l.trim()).length;
     const englishLines = parts.poeticTranslation.split('\n').filter((l) => l.trim()).length;
-    if (englishLines < arabicLines) {
-      stats.shortLines++;
+    if (englishLines !== arabicLines) {
+      if (englishLines < arabicLines) stats.shortLines++;
+      else stats.extraLines++;
       continue;
     }
 
     // Newlines are stored as '*', matching the corpus convention and the
     // app's own saveTranslation().
+    // Drop any literal '*' before encoding: it is the verse separator, so a
+    // markdown italic in the model's output ("*Saqt al-Zand*") would split one
+    // verse into three and shift the poem out of step with the Arabic.
+    const strip = (s) => (s ? s.replace(/\*/g, '') : null);
     pending.push([
       poem.id,
-      parts.poeticTranslation.replace(/\n/g, '*'),
-      parts.depth || null,
-      parts.author || null,
+      strip(parts.poeticTranslation).replace(/\n/g, '*'),
+      strip(parts.depth),
+      strip(parts.author),
     ]);
   }
 
@@ -363,6 +374,7 @@ const stats = await writeBack(results, poemsById);
 console.log('\n' + '-'.repeat(64));
 console.log(`  written:            ${stats.written}`);
 console.log(`  skipped (short):    ${stats.shortLines}`);
+console.log(`  skipped (overrun):  ${stats.extraLines}`);
 console.log(`  skipped (no POEM):  ${stats.noPoem}`);
 console.log(`  skipped (api err):  ${stats.apiError}`);
 console.log('-'.repeat(64));

--- a/scripts/batch-translate.mjs
+++ b/scripts/batch-translate.mjs
@@ -59,6 +59,29 @@ function die(msg) {
   process.exit(1);
 }
 
+/**
+ * fetch with retry on transport failures.
+ *
+ * The request payload runs to tens of megabytes and the poll loop can span
+ * hours, so a single ECONNRESET should cost a few seconds rather than the
+ * whole run. Only transport errors are retried — an HTTP error response is
+ * returned to the caller, which knows whether it is fatal.
+ */
+async function fetchRetry(url, init, attempts = 4) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fetch(url, init);
+    } catch (e) {
+      lastErr = e;
+      const wait = 2000 * 2 ** i;
+      console.log(`  network error (${e.cause?.code || e.message}), retrying in ${wait / 1000}s`);
+      await new Promise((r) => setTimeout(r, wait));
+    }
+  }
+  throw lastErr;
+}
+
 // ── prompt ─────────────────────────────────────────────────────────────────
 // Read the live prompt rather than a copy, so a batch backfill and an
 // in-app translation can never drift apart.
@@ -84,10 +107,29 @@ const parseInsight = (text) => {
 };
 
 // ── db ─────────────────────────────────────────────────────────────────────
-const db = new pg.Client({
+// Timeouts are not optional here. Without a query timeout, a dropped pooler
+// connection leaves the client waiting forever on the next write, process
+// alive at 0% CPU — indistinguishable from slow progress.
+const dbOptions = {
   connectionString: DATABASE_URL,
   ssl: { rejectUnauthorized: false },
-});
+  keepAlive: true,
+  statement_timeout: 120_000,
+  query_timeout: 120_000,
+  connectionTimeoutMillis: 30_000,
+};
+
+let db = new pg.Client(dbOptions);
+
+async function reconnect() {
+  try {
+    await db.end();
+  } catch {
+    /* already closed */
+  }
+  db = new pg.Client(dbOptions);
+  await db.connect();
+}
 
 // Mirrors SERVING in server.js. Poems outside it are never returned to a
 // reader, so translating them buys nothing until the filter changes.
@@ -130,7 +172,7 @@ async function submit(poems) {
   console.log(`  request file: ${(bytes / 1024 / 1024).toFixed(1)} MB`);
 
   // Resumable uploads use the /upload/ host prefix, not the plain API base.
-  const start = await fetch(`https://generativelanguage.googleapis.com/upload/v1beta/files?key=${KEY}`, {
+  const start = await fetchRetry(`https://generativelanguage.googleapis.com/upload/v1beta/files?key=${KEY}`, {
     method: 'POST',
     headers: {
       'X-Goog-Upload-Protocol': 'resumable',
@@ -148,7 +190,7 @@ async function submit(poems) {
     die(`file upload did not start (HTTP ${start.status}): ${(await start.text()).slice(0, 300)}`);
   }
 
-  const up = await fetch(uploadUrl, {
+  const up = await fetchRetry(uploadUrl, {
     method: 'POST',
     headers: {
       'Content-Length': String(bytes),
@@ -162,7 +204,7 @@ async function submit(poems) {
   if (!uploaded.file?.name) die(`upload failed: ${JSON.stringify(uploaded).slice(0, 300)}`);
   console.log(`  uploaded as ${uploaded.file.name}`);
 
-  const create = await fetch(`${BASE}/models/${MODEL}:batchGenerateContent?key=${KEY}`, {
+  const create = await fetchRetry(`${BASE}/models/${MODEL}:batchGenerateContent?key=${KEY}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -180,7 +222,7 @@ async function submit(poems) {
 async function waitFor(jobName) {
   console.log(`\nPolling ${jobName} every ${POLL_SECONDS}s (Ctrl-C is safe; resume with --resume)`);
   for (;;) {
-    const r = await fetch(`${BASE}/${jobName}?key=${KEY}`);
+    const r = await fetchRetry(`${BASE}/${jobName}?key=${KEY}`);
     const j = await r.json();
     const state = j.metadata?.state || j.state;
     const done = j.metadata?.completedRequestCount ?? j.metadata?.succeededRequestCount;
@@ -197,7 +239,7 @@ async function collect(job) {
   const out = [];
   const fileName = job.response?.responsesFile;
   if (fileName) {
-    const dl = await fetch(`${BASE}/${fileName}:download?alt=media&key=${KEY}`);
+    const dl = await fetchRetry(`${BASE}/${fileName}:download?alt=media&key=${KEY}`);
     const text = await dl.text();
     for (const line of text.split('\n')) {
       if (!line.trim()) continue;
@@ -216,6 +258,7 @@ async function collect(job) {
 // ── write back ─────────────────────────────────────────────────────────────
 async function writeBack(results, poemsById) {
   const stats = { written: 0, shortLines: 0, noPoem: 0, apiError: 0 };
+  const pending = [];
 
   for (const r of results) {
     const id = r.key ?? r.metadata?.key;
@@ -243,29 +286,44 @@ async function writeBack(results, poemsById) {
       continue;
     }
 
-    if (DRY_RUN) {
-      stats.written++;
-      continue;
-    }
-
     // Newlines are stored as '*', matching the corpus convention and the
     // app's own saveTranslation().
-    await db.query(
-      `UPDATE poems
-          SET cached_translation = $2,
-              cached_explanation = $3,
-              cached_author_bio  = $4,
-              translated_at      = now()
-        WHERE id = $1 AND cached_translation IS NULL`,
-      [
-        poem.id,
-        parts.poeticTranslation.replace(/\n/g, '*'),
-        parts.depth || null,
-        parts.author || null,
-      ]
-    );
-    stats.written++;
+    pending.push([
+      poem.id,
+      parts.poeticTranslation.replace(/\n/g, '*'),
+      parts.depth || null,
+      parts.author || null,
+    ]);
   }
+
+  if (DRY_RUN) {
+    stats.written = pending.length;
+    return stats;
+  }
+
+  // One round trip per chunk rather than per poem. Against the Supabase pooler
+  // a single-row UPDATE costs ~700ms, so row-at-a-time writes took 45 minutes
+  // for a serving-set backfill that the database itself handles in seconds.
+  const CHUNK = 250;
+  for (let i = 0; i < pending.length; i += CHUNK) {
+    const chunk = pending.slice(i, i + CHUNK);
+    const values = chunk
+      .map((_, j) => `($${j * 4 + 1}::int, $${j * 4 + 2}, $${j * 4 + 3}, $${j * 4 + 4})`)
+      .join(',');
+    await db.query(
+      `UPDATE poems p
+          SET cached_translation = v.translation,
+              cached_explanation = v.explanation,
+              cached_author_bio  = v.bio,
+              translated_at      = now()
+         FROM (VALUES ${values}) AS v(id, translation, explanation, bio)
+        WHERE p.id = v.id AND p.cached_translation IS NULL`,
+      chunk.flat()
+    );
+    stats.written += chunk.length;
+    process.stdout.write(`\r  writing ${stats.written}/${pending.length}`);
+  }
+  if (pending.length) process.stdout.write('\n');
   return stats;
 }
 
@@ -292,10 +350,15 @@ const poemsById = new Map(poems.map((p) => [String(p.id), p]));
 const jobName = RESUME || (await submit(poems));
 if (!RESUME) console.log(`  job:     ${jobName}`);
 
+// Release the connection across the poll — it can run for hours, and an idle
+// pooler connection is a connection the pooler is entitled to close.
+await db.end();
+
 const job = await waitFor(jobName);
 const results = await collect(job);
 console.log(`\nCollected ${results.length} responses`);
 
+await reconnect();
 const stats = await writeBack(results, poemsById);
 console.log('\n' + '-'.repeat(64));
 console.log(`  written:            ${stats.written}`);

--- a/scripts/batch-translate.mjs
+++ b/scripts/batch-translate.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+/**
+ * Backfill cached translations for the corpus via the Gemini Batch API.
+ *
+ * Batch is half the price of the interactive endpoint and has no urgency
+ * attached, which fits a backfill. The job is submitted as a file of requests,
+ * runs asynchronously (minutes to 24h), and the results are written back into
+ * poems.cached_translation / cached_explanation / cached_author_bio.
+ *
+ * The script is resumable: it only ever selects rows where cached_translation
+ * IS NULL, so re-running after a partial write picks up where it stopped.
+ *
+ * Usage:
+ *   node scripts/batch-translate.mjs --scope serving --dry-run
+ *   node scripts/batch-translate.mjs --scope serving --limit 25
+ *   node scripts/batch-translate.mjs --scope serving
+ *   node scripts/batch-translate.mjs --scope all
+ *   node scripts/batch-translate.mjs --resume batches/<id>
+ */
+
+import fs from 'fs';
+import path from 'path';
+import pg from 'pg';
+import { buildInsightPrompt } from '../src/utils/insightPrompt.js';
+
+const args = process.argv.slice(2);
+const flag = (n) => args.includes(`--${n}`);
+const arg = (n, d) => {
+  const i = args.indexOf(`--${n}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : d;
+};
+
+const SCOPE = arg('scope', 'serving'); // serving | all
+const LIMIT = parseInt(arg('limit', '0'), 10); // 0 = no cap
+const MODEL = arg('model', 'gemini-3.7-flash');
+const DRY_RUN = flag('dry-run');
+const RESUME = arg('resume', null);
+const POLL_SECONDS = parseInt(arg('poll', '60'), 10);
+
+const BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
+// ── env ────────────────────────────────────────────────────────────────────
+// --env lets a git worktree borrow the main checkout's .env, which is where
+// the credentials live; worktrees don't get their own copy.
+const envPath = path.resolve(arg('env', path.resolve(process.cwd(), '.env')));
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const m = line.match(/^([^#=]+)=(.*)$/);
+    if (m && !process.env[m[1].trim()]) process.env[m[1].trim()] = m[2].trim();
+  }
+}
+const KEY = process.env.GEMINI_API_KEY || process.env.VITE_GEMINI_API_KEY;
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!KEY) die('GEMINI_API_KEY (or VITE_GEMINI_API_KEY) is not set');
+if (!DATABASE_URL) die('DATABASE_URL is not set');
+
+function die(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+// ── prompt ─────────────────────────────────────────────────────────────────
+// Read the live prompt rather than a copy, so a batch backfill and an
+// in-app translation can never drift apart.
+const promptsSrc = fs.readFileSync(path.resolve(process.cwd(), 'src/prompts.js'), 'utf8');
+const promptMatch = promptsSrc.match(/export const INSIGHTS_SYSTEM_PROMPT = `([\s\S]*?)`/);
+if (!promptMatch) die('could not read INSIGHTS_SYSTEM_PROMPT from src/prompts.js');
+const SYSTEM_PROMPT = promptMatch[1].trim();
+
+// The corpus stores hemistichs separated by '*'; the reader renders them as
+// newlines. Translate against the newline form so the line contract in the
+// prompt counts what the reader will actually display.
+const toLines = (body) => body.split('*').join('\n');
+
+const buildPrompt = (poem) => buildInsightPrompt({ arabic: toLines(poem.body), poet: poem.poet });
+
+const parseInsight = (text) => {
+  if (!text) return null;
+  const parts = text
+    .split(/POEM:|THE DEPTH:|THE AUTHOR:/i)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return { poeticTranslation: parts[0] || '', depth: parts[1] || '', author: parts[2] || '' };
+};
+
+// ── db ─────────────────────────────────────────────────────────────────────
+const db = new pg.Client({
+  connectionString: DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+// Mirrors SERVING in server.js. Poems outside it are never returned to a
+// reader, so translating them buys nothing until the filter changes.
+const SERVING_CLAUSE = `p.quality_score >= 75
+  AND array_length(string_to_array(coalesce(p.diacritized_content, p.content), '*'), 1) <= 24`;
+
+async function selectPoems() {
+  const where =
+    SCOPE === 'all' ? 'p.cached_translation IS NULL' : `p.cached_translation IS NULL AND ${SERVING_CLAUSE}`;
+  const { rows } = await db.query(
+    `SELECT p.id, po.name AS poet, coalesce(p.diacritized_content, p.content) AS body
+       FROM poems p JOIN poets po ON po.id = p.poet_id
+      WHERE ${where}
+      ORDER BY p.quality_score DESC NULLS LAST, p.id
+      ${LIMIT > 0 ? `LIMIT ${LIMIT}` : ''}`
+  );
+  return rows;
+}
+
+// ── batch job ──────────────────────────────────────────────────────────────
+async function submit(poems) {
+  // Requests go up as a JSONL file: inline request lists are capped well below
+  // corpus scale, and the file route is what the Batch API expects for bulk.
+  const jsonl = poems
+    .map((p) =>
+      JSON.stringify({
+        key: String(p.id),
+        request: {
+          contents: [{ parts: [{ text: buildPrompt(p) }] }],
+          systemInstruction: { parts: [{ text: SYSTEM_PROMPT }] },
+          generationConfig: { thinkingConfig: { thinkingLevel: 'low' } },
+        },
+      })
+    )
+    .join('\n');
+
+  const tmp = path.resolve(process.cwd(), `.batch-translate-${Date.now()}.jsonl`);
+  fs.writeFileSync(tmp, jsonl);
+  const bytes = fs.statSync(tmp).size;
+  console.log(`  request file: ${(bytes / 1024 / 1024).toFixed(1)} MB`);
+
+  // Resumable uploads use the /upload/ host prefix, not the plain API base.
+  const start = await fetch(`https://generativelanguage.googleapis.com/upload/v1beta/files?key=${KEY}`, {
+    method: 'POST',
+    headers: {
+      'X-Goog-Upload-Protocol': 'resumable',
+      'X-Goog-Upload-Command': 'start',
+      'X-Goog-Upload-Header-Content-Length': String(bytes),
+      'X-Goog-Upload-Header-Content-Type': 'application/jsonl',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ file: { display_name: 'poem-translations' } }),
+  });
+  const uploadUrl = start.headers.get('x-goog-upload-url');
+  if (!uploadUrl) {
+    // Leave no 30MB payload behind when the upload never gets off the ground.
+    fs.unlinkSync(tmp);
+    die(`file upload did not start (HTTP ${start.status}): ${(await start.text()).slice(0, 300)}`);
+  }
+
+  const up = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Length': String(bytes),
+      'X-Goog-Upload-Offset': '0',
+      'X-Goog-Upload-Command': 'upload, finalize',
+    },
+    body: fs.readFileSync(tmp),
+  });
+  const uploaded = await up.json();
+  fs.unlinkSync(tmp);
+  if (!uploaded.file?.name) die(`upload failed: ${JSON.stringify(uploaded).slice(0, 300)}`);
+  console.log(`  uploaded as ${uploaded.file.name}`);
+
+  const create = await fetch(`${BASE}/models/${MODEL}:batchGenerateContent?key=${KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      batch: {
+        display_name: `translations-${SCOPE}-${new Date().toISOString().slice(0, 10)}`,
+        input_config: { file_name: uploaded.file.name },
+      },
+    }),
+  });
+  const job = await create.json();
+  if (!job.name) die(`batch create failed: ${JSON.stringify(job).slice(0, 400)}`);
+  return job.name;
+}
+
+async function waitFor(jobName) {
+  console.log(`\nPolling ${jobName} every ${POLL_SECONDS}s (Ctrl-C is safe; resume with --resume)`);
+  for (;;) {
+    const r = await fetch(`${BASE}/${jobName}?key=${KEY}`);
+    const j = await r.json();
+    const state = j.metadata?.state || j.state;
+    const done = j.metadata?.completedRequestCount ?? j.metadata?.succeededRequestCount;
+    console.log(`  ${new Date().toISOString().slice(11, 19)} ${state}${done ? ` (${done} done)` : ''}`);
+    if (state === 'BATCH_STATE_SUCCEEDED') return j;
+    if (state === 'BATCH_STATE_FAILED' || state === 'BATCH_STATE_CANCELLED') {
+      die(`batch ${state}: ${JSON.stringify(j).slice(0, 400)}`);
+    }
+    await new Promise((res) => setTimeout(res, POLL_SECONDS * 1000));
+  }
+}
+
+async function collect(job) {
+  const out = [];
+  const fileName = job.response?.responsesFile;
+  if (fileName) {
+    const dl = await fetch(`${BASE}/${fileName}:download?alt=media&key=${KEY}`);
+    const text = await dl.text();
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        out.push(JSON.parse(line));
+      } catch {
+        /* a malformed line costs one poem, not the run */
+      }
+    }
+  } else {
+    for (const r of job.response?.inlinedResponses?.inlinedResponses || []) out.push(r);
+  }
+  return out;
+}
+
+// ── write back ─────────────────────────────────────────────────────────────
+async function writeBack(results, poemsById) {
+  const stats = { written: 0, shortLines: 0, noPoem: 0, apiError: 0 };
+
+  for (const r of results) {
+    const id = r.key ?? r.metadata?.key;
+    const poem = poemsById.get(String(id));
+    if (!poem) continue;
+
+    const text = r.response?.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (!text) {
+      stats.apiError++;
+      continue;
+    }
+    const parts = parseInsight(text);
+    if (!parts?.poeticTranslation) {
+      stats.noPoem++;
+      continue;
+    }
+
+    // Same guard the app applies before caching: a translation with fewer
+    // lines than the original is truncated, and caching it would freeze the
+    // truncation in place for every future reader.
+    const arabicLines = toLines(poem.body).split('\n').filter((l) => l.trim()).length;
+    const englishLines = parts.poeticTranslation.split('\n').filter((l) => l.trim()).length;
+    if (englishLines < arabicLines) {
+      stats.shortLines++;
+      continue;
+    }
+
+    if (DRY_RUN) {
+      stats.written++;
+      continue;
+    }
+
+    // Newlines are stored as '*', matching the corpus convention and the
+    // app's own saveTranslation().
+    await db.query(
+      `UPDATE poems
+          SET cached_translation = $2,
+              cached_explanation = $3,
+              cached_author_bio  = $4,
+              translated_at      = now()
+        WHERE id = $1 AND cached_translation IS NULL`,
+      [
+        poem.id,
+        parts.poeticTranslation.replace(/\n/g, '*'),
+        parts.depth || null,
+        parts.author || null,
+      ]
+    );
+    stats.written++;
+  }
+  return stats;
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+await db.connect();
+
+const poems = await selectPoems();
+console.log('='.repeat(64));
+console.log('BATCH TRANSLATION BACKFILL');
+console.log('='.repeat(64));
+console.log(`  scope:   ${SCOPE}${LIMIT ? ` (capped at ${LIMIT})` : ''}`);
+console.log(`  model:   ${MODEL} (thinkingLevel: low)`);
+console.log(`  poems:   ${poems.length} untranslated`);
+console.log(`  mode:    ${DRY_RUN ? 'DRY RUN — no writes' : 'LIVE — writes to the database'}`);
+
+if (poems.length === 0) {
+  console.log('\nNothing to do.');
+  await db.end();
+  process.exit(0);
+}
+
+const poemsById = new Map(poems.map((p) => [String(p.id), p]));
+
+const jobName = RESUME || (await submit(poems));
+if (!RESUME) console.log(`  job:     ${jobName}`);
+
+const job = await waitFor(jobName);
+const results = await collect(job);
+console.log(`\nCollected ${results.length} responses`);
+
+const stats = await writeBack(results, poemsById);
+console.log('\n' + '-'.repeat(64));
+console.log(`  written:            ${stats.written}`);
+console.log(`  skipped (short):    ${stats.shortLines}`);
+console.log(`  skipped (no POEM):  ${stats.noPoem}`);
+console.log(`  skipped (api err):  ${stats.apiError}`);
+console.log('-'.repeat(64));
+
+const { rows } = await db.query(
+  `SELECT count(*) FILTER (WHERE cached_translation IS NOT NULL) translated,
+          count(*) total
+     FROM poems p WHERE ${SERVING_CLAUSE}`
+);
+console.log(
+  `  serving coverage now: ${rows[0].translated}/${rows[0].total} ` +
+    `(${((rows[0].translated / rows[0].total) * 100).toFixed(1)}%)`
+);
+
+await db.end();

--- a/scripts/check-translation-alignment.mjs
+++ b/scripts/check-translation-alignment.mjs
@@ -116,6 +116,9 @@ const results = [];
 let done = 0;
 
 async function one(r) {
+  // --ids may name a poem that has no translation yet. Nothing to score, and
+  // it is not an error worth a stack trace mid-sweep.
+  if (!r.ct) return;
   const ar = r.body.split('*').map((s) => s.trim()).filter(Boolean);
   const en = r.ct.split('*').map((s) => s.trim()).filter(Boolean);
   if (ar.length < MIN_LINES || en.length < MIN_LINES) return;

--- a/scripts/check-translation-alignment.mjs
+++ b/scripts/check-translation-alignment.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Detect misaligned cached translations.
+ *
+ * The line-count guard in the backfill only checks that a translation has at
+ * least as many lines as the original. A translation that merges the opening
+ * bayt and then shifts by one has a matching count and is wrong from line 2
+ * onward (see issue #733). Counting cannot see that; meaning can.
+ *
+ * Each Arabic line and each English line is embedded with a multilingual
+ * model, and the line-to-line similarity matrix is scored. A correct
+ * translation is diagonal. A shifted one has a bright off-diagonal band, which
+ * is what this reports.
+ *
+ * Read-only: it never writes to the database.
+ *
+ * Usage:
+ *   node scripts/check-translation-alignment.mjs --ids 87900,66800
+ *   node scripts/check-translation-alignment.mjs --limit 200
+ *   node scripts/check-translation-alignment.mjs --limit 200 --json report.json
+ */
+
+import fs from 'fs';
+import path from 'path';
+import pg from 'pg';
+import { scoreAlignment } from '../src/utils/alignmentScore.js';
+
+const args = process.argv.slice(2);
+const arg = (n, d) => {
+  const i = args.indexOf(`--${n}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : d;
+};
+
+const IDS = arg('ids', null);
+const LIMIT = parseInt(arg('limit', '100'), 10);
+const JSON_OUT = arg('json', null);
+const EMBED_MODEL = arg('embed-model', 'gemini-embedding-001');
+const MIN_LINES = parseInt(arg('min-lines', '4'), 10);
+const CONCURRENCY = parseInt(arg('concurrency', '4'), 10);
+
+const envPath = path.resolve(arg('env', path.resolve(process.cwd(), '.env')));
+if (fs.existsSync(envPath)) {
+  for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+    const m = line.match(/^([^#=]+)=(.*)$/);
+    if (m && !process.env[m[1].trim()]) process.env[m[1].trim()] = m[2].trim();
+  }
+}
+const KEY = process.env.GEMINI_API_KEY || process.env.VITE_GEMINI_API_KEY;
+if (!KEY) {
+  console.error('ERROR: GEMINI_API_KEY is not set');
+  process.exit(1);
+}
+
+const BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
+async function embed(texts) {
+  // batchEmbedContents caps per call, so chunk. Order is preserved.
+  const out = [];
+  for (let i = 0; i < texts.length; i += 100) {
+    const chunk = texts.slice(i, i + 100);
+    // The embedding endpoint rate-limits hard on a corpus sweep, and a 429 is
+    // a "wait", not a failure — treat it as retryable alongside transport
+    // errors, or most of the sample is lost to noise rather than to signal.
+    let j;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const res = await fetch(`${BASE}/models/${EMBED_MODEL}:batchEmbedContents?key=${KEY}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            requests: chunk.map((t) => ({
+              model: `models/${EMBED_MODEL}`,
+              content: { parts: [{ text: t }] },
+              outputDimensionality: 768,
+            })),
+          }),
+        });
+        j = await res.json();
+        if (j.embeddings) break;
+        if (res.status !== 429 || attempt >= 6) {
+          throw new Error(`embed failed (HTTP ${res.status}): ${JSON.stringify(j).slice(0, 160)}`);
+        }
+      } catch (e) {
+        if (attempt >= 6) throw e;
+      }
+      await new Promise((r) => setTimeout(r, Math.min(60_000, 3000 * 2 ** attempt)));
+    }
+    out.push(...j.embeddings.map((e) => e.values));
+  }
+  return out;
+}
+
+const db = new pg.Client({
+  connectionString: process.env.DATABASE_URL,
+  ssl: { rejectUnauthorized: false },
+  keepAlive: true,
+  query_timeout: 120_000,
+});
+await db.connect();
+
+const where = IDS
+  ? `p.id IN (${IDS.split(',').map((s) => parseInt(s, 10)).filter(Number.isFinite).join(',')})`
+  : `p.cached_translation IS NOT NULL AND p.quality_score >= 75`;
+
+const { rows } = await db.query(
+  `SELECT p.id, po.name AS poet, coalesce(p.diacritized_content, p.content) AS body,
+          p.cached_translation AS ct
+     FROM poems p JOIN poets po ON po.id = p.poet_id
+    WHERE ${where}
+    ORDER BY ${IDS ? 'p.id' : 'random()'}
+    ${IDS ? '' : `LIMIT ${LIMIT}`}`
+);
+await db.end();
+
+const results = [];
+let done = 0;
+
+async function one(r) {
+  const ar = r.body.split('*').map((s) => s.trim()).filter(Boolean);
+  const en = r.ct.split('*').map((s) => s.trim()).filter(Boolean);
+  if (ar.length < MIN_LINES || en.length < MIN_LINES) return;
+  const vecs = await embed([...ar, ...en]);
+  const s = scoreAlignment(vecs.slice(0, ar.length), vecs.slice(ar.length));
+  if (s.diagonal === null) return;
+  results.push({ id: r.id, poet: r.poet, lines: ar.length, enLines: en.length, ...s });
+  done++;
+  if (done % 25 === 0) process.stdout.write(`\r  scored ${done}/${rows.length}`);
+}
+
+// Bounded concurrency: the embedding endpoint rate-limits, and a corpus sweep
+// is not worth losing to a 429 storm.
+const queue = [...rows];
+await Promise.all(
+  Array.from({ length: CONCURRENCY }, async () => {
+    for (;;) {
+      const r = queue.shift();
+      if (!r) return;
+      try {
+        await one(r);
+      } catch (e) {
+        console.error(`\n  poem ${r.id}: ${e.message}`);
+      }
+    }
+  })
+);
+process.stdout.write('\n');
+
+const misaligned = results.filter((r) => r.shift !== 0 && r.margin > 0.02);
+misaligned.sort((a, b) => b.margin - a.margin);
+
+console.log(`\nscored ${results.length} poems`);
+console.log(`shifted: ${misaligned.length} (${((misaligned.length / results.length) * 100).toFixed(1)}%)\n`);
+for (const m of misaligned.slice(0, 25)) {
+  console.log(
+    `  id ${String(m.id).padEnd(6)} ${String(m.lines).padStart(2)} lines  shift ${m.shift > 0 ? '+' : ''}${m.shift}  diag ${m.diagonal.toFixed(3)} -> ${m.best.toFixed(3)}  (+${m.margin.toFixed(3)})  ${m.poet}`
+  );
+}
+if (JSON_OUT) {
+  fs.writeFileSync(JSON_OUT, JSON.stringify({ results, misaligned }, null, 2));
+  console.log(`\nwrote ${JSON_OUT}`);
+}

--- a/server.js
+++ b/server.js
@@ -1786,7 +1786,14 @@ app.post(
       // Stripping rather than escaping because the app renders these as React
       // text children (no dangerouslySetInnerHTML reaches them), so `&lt;`
       // would be shown to the reader literally.
-      const clean = (s) => s?.replace(/[<>]/g, '') || null;
+      //
+      // '*' goes too: it is the corpus verse separator, and services/database.js
+      // turns every '*' into a newline on read. A model that writes a title in
+      // markdown italics — "*Saqt al-Zand*" — therefore splits one verse into
+      // three and shifts the rest of the poem out of alignment with the Arabic.
+      // In the explanation and bio it is only markdown that renders literally,
+      // so dropping it there is a tidy-up rather than a fix.
+      const clean = (s) => s?.replace(/[<>*]/g, '') || null;
 
       // Only write if not already translated (write-once guard)
       const result = await pool.query(

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -179,13 +179,19 @@ export const discoverTextModels = async (addLog) => {
  * in ~2s. Minimizing thinking drops first-token latency to ~1s with no
  * meaningful quality loss for translation/analysis.
  *
- * Gemini 3.x uses `thinkingLevel` ('minimal' = lowest latency); 2.5 uses
- * `thinkingBudget` (0 disables). Older families don't support thinking and
- * 400 on the field, so they get nothing. Returns a spreadable fragment so the
- * caller merges it into an existing generationConfig.
+ * Gemini 3.x uses `thinkingLevel`; 2.5 uses `thinkingBudget` (0 disables).
+ * Older families don't support thinking and 400 on the field, so they get
+ * nothing. Returns a spreadable fragment so the caller merges it into an
+ * existing generationConfig.
+ *
+ * 'low' rather than 'minimal': gemini-3.7-flash 400s on minimal ("Thinking
+ * level MINIMAL is not supported for this model") and every request paid a
+ * rejected round trip. Measured on one poem, 2026-08-17: default emitted 1,329
+ * thinking tokens in 6.0s; 'low' emitted 0 in 2.2s, with the line contract and
+ * translation quality unchanged.
  */
 export const thinkingConfigFor = (model = '') => {
-  if (/gemini-3/.test(model)) return { thinkingConfig: { thinkingLevel: 'minimal' } };
+  if (/gemini-3/.test(model)) return { thinkingConfig: { thinkingLevel: 'low' } };
   if (/gemini-2\.5/.test(model)) return { thinkingConfig: { thinkingBudget: 0 } };
   return {};
 };

--- a/src/services/gemini.js
+++ b/src/services/gemini.js
@@ -190,6 +190,21 @@ export const thinkingConfigFor = (model = '') => {
   return {};
 };
 
+/** Models observed to 400 on thinking config, so we stop sending it to them. */
+const THINKING_REJECTED = new Set();
+
+/** Remove thinking config from a serialised request body. */
+const stripThinkingConfig = (body) => {
+  try {
+    const parsed = JSON.parse(body);
+    if (parsed?.generationConfig) delete parsed.generationConfig.thinkingConfig;
+    delete parsed.thinkingConfig;
+    return JSON.stringify(parsed);
+  } catch {
+    return body;
+  }
+};
+
 /**
  * Fetch from a Gemini text endpoint with automatic model fallback.
  * Uses the dynamically discovered model list (ranked newest/cheapest first).
@@ -209,7 +224,10 @@ export const geminiTextFetch = async (endpoint, bodyOrBuilder, label, addLog) =>
   for (let i = 0; i < models.length; i++) {
     const model = models[i];
     if (i > 0) log('Model Fallback', `Trying fallback: ${model}`, 'warning');
-    const body = typeof bodyOrBuilder === 'function' ? bodyOrBuilder(model) : bodyOrBuilder;
+    const built = typeof bodyOrBuilder === 'function' ? bodyOrBuilder(model) : bodyOrBuilder;
+    // Once a model has told us it won't take thinking config, stop paying a
+    // rejected round trip for it on every subsequent request this session.
+    const body = THINKING_REJECTED.has(model) ? stripThinkingConfig(built) : built;
     const post = (b) =>
       fetch(`${apiUrl}/api/ai/${model}/${endpoint}`, {
         method: 'POST',
@@ -231,16 +249,9 @@ export const geminiTextFetch = async (endpoint, bodyOrBuilder, label, addLog) =>
         .catch(() => ({}));
       const msg = peek.error?.message || '';
       if (/thinking/i.test(msg) && /\bthinkingConfig\b/.test(body)) {
-        const stripped = JSON.stringify(
-          (() => {
-            const parsed = JSON.parse(body);
-            if (parsed?.generationConfig) delete parsed.generationConfig.thinkingConfig;
-            delete parsed.thinkingConfig;
-            return parsed;
-          })()
-        );
+        THINKING_REJECTED.add(model);
         log('Model Fallback', `${model} rejected thinking config, retrying without it`, 'warning');
-        res = await post(stripped);
+        res = await post(stripThinkingConfig(body));
       }
     }
 

--- a/src/stores/actions/analyzePoem.js
+++ b/src/stores/actions/analyzePoem.js
@@ -5,6 +5,7 @@ import { useUIStore } from '../uiStore';
 import { useModalStore } from '../modalStore';
 import { INSIGHTS_SYSTEM_PROMPT, RATCHET_SYSTEM_PROMPT } from '../../prompts';
 import { parseInsight } from '../../utils/insightParser';
+import { buildInsightPrompt } from '../../utils/insightPrompt';
 import { geminiTextFetch, thinkingConfigFor } from '../../services/gemini.js';
 import { cacheOperations, CACHE_CONFIG } from '../../services/cache.js';
 import { saveTranslation } from '../../services/database.js';
@@ -151,9 +152,8 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
 
   try {
     if (FEATURES.streaming) {
-      const poetInfo = current?.poet ? ` by ${current.poet}` : '';
       const arabicLineCount = (current?.arabic || '').split('\n').filter((l) => l.trim()).length;
-      const promptText = `Deep Analysis of${poetInfo}:\n\n${current?.arabic}\n\n[CRITICAL: This poem has exactly ${arabicLineCount} Arabic lines. You MUST produce exactly ${arabicLineCount} English lines in the POEM section. One line per Arabic line, no exceptions.]`;
+      const promptText = buildInsightPrompt({ arabic: current?.arabic, poet: current?.poet });
       const requestSize = new Blob([
         JSON.stringify({ contents: [{ parts: [{ text: promptText }] }] }),
       ]).size;

--- a/src/stores/actions/analyzePoem.js
+++ b/src/stores/actions/analyzePoem.js
@@ -87,7 +87,11 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
           'info'
         );
         setTimeout(async () => {
-          const finalCheck = await cacheOperations.get(CACHE_CONFIG.stores.insights, current.id, addLog);
+          const finalCheck = await cacheOperations.get(
+            CACHE_CONFIG.stores.insights,
+            current.id,
+            addLog
+          );
           if (finalCheck?.interpretation) {
             addLog(
               'Insights',
@@ -148,14 +152,12 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
   try {
     if (FEATURES.streaming) {
       const poetInfo = current?.poet ? ` by ${current.poet}` : '';
-      const arabicLineCount = (current?.arabic || '').split('\n').filter(l => l.trim()).length;
+      const arabicLineCount = (current?.arabic || '').split('\n').filter((l) => l.trim()).length;
       const promptText = `Deep Analysis of${poetInfo}:\n\n${current?.arabic}\n\n[CRITICAL: This poem has exactly ${arabicLineCount} Arabic lines. You MUST produce exactly ${arabicLineCount} English lines in the POEM section. One line per Arabic line, no exceptions.]`;
       const requestSize = new Blob([
         JSON.stringify({ contents: [{ parts: [{ text: promptText }] }] }),
       ]).size;
-      const estimatedInputTokens = Math.ceil(
-        (promptText.length + activeSystemPrompt.length) / 4
-      );
+      const estimatedInputTokens = Math.ceil((promptText.length + activeSystemPrompt.length) / 4);
       const promptChars = promptText.length;
       const arabicTextChars = current?.arabic?.length || 0;
       const systemPromptChars = activeSystemPrompt.length;
@@ -255,12 +257,10 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
     } else {
       addLog('Insights', `Analyzing poem...${ratchetMode ? ' [Ratchet Mode]' : ''}`, 'request');
       const poetInfoFallback = current?.poet ? ` by ${current.poet}` : '';
-      const arabicLineCount = (current?.arabic || '').split('\n').filter(l => l.trim()).length;
+      const arabicLineCount = (current?.arabic || '').split('\n').filter((l) => l.trim()).length;
       const promptText = `Deep Analysis of${poetInfoFallback}:\n\n${current?.arabic}\n\n[CRITICAL: This poem has exactly ${arabicLineCount} Arabic lines. You MUST produce exactly ${arabicLineCount} English lines in the POEM section. One line per Arabic line, no exceptions.]`;
       const insightsFallbackBody = JSON.stringify({
-        contents: [
-          { parts: [{ text: promptText }] },
-        ],
+        contents: [{ parts: [{ text: promptText }] }],
         systemInstruction: { parts: [{ text: activeSystemPrompt }] },
         generationConfig: { maxOutputTokens: 8192 },
       });
@@ -279,15 +279,20 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
     // CACHE (skip for ratchet mode — different prompt style)
     if (FEATURES.caching && current?.id && insightText && !ratchetMode) {
       const cacheStart = performance.now();
-      await cacheOperations.set(CACHE_CONFIG.stores.insights, current.id, {
-        interpretation: insightText,
-        metadata: {
-          poet: current.poet,
-          title: current.title,
-          charCount: insightText.length,
-          tokens: Math.ceil(insightText.length / 4),
+      await cacheOperations.set(
+        CACHE_CONFIG.stores.insights,
+        current.id,
+        {
+          interpretation: insightText,
+          metadata: {
+            poet: current.poet,
+            title: current.title,
+            charCount: insightText.length,
+            tokens: Math.ceil(insightText.length / 4),
+          },
         },
-      }, addLog);
+        addLog
+      );
       const cacheTime = performance.now() - cacheStart;
       const elapsedTime = apiStartTime
         ? ((performance.now() - apiStartTime) / 1000).toFixed(1)
@@ -303,8 +308,8 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
     if (current?.isFromDatabase && current?.id && insightText) {
       const parts = parseInsight(insightText, addLog);
       if (parts?.poeticTranslation) {
-        const arabicLines = (current?.arabic || '').split('\n').filter(l => l.trim());
-        const englishLines = parts.poeticTranslation.split('\n').filter(l => l.trim());
+        const arabicLines = (current?.arabic || '').split('\n').filter((l) => l.trim());
+        const englishLines = parts.poeticTranslation.split('\n').filter((l) => l.trim());
         const translation = parts.poeticTranslation;
         if (englishLines.length < arabicLines.length) {
           addLog(
@@ -330,6 +335,10 @@ export async function analyzePoem({ current, addLog, track, retryFn }) {
     if (insightText) {
       useModalStore.getState().showToast('insight');
       setTimeout(() => useModalStore.getState().hideToast('insight'), 1500);
+    } else {
+      // The request ran to completion and came back with nothing. This is the
+      // only place that can tell an empty response apart from "still waiting".
+      addLog('Translation', `Request completed with no text | Poem ID: ${current?.id}`, 'error');
     }
   } catch (e) {
     Sentry.captureException(e);

--- a/src/stores/uiStore.js
+++ b/src/stores/uiStore.js
@@ -115,7 +115,9 @@ export const CATEGORY_MAP = {
   request: { color: '#ff9800', prefix: '  →' },
   success: { color: '#4caf50', prefix: '  ←' },
   error: { color: '#ef4444', prefix: '← FAIL' },
-  warning: { color: '#ef4444', prefix: '← FAIL' },
+  // Distinct from error: a warning is something to look at, not something that
+  // broke. Sharing the red FAIL prefix made recoverable states read as outages.
+  warning: { color: '#f59e0b', prefix: '⚠ WARN' },
   info: { color: '#78909c', prefix: ' SYS' },
 };
 

--- a/src/test/alignmentScore.test.js
+++ b/src/test/alignmentScore.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { scoreAlignment } from '../utils/alignmentScore';
+
+// Synthetic "embeddings": each concept is a distinct unit vector, so a line
+// pair that should match has cosine 1 and an unrelated pair has cosine 0.
+const v = (i, dim = 8) => Array.from({ length: dim }, (_, k) => (k === i ? 1 : 0));
+
+describe('scoreAlignment', () => {
+  it('reports no shift when every line matches its counterpart', () => {
+    const ar = [v(0), v(1), v(2), v(3), v(4), v(5)];
+    const en = [v(0), v(1), v(2), v(3), v(4), v(5)];
+    const s = scoreAlignment(ar, en);
+    expect(s.shift).toBe(0);
+    expect(s.diagonal).toBeCloseTo(1, 5);
+  });
+
+  it('detects a translation shifted one line early', () => {
+    // English line i actually renders Arabic line i+1 — the 87900 failure,
+    // where the opening bayt was merged and everything after slid up one.
+    const ar = [v(0), v(1), v(2), v(3), v(4), v(5)];
+    const en = [v(1), v(2), v(3), v(4), v(5), v(6)];
+    const s = scoreAlignment(ar, en);
+    expect(s.shift).toBe(-1);
+    expect(s.margin).toBeGreaterThan(0.02);
+  });
+
+  it('detects a shift in the other direction', () => {
+    const ar = [v(1), v(2), v(3), v(4), v(5), v(6)];
+    const en = [v(0), v(1), v(2), v(3), v(4), v(5)];
+    const s = scoreAlignment(ar, en);
+    expect(s.shift).toBe(1);
+  });
+
+  it('does not flag a merely weak translation as shifted', () => {
+    // Low similarity everywhere, but no offset does better than the diagonal.
+    const ar = [v(0), v(1), v(2), v(3), v(4), v(5)];
+    const en = [v(6), v(6), v(6), v(6), v(6), v(6)];
+    const s = scoreAlignment(ar, en);
+    expect(s.margin).toBeLessThanOrEqual(0.02);
+  });
+
+  it('refuses to score when too few pairs overlap', () => {
+    expect(scoreAlignment([v(0), v(1)], [v(0), v(1)]).diagonal).not.toBeNull();
+    expect(scoreAlignment([], []).diagonal).toBeNull();
+  });
+
+  it('tolerates unequal line counts by scoring the overlap', () => {
+    const ar = [v(0), v(1), v(2), v(3), v(4)];
+    const en = [v(0), v(1), v(2), v(3), v(4), v(5), v(6)];
+    expect(scoreAlignment(ar, en).shift).toBe(0);
+  });
+});

--- a/src/test/gemini-thinking.test.js
+++ b/src/test/gemini-thinking.test.js
@@ -8,13 +8,28 @@ import { thinkingConfigFor } from '../services/gemini.js';
  * The field name differs by family, so a wrong field would 400 the request.
  */
 describe('thinkingConfigFor', () => {
-  it('uses thinkingLevel:minimal for Gemini 3.x models', () => {
+  // 'low', not 'minimal': gemini-3.7-flash rejects minimal outright ("Thinking
+  // level MINIMAL is not supported for this model"), so every request paid a
+  // 400 and a retry. Measured on one poem, 2026-08-17: default spent 1,329
+  // thinking tokens in 6.0s, 'low' spent 0 in 2.2s with identical output
+  // quality. Anything above 'low' silently reintroduces the latency this
+  // function exists to remove.
+  it('uses thinkingLevel:low for Gemini 3.x models', () => {
     expect(thinkingConfigFor('gemini-3.5-flash')).toEqual({
-      thinkingConfig: { thinkingLevel: 'minimal' },
+      thinkingConfig: { thinkingLevel: 'low' },
     });
     expect(thinkingConfigFor('gemini-3-flash-preview')).toEqual({
-      thinkingConfig: { thinkingLevel: 'minimal' },
+      thinkingConfig: { thinkingLevel: 'low' },
     });
+    expect(thinkingConfigFor('gemini-3.7-flash')).toEqual({
+      thinkingConfig: { thinkingLevel: 'low' },
+    });
+  });
+
+  it('never sends minimal, which Gemini 3.7 rejects', () => {
+    for (const m of ['gemini-3-flash-preview', 'gemini-3.5-flash', 'gemini-3.7-flash']) {
+      expect(thinkingConfigFor(m).thinkingConfig.thinkingLevel).not.toBe('minimal');
+    }
   });
 
   it('uses thinkingBudget:0 for Gemini 2.5 models', () => {

--- a/src/test/insightPrompt.test.js
+++ b/src/test/insightPrompt.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildInsightPrompt } from '../utils/insightPrompt';
+
+describe('buildInsightPrompt', () => {
+  const arabic = 'سطر أول\nسطر ثان\nسطر ثالث';
+
+  it('states the line contract using the count the reader will see', () => {
+    const p = buildInsightPrompt({ arabic, poet: 'المتنبي' });
+    expect(p).toContain('This poem has exactly 3 Arabic lines');
+    expect(p).toContain('produce exactly 3 English lines');
+  });
+
+  it('ignores blank lines when counting', () => {
+    const p = buildInsightPrompt({ arabic: 'أول\n\n  \nثان', poet: 'x' });
+    expect(p).toContain('exactly 2 Arabic lines');
+  });
+
+  it('names the poet when known', () => {
+    expect(buildInsightPrompt({ arabic, poet: 'المتنبي' })).toContain(
+      'Deep Analysis of by المتنبي:'
+    );
+  });
+
+  it('omits the poet clause entirely when unknown', () => {
+    const p = buildInsightPrompt({ arabic });
+    expect(p.startsWith('Deep Analysis of:')).toBe(true);
+    expect(p).not.toContain(' by ');
+  });
+
+  it('carries the Arabic through verbatim', () => {
+    expect(buildInsightPrompt({ arabic, poet: 'x' })).toContain(arabic);
+  });
+
+  // The batch backfill (scripts/batch-translate.mjs) converts the corpus's '*'
+  // hemistich separator to newlines and then calls this same function. If that
+  // conversion is skipped the whole poem counts as one line, and the model is
+  // told to return a single line of English for a 20-line poem.
+  it('counts a raw star-separated poem as one line, which is why callers convert first', () => {
+    const raw = 'سطر أول*سطر ثان*سطر ثالث';
+    expect(buildInsightPrompt({ arabic: raw })).toContain('exactly 1 Arabic lines');
+    expect(buildInsightPrompt({ arabic: raw.split('*').join('\n') })).toContain(
+      'exactly 3 Arabic lines'
+    );
+  });
+
+  it('survives missing input without throwing', () => {
+    expect(buildInsightPrompt()).toContain('exactly 0 Arabic lines');
+    expect(buildInsightPrompt({})).toContain('exactly 0 Arabic lines');
+  });
+});

--- a/src/utils/alignmentScore.js
+++ b/src/utils/alignmentScore.js
@@ -1,0 +1,75 @@
+/**
+ * Score whether a translation's lines line up with the original's.
+ *
+ * The line-count guard in the translation backfill only checks that a
+ * translation has at least as many lines as the poem. A translation that
+ * merges the opening bayt and then slides every later line up by one has a
+ * matching count and is wrong from line 2 onward (issue #733). Counting cannot
+ * see that, so this compares meaning instead: given an embedding per line on
+ * each side, a correct translation scores highest on the diagonal, and a
+ * shifted one scores highest on an off-diagonal band.
+ *
+ * Pure and dependency-free so it can be unit tested without calling an
+ * embedding API; scripts/check-translation-alignment.mjs supplies real vectors.
+ */
+
+/** Cosine similarity of two equal-length vectors. */
+export function cosine(a, b) {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  const denom = Math.sqrt(na) * Math.sqrt(nb);
+  return denom ? dot / denom : 0;
+}
+
+/**
+ * @param {number[][]} arVecs - One embedding per source line
+ * @param {number[][]} enVecs - One embedding per translated line
+ * @param {number} [maxShift=3] - Widest offset to test in each direction
+ * @returns {{diagonal: number|null, best: number|null, shift: number, margin: number}}
+ *   `shift` is the offset that beats the diagonal, 0 when none does.
+ *   `margin` is how much it beats it by — the confidence in the finding.
+ */
+export function scoreAlignment(arVecs = [], enVecs = [], maxShift = 3) {
+  const n = Math.min(arVecs.length, enVecs.length);
+  if (n === 0) return { diagonal: null, best: null, shift: 0, margin: 0 };
+
+  // Require a real overlap before trusting an offset: near the edges only a
+  // couple of pairs survive, and two lucky pairs are not evidence of a shift.
+  const minPairs = Math.max(3, Math.floor(n / 2));
+
+  const meanAt = (offset) => {
+    let sum = 0;
+    let count = 0;
+    for (let i = 0; i < n; i++) {
+      const j = i + offset;
+      if (j < 0 || j >= n) continue;
+      sum += cosine(arVecs[i], enVecs[j]);
+      count++;
+    }
+    return count >= (offset === 0 ? 1 : minPairs) ? sum / count : null;
+  };
+
+  const diagonal = meanAt(0);
+  let best = diagonal;
+  let shift = 0;
+  for (let offset = -maxShift; offset <= maxShift; offset++) {
+    if (offset === 0) continue;
+    const m = meanAt(offset);
+    if (m !== null && best !== null && m > best) {
+      best = m;
+      shift = offset;
+    }
+  }
+  return {
+    diagonal,
+    best,
+    shift,
+    margin: best !== null && diagonal !== null ? best - diagonal : 0,
+  };
+}

--- a/src/utils/insightParser.js
+++ b/src/utils/insightParser.js
@@ -11,18 +11,20 @@
  * @returns {{ poeticTranslation: string, depth: string, author: string } | null}
  */
 export function parseInsight(interpretation, addLog) {
-  if (!interpretation) {
-    addLog?.('Translation', 'No interpretation text received', 'warning');
-    return null;
-  }
+  // Empty is the normal pre-response state, not a failure. This runs from a
+  // render memo, so every poem passes through it before the model answers and
+  // again after each `Translation cleared`. Logging here painted a red FAIL on
+  // ordinary waiting. The genuine "request finished with nothing" case is
+  // logged by analyzePoem, which knows the request actually completed.
+  if (!interpretation) return null;
   const parts = interpretation
     .split(/POEM:|THE DEPTH:|THE AUTHOR:/i)
-    .map(p => p.trim())
+    .map((p) => p.trim())
     .filter(Boolean);
   const result = {
-    poeticTranslation: parts[0] || "",
-    depth: parts[1] || "",
-    author: parts[2] || "",
+    poeticTranslation: parts[0] || '',
+    depth: parts[1] || '',
+    author: parts[2] || '',
   };
   if (!result.poeticTranslation) {
     addLog?.('Translation', `Empty — no POEM marker | ${interpretation.length} chars`, 'error');

--- a/src/utils/insightPrompt.js
+++ b/src/utils/insightPrompt.js
@@ -1,0 +1,22 @@
+/**
+ * Build the user-turn prompt for a poem insight request.
+ *
+ * Shared by the in-app request (stores/actions/analyzePoem.js) and the batch
+ * backfill (scripts/batch-translate.mjs) so a translation generated offline is
+ * byte-identical to one generated live. When these drifted, the corpus slowly
+ * accumulated two different translation styles with no way to tell them apart.
+ *
+ * `arabic` is the newline-separated form the reader displays. The database
+ * stores hemistichs separated by '*'; services/database.js converts on read,
+ * and callers working straight from SQL should convert first.
+ *
+ * @param {Object} poem
+ * @param {string} poem.arabic - Newline-separated Arabic text
+ * @param {string} [poem.poet] - Poet name, omitted from the prompt when absent
+ * @returns {string}
+ */
+export function buildInsightPrompt({ arabic, poet } = {}) {
+  const poetInfo = poet ? ` by ${poet}` : '';
+  const arabicLineCount = (arabic || '').split('\n').filter((l) => l.trim()).length;
+  return `Deep Analysis of${poetInfo}:\n\n${arabic}\n\n[CRITICAL: This poem has exactly ${arabicLineCount} Arabic lines. You MUST produce exactly ${arabicLineCount} English lines in the POEM section. One line per Arabic line, no exceptions.]`;
+}


### PR DESCRIPTION
`26.5s ← FAIL [Translation] No interpretation text received` was not a failed request. `parseInsight` is called from a render memo (`app.jsx:940`) and an effect (`app.jsx:572`), so it runs for every poem with an empty `interpretation` before the model answers, and again after each `Translation cleared` on swipe. It logged at `warning`, and `warning` was mapped to the same red `← FAIL` prefix as `error`.

The only caller that could have produced a true positive (`analyzePoem.js:304`) is already guarded by `&& insightText`, so the warning branch had no honest caller at all.

## Changes

- `parseInsight` returns `null` silently on empty input. The "model returned text with no POEM marker" error at line 28 stays.
- `analyzePoem` logs `Request completed with no text` at error level after the call finishes. That is the only place that can distinguish an empty response from still-waiting.
- `warning` gets `⚠ WARN` in amber instead of borrowing `error`'s red `← FAIL`.
- `geminiTextFetch` remembers which model 400'd on thinking config, so the strip-and-retry costs one round trip per session instead of one per request.

## Not fixed here

The 34s the translation actually took is real and is #713 — only ~13% of poems have a cached translation, the rest are generated lazily.

1034 unit tests pass (5 pre-existing `utils-extracted` failures from Node's `localStorage` global, unrelated). Build clean.